### PR TITLE
jigasi: generate google cloud credentials from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,9 +340,14 @@ If you want to enable the Transcribing function, these options are required:
 Variable | Description | Example
 --- | --- | ---
 `ENABLE_TRANSCRIPTIONS` | Enable Jigasi transcription in a conference | 1
-`GOOGLE_APPLICATION_CREDENTIALS` | Credentials for connect to Cloud Google API from Jigasi. Path located inside the container | /config/key.json
+`GC_PROJECT_ID` | `project_id` from Google Cloud Credetials
+`GC_PRIVATE_KEY_ID` | `private_key_id` from Google Cloud Credetials
+`GC_PRIVATE_KEY` | `private_key` from Google Cloud Credetials
+`GC_CLIENT_EMAIL` | `client_email` from Google Cloud Credetials
+`GC_CLIENT_ID` | `client_id` from Google Cloud Credetials
+`GC_CLIENT_CERT_URL` | `client_x509_cert_url` from Google Cloud Credetials
 
-For setting `GOOGLE_APPLICATION_CREDENTIALS` please read https://cloud.google.com/text-to-speech/docs/quickstart-protocol section "Before you begin" from 1 to 5 paragraph.
+For setting the Google Cloud Credentials please read https://cloud.google.com/text-to-speech/docs/quickstart-protocol section "Before you begin" from 1 to 5 paragraph.
 
 ### Advanced configuration
 

--- a/env.example
+++ b/env.example
@@ -243,11 +243,15 @@ JIGASI_PORT_MAX=20050
 # Jigasi post to the chat an url with transcription file. Default false.
 #JIGASI_TRANSCRIBER_ADVERTISE_URL=true
 
-# Credentials for connect to Cloud Google API from Jigasi. Path located inside the container.
-# Please read https://cloud.google.com/text-to-speech/docs/quickstart-protocol
-# section "Before you begin" from 1 to 5 paragraph. Copy the key on
-# the docker host to ${CONFIG}/jigasi/key.json and to enable this setting:
-#GOOGLE_APPLICATION_CREDENTIALS=/config/key.json
+# Credentials for connect to Cloud Google API from Jigasi
+# Please read https://cloud.google.com/text-to-speech/docs/quickstart-protocol section "Before you begin" from 1 to 5 paragraph.
+# Copy the values from the json to the related env vars
+#GC_PROJECT_ID=
+#GC_PRIVATE_KEY_ID=
+#GC_PRIVATE_KEY=
+#GC_CLIENT_EMAIL=
+#GC_CLIENT_ID=
+#GC_CLIENT_CERT_URL=
 
 # Enable recording
 #ENABLE_RECORDING=1

--- a/jigasi.yml
+++ b/jigasi.yml
@@ -34,7 +34,12 @@ services:
             - JIGASI_TRANSCRIBER_ADVERTISE_URL
             - JIGASI_TRANSCRIBER_RECORD_AUDIO
             - JIGASI_TRANSCRIBER_SEND_TXT
-            - GOOGLE_APPLICATION_CREDENTIALS
+            - GC_PROJECT_ID
+            - GC_PRIVATE_KEY_ID
+            - GC_PRIVATE_KEY
+            - GC_CLIENT_EMAIL
+            - GC_CLIENT_ID
+            - GC_CLIENT_CERT_URL
             - TZ
         depends_on:
             - prosody

--- a/jigasi/Dockerfile
+++ b/jigasi/Dockerfile
@@ -1,9 +1,11 @@
 ARG JITSI_REPO=jitsi
 FROM ${JITSI_REPO}/base-java
 
+ENV GOOGLE_APPLICATION_CREDENTIALS /config/key.json
+
 RUN \
 	apt-dpkg-wrap apt-get update && \
-	apt-dpkg-wrap apt-get install -y jigasi && \
+	apt-dpkg-wrap apt-get install -y jigasi jq && \
 	apt-cleanup
 
 COPY rootfs/ /

--- a/jigasi/rootfs/etc/cont-init.d/10-config
+++ b/jigasi/rootfs/etc/cont-init.d/10-config
@@ -10,3 +10,32 @@ fi
 
 mkdir -pm777 /tmp/transcripts
 chown jigasi:jitsi /tmp/transcripts
+
+# Create Google Cloud Credentials
+if [[ $ENABLE_TRANSCRIPTIONS -eq 1 || $ENABLE_TRANSCRIPTIONS == "true" ]] && [[ ! -f /config/key.json ]]; then
+    if [[ -z $GC_PROJECT_ID || -z $GC_PRIVATE_KEY_ID || -z $GC_PRIVATE_KEY || -z $GC_CLIENT_EMAIL || -z $GC_CLIENT_ID || -z $GC_CLIENT_CERT_URL ]]; then
+        echo 'Transcriptions: One or more environment variables are undefined'
+        exit 1
+    fi
+
+    jq -n \
+        --arg GC_PROJECT_ID "$GC_PROJECT_ID" \
+        --arg GC_PRIVATE_KEY_ID "$GC_PRIVATE_KEY_ID" \
+        --arg GC_PRIVATE_KEY "$GC_PRIVATE_KEY" \
+        --arg GC_CLIENT_EMAIL "$GC_CLIENT_EMAIL" \
+        --arg GC_CLIENT_ID "$GC_CLIENT_ID" \
+        --arg GC_CLIENT_CERT_URL "$GC_CLIENT_CERT_URL" \
+        '{
+            type: "service_account",
+            project_id: $GC_PROJECT_ID,
+            private_key_id: $GC_PRIVATE_KEY_ID,
+            private_key: $GC_PRIVATE_KEY,
+            client_email: $GC_CLIENT_EMAIL,
+            client_id: $GC_CLIENT_ID,
+            auth_uri: "https://accounts.google.com/o/oauth2/auth",
+            token_uri: "https://oauth2.googleapis.com/token",
+            auth_provider_x509_cert_url: "https://www.googleapis.com/oauth2/v1/certs",
+            client_x509_cert_url: $GC_CLIENT_CERT_URL
+        }' \
+        > /config/key.json
+fi


### PR DESCRIPTION
When using the transcription feature in an cloud environment like kubernetes the credentials should be saved in a secret. This change makes it possible to do exactly this.

A cloud native container should be configurable via env variables instead of manually adding config files.

need this for #126 