### PR TITLE
prosody: add speakerstats module handler

### DIFF
--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -45,7 +45,9 @@ VirtualHost "{{ .Env.XMPP_DOMAIN }}"
         "auth_cyrus";
         {{end}}
     }
-
+    {{ if .Env.ENABLE_SPEAKER_STATS | default "0" | toBool }}
+    speakerstats_component = "speakerstats.{{ .Env.XMPP_DOMAIN }}"
+    {{ end }}
     c2s_require_encryption = false
 
 {{ if and $ENABLE_AUTH (.Env.ENABLE_GUESTS | default "0" | toBool) }}
@@ -60,6 +62,11 @@ VirtualHost "{{ .Env.XMPP_AUTH_DOMAIN }}"
         certificate = "/config/certs/{{ .Env.XMPP_AUTH_DOMAIN }}.crt";
     }
     authentication = "internal_plain"
+
+{{ if .Env.ENABLE_SPEAKER_STATS | default "0" | toBool }}
+Component "speakerstats.{{ .Env.XMPP_DOMAIN }}" "speakerstats_component"
+    muc_component = "{{ .Env.XMPP_MUC_DOMAIN }}"
+{{ end }}
 
 Component "{{ .Env.XMPP_INTERNAL_MUC_DOMAIN }}" "muc"
     modules_enabled = {

--- a/prosody/rootfs/etc/cont-init.d/10-config
+++ b/prosody/rootfs/etc/cont-init.d/10-config
@@ -29,6 +29,8 @@ if [[ "$(stat -c %U /prosody-plugins-custom)" != "prosody" ]]; then
     chown -R prosody /prosody-plugins-custom
 fi
 
+grep -q speakerstats <<< ${XMPP_MUC_MODULES} && export ENABLE_SPEAKER_STATS=1
+
 if [[ ! -f $PROSODY_CFG ]]; then
     cp -r /defaults/* /config
     tpl /defaults/conf.d/jitsi-meet.cfg.lua > /config/conf.d/jitsi-meet.cfg.lua


### PR DESCRIPTION
If the `speakerstats` module is enabled in variable `XMPP_MUC_MODULES`, the properly handling it will already preconfigured. This PR depends on #131