### PR TITLE
workaround #209

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ follow these steps:
 * Create a ``.env`` file by copying and adjusting ``env.example``, and create required `CONFIG` directories
   * `cp env.example .env`
   * `mkdir -p ~/.jitsi-meet-cfg/{web/letsencrypt,transcripts,prosody,jicofo,jvb}`
+  * `openssl dhparam -out ~/.jitsi-meet-cfg/web/nginx/dhparams.pem 2048
 * Run ``docker-compose up -d``.
-* Access the web UI at [``https://localhost:8443``](https://localhost:8443) (or a different port, in case you edited the compose file).
+* Access the web UI at [``https://localhost:8888``](https://localhost:8888) (or a different port, in case you edited the compose file).
 
 Note that HTTP (not HTTPS) is also available (on port 8000, by default), but that's e.g. for a reverse proxy setup;
 direct access via HTTP instead HTTPS leads to WebRTC errors such as _Failed to access your microphone/camera: Cannot use microphone/camera for an unknown reason. Cannot read property 'getUserMedia' of undefined_ or _navigator.mediaDevices is undefined_.

--- a/env.example
+++ b/env.example
@@ -9,7 +9,7 @@ CONFIG=~/.jitsi-meet-cfg
 HTTP_PORT=8000
 
 # Exposed HTTPS port.
-HTTPS_PORT=8443
+HTTPS_PORT=8888
 
 # System time zone.
 TZ=Europe/Amsterdam


### PR DESCRIPTION
Today I setup docker jitsi on the google cloud shell web preview and got the website working but no the audio or video stream.
I got it running up to the point I could connect with authenticated login via google, but the audio was not working and the app did not work, presumably because they did not handle the login via google that redirects to the sso/oauth. That will be a job for another day, I did change the https port to 8888 because that was an option. 

I encountered one issue that the certificate for nginx did not work and the workaround was to generate it again and bounce the server,
ideally you would do that before starting, just after you copy the configuration.
https://github.com/jitsi/docker-jitsi-meet/issues/209

My workaround is documented in my updated version here. Hope this helps someone. I don't expect this pull request to be merged because of the port change. 