### PR TITLE
jigasi: add SDES srtp enabling possibility and healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ Variable | Description | Default value
 `JIGASI_BREWERY_MUC` | MUC name for the Jigasi pool | jigasibrewery
 `JIGASI_PORT_MIN` | Minimum port for media used by Jigasi | 20000
 `JIGASI_PORT_MAX` | Maximum port for media used by Jigasi | 20050
+`JIGASI_ENABLE_SDES_SRTP` | Enable SDES srtp | 1
+`JIGASI_SIP_KEEP_ALIVE_METHOD` | Keepalive method | OPTIONS
+`JIGASI_HEALTH_CHECK_SIP_URI` | Health-check extension. Jigasi will call it for healthcheck | keepalive
+`JIGASI_HEALTH_CHECK_INTERVAL` | Interval of healthcheck in milliseconds | 300000
 `DISABLE_HTTPS` | Disable HTTPS, this can be useful if TLS connections are going to be handled outside of this setup | 1
 `ENABLE_HTTP_REDIRECT` | Redirects HTTP traffic to HTTPS | 1
 

--- a/env.example
+++ b/env.example
@@ -158,6 +158,18 @@ JIGASI_PORT_MIN=20000
 # Maximum port for media used by Jigasi.
 JIGASI_PORT_MAX=20050
 
+# Enable SDES srtp
+#JIGASI_ENABLE_SDES_SRTP=1
+
+# Keepalive method
+#JIGASI_SIP_KEEP_ALIVE_METHOD=OPTIONS
+
+# Health-check extension
+#JIGASI_HEALTH_CHECK_SIP_URI=keepalive
+
+# Health-check interval
+#JIGASI_HEALTH_CHECK_INTERVAL=300000
+
 # Disable HTTPS. This can be useful if TLS connections are going to be handled outside of this setup.
 #DISABLE_HTTPS=1
 

--- a/jigasi.yml
+++ b/jigasi.yml
@@ -24,6 +24,10 @@ services:
             - JIGASI_BREWERY_MUC
             - JIGASI_PORT_MIN
             - JIGASI_PORT_MAX
+            - JIGASI_HEALTH_CHECK_SIP_URI
+            - JIGASI_HEALTH_CHECK_INTERVAL
+            - JIGASI_SIP_KEEP_ALIVE_METHOD
+            - JIGASI_ENABLE_SDES_SRTP
             - TZ
         depends_on:
             - prosody

--- a/jigasi/rootfs/defaults/sip-communicator.properties
+++ b/jigasi/rootfs/defaults/sip-communicator.properties
@@ -11,8 +11,20 @@ net.java.sip.communicator.impl.protocol.sip.acc1=acc1
 {{ if and .Env.JIGASI_SIP_PORT .Env.JIGASI_SIP_TRANSPORT }}
 net.java.sip.communicator.impl.protocol.sip.acc1.PROXY_ADDRESS={{ .Env.JIGASI_SIP_SERVER }}
 net.java.sip.communicator.impl.protocol.sip.acc1.PROXY_AUTO_CONFIG=false
