### PR TITLE
misc: refactoring Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,49 +1,31 @@
 FORCE_REBUILD ?= 0
-JITSI_RELEASE ?= "stable"
-JITSI_BUILD ?= "latest"
+JITSI_RELEASE ?= stable
+JITSI_BUILD ?= latest
+JITSI_REPO ?= jitsi
+JITSI_SERVICES ?= base base-java web prosody jicofo jvb jigasi
 
 ifeq ($(FORCE_REBUILD), 1)
   BUILD_ARGS = "--no-cache"
 endif
 
-build-all:
-	BUILD_ARGS=$(BUILD_ARGS) JITSI_RELEASE=$(JITSI_RELEASE) $(MAKE) -C base build
-	BUILD_ARGS=$(BUILD_ARGS) $(MAKE) -C base-java build
-	BUILD_ARGS=$(BUILD_ARGS) $(MAKE) -C web build
-	BUILD_ARGS=$(BUILD_ARGS) $(MAKE) -C prosody build
-	BUILD_ARGS=$(BUILD_ARGS) $(MAKE) -C jicofo build
-	BUILD_ARGS=$(BUILD_ARGS) $(MAKE) -C jvb build
-	BUILD_ARGS=$(BUILD_ARGS) $(MAKE) -C jigasi build
 
-tag-all:
-	docker tag jitsi/base:latest jitsi/base:$(JITSI_BUILD)
-	docker tag jitsi/base-java:latest jitsi/base-java:$(JITSI_BUILD)
-	docker tag jitsi/web:latest jitsi/web:$(JITSI_BUILD)
-	docker tag jitsi/prosody:latest jitsi/prosody:$(JITSI_BUILD)
-	docker tag jitsi/jicofo:latest jitsi/jicofo:$(JITSI_BUILD)
-	docker tag jitsi/jvb:latest jitsi/jvb:$(JITSI_BUILD)
-	docker tag jitsi/jigasi:latest jitsi/jigasi:$(JITSI_BUILD)
+all:	build-all tag-all push-all
 
-push-all:
-	docker push jitsi/base:latest
-	docker push jitsi/base-java:latest
-	docker push jitsi/web:latest
-	docker push jitsi/prosody:latest
-	docker push jitsi/jicofo:latest
-	docker push jitsi/jvb:latest
-	docker push jitsi/jigasi:latest
-	docker push jitsi/base:$(JITSI_BUILD)
-	docker push jitsi/base-java:$(JITSI_BUILD)
-	docker push jitsi/web:$(JITSI_BUILD)
-	docker push jitsi/prosody:$(JITSI_BUILD)
-	docker push jitsi/jicofo:$(JITSI_BUILD)
-	docker push jitsi/jvb:$(JITSI_BUILD)
-	docker push jitsi/jigasi:$(JITSI_BUILD)
+build:
+	$(MAKE) BUILD_ARGS=$(BUILD_ARGS) JITSI_RELEASE=$(JITSI_RELEASE) -C $(JITSI_SERVICE) build
 
+tag:
+	docker tag jitsi/$(JITSI_SERVICE):latest $(JITSI_REPO)/$(JITSI_SERVICE):$(JITSI_BUILD)
+
+push:
+	docker push $(JITSI_REPO)/$(JITSI_SERVICE):$(JITSI_BUILD)
+
+%-all:
+	@$(foreach SERVICE, $(JITSI_SERVICES), $(MAKE) --no-print-directory JITSI_SERVICE=$(SERVICE) $(subst -all,;,$@))
 
 clean:
 	docker-compose stop
 	docker-compose rm
 	docker network prune
 
-.PHONY: build-all tag-all push-all clean
+.PHONY: all build tag push clean

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ ifeq ($(FORCE_REBUILD), 1)
 endif
 
 
-all:	build-all tag-all push-all
+all:	build-all
+
+release: tag-all push-all
 
 build:
 	$(MAKE) BUILD_ARGS=$(BUILD_ARGS) JITSI_RELEASE=$(JITSI_RELEASE) -C $(JITSI_SERVICE) build


### PR DESCRIPTION
PR makes Makefile more flexible and simple.
* Variable `JITSI_REPO` - can be set to you private registry path (default jitsi dockerhub)
* Variable `JITSI_SERVICES` - contains all services that need to build/tag/push
* Target `all` will build all services then tag it from default name to custom name and push to registry
* Target pattern `%-all` will `build-all`/`tag-all`/`push-all` services described on `JITSI_SERVICES`
* Command `make JITSI_SERVICE=base push` will push only selected service.