### PR TITLE
fix letsencrypt renewal

### DIFF
--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -18,7 +18,16 @@ if [[ $DISABLE_HTTPS -ne 1 ]]; then
                 -d $LETSENCRYPT_DOMAIN \
                 --agree-tos \
                 --email $LETSENCRYPT_EMAIL
-            cp /defaults/letsencrypt-renew /etc/cron.monthly/
+        fi
+
+        # remove default certbot renewal
+        if [[ -f /etc/cron.d/certbot ]]; then
+            rm /etc/cron.d/certbot
+        fi
+
+        # setup certbot renewal script
+        if [[ ! -f /etc/cron.daily/letencrypt-renew ]]; then
+            cp /defaults/letsencrypt-renew /etc/cron.daily/
         fi
     else
         # use self-signed certs


### PR DESCRIPTION
When mounting the `/etc/letsencrypt` directory into a volume the letsencrypt renewal does not succeed because the init script only copies the renewal script into `/etc/cron.monthly` if there is no certificate yet.

Also it's better to use cron.daily since `certbot renew` does only renew the certificate if it's close to expire.