### PR TITLE
Allow dashes in roomnames

### DIFF
--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -6,7 +6,7 @@ root /usr/share/jitsi-meet;
 index index.html
 error_page 404 /static/404.html;
 
-location ~ ^/([a-zA-Z0-9=\?]+)$ {
+location ~ ^/([a-zA-Z0-9=\?\-]+)$ {
     rewrite ^/(.*)$ / break;
 }
 
@@ -27,7 +27,7 @@ location / {
 }
 
 # BOSH
-location /http-bind {
+location = /http-bind {
     proxy_pass {{ .Env.XMPP_BOSH_URL_BASE }}/http-bind;
     proxy_set_header X-Forwarded-For $remote_addr;
     proxy_set_header Host {{ .Env.XMPP_DOMAIN }};


### PR DESCRIPTION
Currently it's not possible to have dashes in roomnames.
E.g., `https://meet.jit.si/test-room` works, but when using the web docker image, it doesn't work.

This patch allows dashes in roomnames.