### PR TITLE
Make JVB DAEMON_OPTS Configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Variable | Description | Default value
 `JVB_STUN_SERVERS` | STUN servers used to discover the server's public IP | stun.l.google.com:19302, stun1.l.google.com:19302, stun2.l.google.com:19302
 `JVB_PORT` | Port for media used by Jitsi Videobridge | 10000
 `JVB_BREWERY_MUC` | MUC name for the JVB pool | jvbbrewery
+`JVB_ENABLE_APIS` | Comma separated list of JVB APIs to enable | none
 `JIGASI_XMPP_USER` | XMPP user for Jigasi MUC client connections | jigasi
 `JIGASI_XMPP_PASSWORD` | XMPP password for Jigasi MUC client connections | passw0rd
 `JIGASI_BREWERY_MUC` | MUC name for the Jigasi pool | jigasibrewery

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,7 @@ services:
             - JVB_BREWERY_MUC
             - JVB_PORT
             - JVB_STUN_SERVERS
+            - JVB_ENABLE_APIS
             - JICOFO_AUTH_USER
             - TZ
         depends_on:

--- a/env.example
+++ b/env.example
@@ -77,6 +77,10 @@ JVB_STUN_SERVERS=stun.l.google.com:19302,stun1.l.google.com:19302,stun2.l.google
 # Media port for the Jitsi Videobridge
 JVB_PORT=10000
 
+# A comma separated list of APIs to enable when the JVB is started. The default is none.
+# See https://github.com/jitsi/jitsi-videobridge/blob/master/doc/rest.md for more information
+#JVB_ENABLE_APIS=rest,colibri
+
 # XMPP component password for Jicofo.
 JICOFO_COMPONENT_SECRET=s3cr37
 

--- a/jvb/rootfs/etc/services.d/jvb/run
+++ b/jvb/rootfs/etc/services.d/jvb/run
@@ -8,7 +8,9 @@ if [[ ! -z "$DOCKER_HOST_ADDRESS" ]]; then
 fi
 
 DAEMON=/usr/share/jitsi-videobridge/jvb.sh
-DAEMON_OPTS="--apis=none"
+DEFAULT_DAEMON_OPTS="none"
 
-exec s6-setuidgid jvb /bin/bash -c "JAVA_SYS_PROPS=\"$JAVA_SYS_PROPS\" exec $DAEMON $DAEMON_OPTS"
+DAEMON_OPTS=${JVB_ENABLE_APIS:=$DEFAULT_DAEMON_OPTS}
+
+exec s6-setuidgid jvb /bin/bash -c "JAVA_SYS_PROPS=\"$JAVA_SYS_PROPS\" exec $DAEMON --apis=${DAEMON_OPTS}"
 


### PR DESCRIPTION
This PR updates the `DAEMON_OPTS` passed the the JVB configurable by the user via the environment variable `JVB_DAEMON_OPTS`.  

If `JVB_DAEMON_OPTS` environment variable is present, it will be used, otherwise, the default opts will be used.