### PR TITLE
jigasi: add missing transcription volumes to Dockerfile

### DIFF
--- a/jigasi/Dockerfile
+++ b/jigasi/Dockerfile
@@ -8,4 +8,4 @@ RUN \
 
 COPY rootfs/ /
 
-VOLUME /config
+VOLUME ["/config", "/tmp/transcripts"]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -13,4 +13,4 @@ COPY rootfs/ /
 
 EXPOSE 80 443
 
-VOLUME ["/config", "/etc/letsencrypt"]
+VOLUME ["/config", "/etc/letsencrypt", "/usr/share/jitsi-meet/transcripts"]


### PR DESCRIPTION
The volumes are already defined in the `docker-compose.yml` but are missing in the Dockerfiles.