### PR TITLE
Adds support of reservation REST API base URL .env input (fixes #175)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,6 +123,7 @@ services:
             - JIBRI_BREWERY_MUC
             - JIBRI_PENDING_TIMEOUT
             - TZ
+            - JICOFO_RESERVATION_REST_BASE_URL
         depends_on:
             - prosody
         networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,12 +118,12 @@ services:
             - JICOFO_COMPONENT_SECRET
             - JICOFO_AUTH_USER
             - JICOFO_AUTH_PASSWORD
+            - JICOFO_RESERVATION_REST_BASE_URL
             - JVB_BREWERY_MUC
             - JIGASI_BREWERY_MUC
             - JIBRI_BREWERY_MUC
             - JIBRI_PENDING_TIMEOUT
             - TZ
-            - JICOFO_RESERVATION_REST_BASE_URL
         depends_on:
             - prosody
         networks:

--- a/env.example
+++ b/env.example
@@ -201,6 +201,9 @@ JICOFO_AUTH_USER=focus
 # XMPP password for Jicofo client connections.
 JICOFO_AUTH_PASSWORD=passw0rd
 
+# Base URL of Jicofo's reservation REST API
+#JICOFO_RESERVATION_REST_BASE_URL=http://reservation.example.com
+
 # XMPP user for Jigasi MUC client connections.
 JIGASI_XMPP_USER=jigasi
 

--- a/jicofo/rootfs/defaults/sip-communicator.properties
+++ b/jicofo/rootfs/defaults/sip-communicator.properties
@@ -13,3 +13,7 @@ org.jitsi.jicofo.jigasi.BREWERY={{ .Env.JIGASI_BREWERY_MUC}}@{{ .Env.XMPP_INTERN
 {{ if .Env.ENABLE_AUTH | default "0" | toBool }}
 org.jitsi.jicofo.auth.URL=XMPP:{{ .Env.XMPP_DOMAIN }}
 {{ end }}
+
+{{ if .Env.JICOFO_RESERVATION_REST_BASE_URL }}
+org.jitsi.impl.reservation.rest.BASE_URL={{ .Env.JICOFO_RESERVATION_REST_BASE_URL }}
+{{ end }}


### PR DESCRIPTION
Enables setting the Base URL of Jicofo's reservation system from the .env file.
Instead of adding `org.jitsi.impl.reservation.rest.BASE_URL=http://reservation.example.com` manually to .jitsi-meet-cfg/jicofo/sip-communicator.properties, which get's resetted sometimes.