-net.java.sip.communicator.impl.protocol.sip.acc1.PROXY_PORT={{ .Env.JIGASI_SIP_PORT }}
-net.java.sip.communicator.impl.protocol.sip.acc1.PREFERRED_TRANSPORT={{ .Env.JIGASI_SIP_TRANSPORT }}
+net.java.sip.communicator.impl.protocol.sip.acc1.PROXY_PORT={{ .Env.JIGASI_SIP_PORT | default "5060" }}
+net.java.sip.communicator.impl.protocol.sip.acc1.PREFERRED_TRANSPORT={{ .Env.JIGASI_SIP_TRANSPORT | default "UDP" }}
+{{ end }}
+{{ if .Env.JIGASI_ENABLE_SDES_SRTP | default "0" | toBool }}
+net.java.sip.communicator.impl.protocol.sip.acc1.SAVP_OPTION=1
+net.java.sip.communicator.impl.protocol.sip.acc1.DEFAULT_ENCRYPTION=true
+net.java.sip.communicator.impl.protocol.sip.acc1.DEFAULT_SIPZRTP_ATTRIBUTE=false
+net.java.sip.communicator.impl.protocol.sip.acc1.ENCRYPTION_PROTOCOL.ZRTP=0
+net.java.sip.communicator.impl.protocol.sip.acc1.ENCRYPTION_PROTOCOL.SDES=1
+net.java.sip.communicator.impl.protocol.sip.acc1.ENCRYPTION_PROTOCOL.DTLS-SRTP=0
+net.java.sip.communicator.impl.protocol.sip.acc1.ENCRYPTION_PROTOCOL_STATUS.ZRTP=false
+net.java.sip.communicator.impl.protocol.sip.acc1.ENCRYPTION_PROTOCOL_STATUS.SDES=true
+net.java.sip.communicator.impl.protocol.sip.acc1.ENCRYPTION_PROTOCOL_STATUS.DTLS-SRTP=fasle
+net.java.sip.communicator.impl.protocol.sip.acc1.SDES_CIPHER_SUITES=AES_CM_128_HMAC_SHA1_80,AES_CM_128_HMAC_SHA1_32
 {{ end }}
 net.java.sip.communicator.impl.protocol.sip.acc1.ACCOUNT_UID=SIP\:{{ .Env.JIGASI_SIP_URI }}
 net.java.sip.communicator.impl.protocol.sip.acc1.PASSWORD={{ .Env.JIGASI_SIP_PASSWORD | b64enc }}
@@ -20,7 +32,7 @@ net.java.sip.communicator.impl.protocol.sip.acc1.PROTOCOL_NAME=SIP
 net.java.sip.communicator.impl.protocol.sip.acc1.SERVER_ADDRESS={{ .Env.JIGASI_SIP_SERVER }}
 net.java.sip.communicator.impl.protocol.sip.acc1.USER_ID={{ .Env.JIGASI_SIP_URI }}
 net.java.sip.communicator.impl.protocol.sip.acc1.KEEP_ALIVE_INTERVAL=25
-net.java.sip.communicator.impl.protocol.sip.acc1.KEEP_ALIVE_METHOD=OPTIONS
+net.java.sip.communicator.impl.protocol.sip.acc1.KEEP_ALIVE_METHOD={{ .Env.JIGASI_SIP_KEEP_ALIVE_METHOD | default "OPTIONS" }}
 net.java.sip.communicator.impl.protocol.sip.acc1.VOICEMAIL_ENABLED=false
 net.java.sip.communicator.impl.protocol.sip.acc1.JITSI_MEET_ROOM_HEADER_NAME=X-Room-Name
 net.java.sip.communicator.impl.protocol.sip.acc1.JITSI_MEET_DOMAIN_BASE_HEADER_NAME=X-Domain-Base
@@ -90,6 +102,10 @@ net.java.sip.communicator.impl.protocol.jabber.acc1.BREWERY={{ .Env.JIGASI_BREWE
 net.java.sip.communicator.impl.protocol.jabber.acc1.DOMAIN_BASE={{ .Env.XMPP_DOMAIN }}
 
 org.jitsi.jigasi.BREWERY_ENABLED=true
+
+org.jitsi.jigasi.HEALTH_CHECK_SIP_URI={{ .Env.JIGASI_HEALTH_CHECK_SIP_URI | default "" }}
+org.jitsi.jigasi.HEALTH_CHECK_INTERVAL={{ .Env.JIGASI_HEALTH_CHECK_INTERVAL | default "300000" }}
+org.jitsi.jigasi.HEALTH_CHECK_TIMEOUT=600000
 
 org.jitsi.jigasi.xmpp.acc.IS_SERVER_OVERRIDDEN=true
 org.jitsi.jigasi.xmpp.acc.SERVER_ADDRESS={{ .Env.XMPP_SERVER }}


### PR DESCRIPTION
this PR adds possibility to set in .env file: 
- JIGASI_ENABLE_SDES_SRTP for enabling SDES srtp in jigasi
- JIGASI_HEALTH_CHECK_SIP_URI set healthcheck extansion for call to
- JIGASI_HEALTH_CHECK_INTERVAL set time interval (in ms) for calling healthcheck extension
- JIGASI_SIP_KEEP_ALIVE_METHOD set change default sip ping method, by default is OPTION
