### PR TITLE
use :Z (selinux) for volume mounts (re. #201)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,9 @@ services:
             - '${HTTP_PORT}:80'
             - '${HTTPS_PORT}:443'
         volumes:
-            - ${CONFIG}/web:/config
-            - ${CONFIG}/web/letsencrypt:/etc/letsencrypt
-            - ${CONFIG}/transcripts:/usr/share/jitsi-meet/transcripts
+            - ${CONFIG}/web:/config:Z
+            - ${CONFIG}/web/letsencrypt:/etc/letsencrypt:Z
+            - ${CONFIG}/transcripts:/usr/share/jitsi-meet/transcripts:Z
         environment:
             - ENABLE_AUTH
             - ENABLE_GUESTS
@@ -50,7 +50,7 @@ services:
             - '5347'
             - '5280'
         volumes:
-            - ${CONFIG}/prosody:/config
+            - ${CONFIG}/prosody:/config:Z
         environment:
             - AUTH_TYPE
             - ENABLE_AUTH
@@ -109,7 +109,7 @@ services:
     jicofo:
         image: jitsi/jicofo
         volumes:
-            - ${CONFIG}/jicofo:/config
+            - ${CONFIG}/jicofo:/config:Z
         environment:
             - ENABLE_AUTH
             - XMPP_DOMAIN
@@ -137,7 +137,7 @@ services:
             - '${JVB_PORT}:${JVB_PORT}/udp'
             - '${JVB_TCP_PORT}:${JVB_TCP_PORT}'
         volumes:
-            - ${CONFIG}/jvb:/config
+            - ${CONFIG}/jvb:/config:Z
         environment:
             - DOCKER_HOST_ADDRESS
             - XMPP_AUTH_DOMAIN


### PR DESCRIPTION
This helps with, but doesn't entirely fix just yet,
running this project on Fedora using `podman up -d` instead of Docker.

This should not break regular `docker-compose` on systems without SELinux.