### PR TITLE
misc: add ARG JITSI_REPO for dependented dockerfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,9 @@ JITSI_BUILD ?= latest
 JITSI_REPO ?= jitsi
 JITSI_SERVICES ?= base base-java web prosody jicofo jvb jigasi etherpad
 
+BUILD_ARGS := --build-arg JITSI_REPO=$(JITSI_REPO)
 ifeq ($(FORCE_REBUILD), 1)
-  BUILD_ARGS = "--no-cache"
+  BUILD_ARGS := $(BUILD_ARGS) --no-cache
 endif
 
 
@@ -14,7 +15,7 @@ all:	build-all
 release: tag-all push-all
 
 build:
-	$(MAKE) BUILD_ARGS=$(BUILD_ARGS) JITSI_REPO=$(JITSI_REPO) JITSI_RELEASE=$(JITSI_RELEASE) -C $(JITSI_SERVICE) build
+	$(MAKE) BUILD_ARGS="$(BUILD_ARGS)" JITSI_REPO="$(JITSI_REPO)" JITSI_RELEASE="$(JITSI_RELEASE)" -C $(JITSI_SERVICE) build
 
 tag:
 	docker tag $(JITSI_REPO)/$(JITSI_SERVICE):latest $(JITSI_REPO)/$(JITSI_SERVICE):$(JITSI_BUILD)

--- a/base-java/Dockerfile
+++ b/base-java/Dockerfile
@@ -1,4 +1,5 @@
-FROM jitsi/base
+ARG JITSI_REPO=jitsi
+FROM ${JITSI_REPO}/base
 
 RUN	\
 	mkdir -p /usr/share/man/man1 && \

--- a/jicofo/Dockerfile
+++ b/jicofo/Dockerfile
@@ -1,4 +1,5 @@
-FROM jitsi/base-java
+ARG JITSI_REPO=jitsi
+FROM ${JITSI_REPO}/base-java
 
 RUN \
 	apt-dpkg-wrap apt-get update && \

--- a/jigasi/Dockerfile
+++ b/jigasi/Dockerfile
@@ -1,4 +1,5 @@
-FROM jitsi/base-java
+ARG JITSI_REPO=jitsi
+FROM ${JITSI_REPO}/base-java
 
 RUN \
 	apt-dpkg-wrap apt-get update && \

--- a/jvb/Dockerfile
+++ b/jvb/Dockerfile
@@ -1,4 +1,5 @@
-FROM jitsi/base-java
+ARG JITSI_REPO=jitsi
+FROM ${JITSI_REPO}/base-java
 
 RUN \
 	apt-dpkg-wrap apt-get update && \

--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -1,4 +1,5 @@
-FROM jitsi/base
+ARG JITSI_REPO=jitsi
+FROM ${JITSI_REPO}/base
 
 RUN \
     apt-dpkg-wrap apt-get update \

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,5 @@
-FROM jitsi/base
+ARG JITSI_REPO=jitsi
+FROM ${JITSI_REPO}/base
 
 RUN \
 	apt-dpkg-wrap apt-get update && \


### PR DESCRIPTION
in addition to 2b30ab9 It finally covering logic for different from `jitsi` docker repo