### PR TITLE
Add default host to prosody config

### DIFF
--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -1,5 +1,6 @@
 admins = { "{{ .Env.JICOFO_AUTH_USER }}@{{ .Env.XMPP_AUTH_DOMAIN }}" }
 plugin_paths = { "/prosody-plugins-custom" }
+http_default_host = "{{ .Env.XMPP_DOMAIN }}"
 
 VirtualHost "{{ .Env.XMPP_DOMAIN }}"
     {{ if .Env.ENABLE_AUTH | default "0" | toBool }}


### PR DESCRIPTION
I need to add a default host because when I want to connect from another backend server to a prosody module I don't want to proxy my traffic to just set the host like we are already doing it for bosh in the nginx config.