### PR TITLE
Add TCP Harvester configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ Variable | Description | Default value
 `JVB_AUTH_USER` | XMPP user for JVB MUC client connections | jvb
 `JVB_AUTH_PASSWORD` | XMPP password for JVB MUC client connections | passw0rd
 `JVB_STUN_SERVERS` | STUN servers used to discover the server's public IP | stun.l.google.com:19302, stun1.l.google.com:19302, stun2.l.google.com:19302
-`JVB_PORT` | Port for media used by Jitsi Videobridge | 10000
+`JVB_PORT` | UDP port for media used by Jitsi Videobridge | 10000
+`JVB_TCP_HARVESTER_DISABLED` | Disable the additional harvester which allows video over TCP (rather than just UDP) | true
+`JVB_TCP_PORT` | TCP port for media used by Jitsi Videobridge when the TCP Harvester is enabled | 4443
 `JVB_BREWERY_MUC` | MUC name for the JVB pool | jvbbrewery
 `JVB_ENABLE_APIS` | Comma separated list of JVB APIs to enable | none
 `JIGASI_XMPP_USER` | XMPP user for Jigasi MUC client connections | jigasi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,7 @@ services:
         image: jitsi/jvb
         ports:
             - '${JVB_PORT}:${JVB_PORT}/udp'
+            - '${JVB_TCP_PORT}:${JVB_TCP_PORT}'
         volumes:
             - ${CONFIG}/jvb:/config
         environment:
@@ -95,6 +96,8 @@ services:
             - JVB_AUTH_PASSWORD
             - JVB_BREWERY_MUC
             - JVB_PORT
+            - JVB_TCP_HARVESTER_DISABLED
+            - JVB_TCP_PORT
             - JVB_STUN_SERVERS
             - JVB_ENABLE_APIS
             - JICOFO_AUTH_USER

--- a/env.example
+++ b/env.example
@@ -91,6 +91,10 @@ JVB_STUN_SERVERS=stun.l.google.com:19302,stun1.l.google.com:19302,stun2.l.google
 # Media port for the Jitsi Videobridge
 JVB_PORT=10000
 
+# TCP Fallback for Jitsi Videobridge for when UDP isn't available
+JVB_TCP_HARVESTER_DISABLED=true
+JVB_TCP_PORT=4443
+
 # A comma separated list of APIs to enable when the JVB is started. The default is none.
 # See https://github.com/jitsi/jitsi-videobridge/blob/master/doc/rest.md for more information
 #JVB_ENABLE_APIS=rest,colibri

--- a/jvb/rootfs/defaults/sip-communicator.properties
+++ b/jvb/rootfs/defaults/sip-communicator.properties
@@ -1,6 +1,8 @@
 org.jitsi.videobridge.AUTHORIZED_SOURCE_REGEXP={{ .Env.JICOFO_AUTH_USER }}@{{ .Env.XMPP_AUTH_DOMAIN }}/.*
 org.jitsi.videobridge.SINGLE_PORT_HARVESTER_PORT={{ .Env.JVB_PORT }}
-org.jitsi.videobridge.DISABLE_TCP_HARVESTER=true
+org.jitsi.videobridge.DISABLE_TCP_HARVESTER={{ .Env.JVB_TCP_HARVESTER_DISABLED }}
+org.jitsi.videobridge.TCP_HARVESTER_PORT={{ .Env.JVB_TCP_PORT }}
+org.jitsi.videobridge.TCP_HARVESTER_MAPPED_PORT={{ .Env.JVB_TCP_PORT }}
 org.ice4j.ice.harvest.STUN_MAPPING_HARVESTER_ADDRESSES={{ .Env.JVB_STUN_SERVERS }}
 
 org.jitsi.videobridge.xmpp.user.shard.HOSTNAME={{ .Env.XMPP_SERVER }}

--- a/jvb/rootfs/defaults/sip-communicator.properties
+++ b/jvb/rootfs/defaults/sip-communicator.properties
@@ -2,7 +2,6 @@ org.jitsi.videobridge.AUTHORIZED_SOURCE_REGEXP={{ .Env.JICOFO_AUTH_USER }}@{{ .E
 org.jitsi.videobridge.SINGLE_PORT_HARVESTER_PORT={{ .Env.JVB_PORT }}
 org.jitsi.videobridge.DISABLE_TCP_HARVESTER={{ .Env.JVB_TCP_HARVESTER_DISABLED }}
 org.jitsi.videobridge.TCP_HARVESTER_PORT={{ .Env.JVB_TCP_PORT }}
-org.jitsi.videobridge.TCP_HARVESTER_MAPPED_PORT={{ .Env.JVB_TCP_PORT }}
 org.ice4j.ice.harvest.STUN_MAPPING_HARVESTER_ADDRESSES={{ .Env.JVB_STUN_SERVERS }}
 
 org.jitsi.videobridge.xmpp.user.shard.HOSTNAME={{ .Env.XMPP_SERVER }}


### PR DESCRIPTION
Add TCP fallback comms to the JVB, leaving it off by default.
Was useful in my specific context, where OSX Firewall blocked UDP.