### PR TITLE
Add JWT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,17 @@ Once in the container, run the following command to create a user:
 
 ``prosodyctl --config /config/prosody.cfg.lua register user meet.jitsi password``
 
+#### Authentication using JWT tokens
+You can also use JWT tokens to authenticate users. To enable it you have to enable authentication via both `ENABLE_AUTH` & `JWT_ENABLE_TOKEN_AUTH` environment variables and configure the settings you can see below.
+
+Variable | Description | Example
+--- | --- | ---
+`JWT_ENABLE_TOKEN_AUTH` | Enable authentication via JWT tokens | 1
+`JWT_APP_ID` | Application identifier | my_jitsi_app_id
+`JWT_APP_SECRET` | Application secret known only to your token | my_jitsi_app_secret
+`JWT_ACCEPTED_ISSUERS` | (Optional) Set asap_accepted_issuers as a comma separated list | my_web_client,my_app_client
+`JWT_ACCEPTED_AUDIENCES` | (Optional) Set asap_accepted_audiences as a comma separated list | my_server1,my_server2
+
 ### Advanced configuration
 
 These configuration options are already set and generally don't need to be changed.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,11 @@ services:
             - JVB_AUTH_PASSWORD
             - JIGASI_XMPP_USER
             - JIGASI_XMPP_PASSWORD
+            - JWT_ENABLE_TOKEN_AUTH
+            - JWT_APP_ID
+            - JWT_APP_SECRET
+            - JWT_ACCEPTED_ISSUERS
+            - JWT_ACCEPTED_AUDIENCES
             - TZ
         networks:
             meet.jitsi:

--- a/env.example
+++ b/env.example
@@ -62,6 +62,21 @@ TZ=Europe/Amsterdam
 # Enable guest access.
 #ENABLE_GUESTS=1
 
+# Enable authentication via JWT tokens.
+#JWT_ENABLE_TOKEN_AUTH=1
+
+# Application identifier.
+#JWT_APP_ID=my_jitsi_app_id
+
+# Application secret known only to your token.
+#JWT_APP_SECRET=my_jitsi_app_secret
+
+# (Optional) Set asap_accepted_issuers as a comma separated list.
+#JWT_ACCEPTED_ISSUERS=my_web_client,my_app_client
+
+# (Optional) Set asap_accepted_audiences as a comma separated list.
+#JWT_ACCEPTED_AUDIENCES=my_server1,my_server2
+
 #
 # Advanced configuration options (you generally don't need to change these)
 #

--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -1,10 +1,24 @@
 FROM jitsi/base
 
+ADD https://raw.githubusercontent.com/jitsi/jitsi-meet/fc129d9849ca5e26245d54df6451931b6c179987/resources/prosody-plugins/token/util.lib.lua /prosody-plugins/token/util.lib.lua
+ADD https://raw.githubusercontent.com/jitsi/jitsi-meet/fc129d9849ca5e26245d54df6451931b6c179987/resources/prosody-plugins/mod_token_verification.lua /prosody-plugins/mod_token_verification.lua
+ADD https://raw.githubusercontent.com/jitsi/jitsi-meet/fc129d9849ca5e26245d54df6451931b6c179987/resources/prosody-plugins/mod_auth_token.lua /prosody-plugins/mod_auth_token.lua
+
+RUN sed -i s/hook/hook_global/g /prosody-plugins/mod_auth_token.lua
+
 RUN \
 	apt-dpkg-wrap apt-get update && \
+	apt-dpkg-wrap apt-get install -y lua5.2 liblua5.2-dev libssl1.0-dev lua-basexx luarocks gcc git && \
 	apt-dpkg-wrap apt-get install -t stretch-backports -y prosody && \
-	apt-cleanup && \
 	rm -rf /etc/prosody
+
+RUN \
+	luarocks install lua-cjson 2.1.0-1 && \
+	luarocks install luajwtjitsi
+
+RUN \
+	apt-dpkg-wrap apt-get remove -y liblua5.2-dev libssl1.0-dev gcc git && \
+	apt-cleanup
 
 COPY rootfs/ /
 

