### PR TITLE
fix prosody certs directory ownership

### DIFF
--- a/prosody/rootfs/etc/cont-init.d/10-config
+++ b/prosody/rootfs/etc/cont-init.d/10-config
@@ -4,7 +4,7 @@ PROSODY_CFG="/config/prosody.cfg.lua"
 
 if [[ ! -d /config/data ]]; then
     mkdir -p /config/data
-    chmod 777 /config/data
+    chown -R prosody:prosody /config/data
 fi
 
 if [[ ! -f $PROSODY_CFG ]]; then
@@ -19,18 +19,25 @@ if [[ ! -f $PROSODY_CFG ]]; then
     fi
 fi
 
-mkdir -p /config/certs
+if [[ ! -d /config/certs ]]; then
+    mkdir -p /config/certs
+    chown -R prosody:prosody /config/certs
+fi
 
 if [[ ! -f /config/certs/$XMPP_DOMAIN.crt ]]; then
     # echo for using all default values
     echo | prosodyctl --config $PROSODY_CFG cert generate $XMPP_DOMAIN
+
+    # certs will be created in /config/data
+    mv /config/data/*.{crt,key} /config/certs/
+    rm -f /config/data/*.cnf
 fi
 
 if [[ ! -f /config/certs/$XMPP_AUTH_DOMAIN.crt ]]; then
     # echo for using all default values
     echo | prosodyctl --config $PROSODY_CFG cert generate $XMPP_AUTH_DOMAIN
-fi
 
-# certs will be created in /config/data
-mv /config/data/*.{crt,key} /config/certs/
-rm -f /config/data/*.cnf
+    # certs will be created in /config/data
+    mv /config/data/*.{crt,key} /config/certs/
+    rm -f /config/data/*.cnf
+fi


### PR DESCRIPTION
Hi,
in some environments I'm getting permission errors when creating the prosody container:
```
prosody_1  | The directory /config/data is not owned by the current user, won't be able to write files to it
prosody_1  | mv: cannot stat '/config/data/*.crt': No such file or directory
prosody_1  | mv: cannot stat '/config/data/*.key': No such file or directory
prosody_1  | The directory /config/data is not owned by the current user, won't be able to write files to it
...
prosody_1  | certmanager         error	SSL/TLS: Failed to load '/config/certs/meet.jitsi.key': Check that the path is correct, and the file exists. (for meet.jitsi)
prosody_1  | meet.jitsi:tls      error	Error creating context for c2s: error loading private key (No such file or directory)
```
This is happening because an ownership check in prosody fails. To solve this I replaced the chmod 777 in the prosody init script with a chown and added a chown for the certs directory.