### PR TITLE
add letsencrypt volume

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,5 +12,4 @@ COPY rootfs/ /
 
 EXPOSE 80 443
 
-VOLUME /config
-
+VOLUME ["/config", "/etc/letsencrypt"]


### PR DESCRIPTION
Hi,
I think it would make sense to declare `/etc/letsencrypt` as a volume so the certificate is preserved on container upgrades.