--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -1,13 +1,28 @@
 admins = { "{{ .Env.JICOFO_AUTH_USER }}@{{ .Env.XMPP_AUTH_DOMAIN }}" }
-plugin_paths = { "/prosody-plugins-custom" }
+plugin_paths = { "/prosody-plugins/", "/prosody-plugins-custom" }
 http_default_host = "{{ .Env.XMPP_DOMAIN }}"
 
+{{ if and (.Env.ENABLE_AUTH | default "0" | toBool) (.Env.JWT_ENABLE_TOKEN_AUTH | default "0" | toBool) .Env.JWT_ACCEPTED_ISSUERS }}
+asap_accepted_issuers = { "{{ join "\",\"" (splitList "," .Env.JWT_ACCEPTED_ISSUERS) }}" }
+{{ end }}
+
+{{ if and (.Env.ENABLE_AUTH | default "0" | toBool) (.Env.JWT_ENABLE_TOKEN_AUTH | default "0" | toBool) .Env.JWT_ACCEPTED_AUDIENCES }}
+asap_accepted_audiences = { "{{ join "\",\"" (splitList "," .Env.JWT_ACCEPTED_AUDIENCES) }}" }
+{{ end }}
+
 VirtualHost "{{ .Env.XMPP_DOMAIN }}"
-    {{ if .Env.ENABLE_AUTH | default "0" | toBool }}
-    authentication = "internal_plain"
+{{ if .Env.ENABLE_AUTH | default "0" | toBool }}
+    {{ if .Env.JWT_ENABLE_TOKEN_AUTH | default "0" | toBool }}
+    authentication = "token"
+    app_id = "{{ .Env.JWT_APP_ID }}"
+    app_secret = "{{ .Env.JWT_APP_SECRET }}"
+    allow_empty_token = false
     {{ else }}
-    authentication = "anonymous"
+    authentication = "internal_plain"
     {{ end }}
+{{ else }}
+    authentication = "anonymous"
+{{ end }}
     ssl = {
         key = "/config/certs/{{ .Env.XMPP_DOMAIN }}.key";
         certificate = "/config/certs/{{ .Env.XMPP_DOMAIN }}.crt";
@@ -52,8 +67,10 @@ Component "{{ .Env.XMPP_MUC_DOMAIN }}" "muc"
         {{ if .Env.XMPP_MUC_MODULES }}
         "{{ join "\";\n\"" (splitList "," .Env.XMPP_MUC_MODULES) }}";
         {{ end }}
+        {{ if .Env.JWT_ENABLE_TOKEN_AUTH | default "0" | toBool }}
+        "token_verification";
+        {{ end }}
     }
 
 Component "focus.{{ .Env.XMPP_DOMAIN }}"
     component_secret = "{{ .Env.JICOFO_COMPONENT_SECRET }}"
-

--- a/prosody/rootfs/etc/cont-init.d/10-config
+++ b/prosody/rootfs/etc/cont-init.d/10-config
@@ -10,6 +10,14 @@ if [[ "$(stat -c %U /config)" != "prosody" ]]; then
     chown -R prosody /config
 fi
 
+if [[ "$(stat -c %U /prosody-plugins)" != "prosody" ]]; then
+    chown -R prosody /prosody-plugins
+fi
+
+if [[ "$(stat -c %U /prosody-plugins-custom)" != "prosody" ]]; then
+    chown -R prosody /prosody-plugins-custom
+fi
+
 if [[ ! -f $PROSODY_CFG ]]; then
     cp -r /defaults/* /config
     tpl /defaults/conf.d/jitsi-meet.cfg.lua > /config/conf.d/jitsi-meet.cfg.lua


### PR DESCRIPTION
With this PR I'm adding support for JWT tokens to the prosody container.
I don't wanted to copy the prosody modules out of the `jitsi/jitsi-meet` repository so that I added it as a submodule to have no duplicates and one single point of truth.

I hope I didn't missed something.

@amirasaran Thanks for your help.