### PR TITLE
docker-compose: add the right IP for the XMPP_DOMAIN in /etc/hosts

### DIFF
--- a/jibri.yml
+++ b/jibri.yml
@@ -12,6 +12,8 @@ services:
         devices:
             - /dev/snd:/dev/snd
         environment:
+            - DISABLE_HTTPS
+            - DOCKER_HOST_ADDRESS
             - XMPP_AUTH_DOMAIN
             - XMPP_INTERNAL_MUC_DOMAIN
             - XMPP_RECORDER_DOMAIN

--- a/jibri/rootfs/etc/cont-init.d/10-config
+++ b/jibri/rootfs/etc/cont-init.d/10-config
@@ -36,3 +36,9 @@ chown -R jibri ${JIBRI_RECORDING_DIR}
 [ -z "${JIBRI_LOGS_DIR}" ] && export JIBRI_LOGS_DIR=/config/logs
 mkdir -p ${JIBRI_LOGS_DIR}
 chown -R jibri ${JIBRI_LOGS_DIR}
+
+# if https in container is disabled then it must be enabled on the external address,
+# give Chrome a chance to find the right site.
+[ ! -z "${DOCKER_HOST_ADDRESS}" ] \
+&& [ "${DISABLE_HTTPS}" -eq 1 ] \
+&& echo "${DOCKER_HOST_ADDRESS}  ${XMPP_DOMAIN}" >>/etc/hosts


### PR DESCRIPTION
This must fix the issue I described [here](https://github.com/jitsi/docker-jitsi-meet/issues/174#issuecomment-578316073). In short, if HTTPS is disabled then it must be enabled on the external IP. And since Chrome uses only HTTPS then we must direct it to that external IP.

I must warn that I didn't test this code (I only manually added a line to `/etc/hosts` inside container) but it's rather trivial.