### PR TITLE
web: add option for enable chrome screen sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Variable | Description | Default value
 `JIGASI_PORT_MAX` | Maximum port for media used by Jigasi | 20050
 `DISABLE_HTTPS` | Disable HTTPS, this can be useful if TLS connections are going to be handled outside of this setup | 1
 `ENABLE_HTTP_REDIRECT` | Redirects HTTP traffic to HTTPS | 1
+`ENABLE_CHROME_SCREEN_SHARING` | Enable screensharing for Chrome (has been working in Chrome since version 72) | 1
 
 ### Running on a LAN environment
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
             - JICOFO_AUTH_USER
             - LETSENCRYPT_DOMAIN
             - LETSENCRYPT_EMAIL
+            - ENABLE_CHROME_SCREEN_SHARING
             - XMPP_DOMAIN
             - XMPP_AUTH_DOMAIN
             - XMPP_BOSH_URL_BASE=http://xmpp.meet.jitsi:5280

--- a/env.example
+++ b/env.example
@@ -142,3 +142,6 @@ JIGASI_PORT_MAX=20050
 
 # Redirects HTTP traffic to HTTPS. Only works with the standard HTTPS port (443).
 #ENABLE_HTTP_REDIRECT=1
+
+# Enable screensharing for Chrome (has been working in Chrome since version 72)
+ENABLE_CHROME_SCREEN_SHARING=1

--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -72,6 +72,13 @@ if [[ ! -f /config/config.js ]]; then
             -e "s#// authdomain:.*#authdomain: '${XMPP_DOMAIN}',#" \
             /config/config.js
     fi
+
+    if [[ $ENABLE_CHROME_SCREEN_SHARING -eq 1 ]]; then
+        sed -i \
+            -e "s#desktopSharingChromeDisabled:.*#desktopSharingChromeDisabled: false,#" \
+            /config/config.js
+    fi
+
 fi
 
 if [[ ! -f /config/interface_config.js ]]; then


### PR DESCRIPTION
The PR enable screensharing for Chrome (has been working in Chrome since version 72)