### PR TITLE
changes the test for "unstable" to proper /bin/sh syntax

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -23,7 +23,7 @@ RUN \
 	chmod +x /usr/bin/frep
 
 RUN \
-	[[ "$JITSI_RELEASE" == "unstable" ]] && \
+	[ "$JITSI_RELEASE" = "unstable" ] && \
 	apt-dpkg-wrap apt-get update && \
 	apt-dpkg-wrap apt-get install -y jq procps curl vim iputils-ping net-tools && \
 	apt-cleanup || \


### PR DESCRIPTION
i noticed that in the build of the base image the check for $JITSI_RELEASE as always failing.
this happens because with `/bin/sh` a single `=` has to be used, otherwise it will always fail with "unexpected operator".