### PR TITLE
Fixed URL that contains dash

### DIFF
--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -6,7 +6,7 @@ root /usr/share/jitsi-meet;
 index index.html
 error_page 404 /static/404.html;
 
-location ~ ^/([a-zA-Z0-9=\?]+)$ {
+location ~ ^/([a-zA-Z0-9=\?\-]+)$ {
     rewrite ^/(.*)$ / break;
 }
 

--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -6,7 +6,7 @@ root /usr/share/jitsi-meet;
 index index.html
 error_page 404 /static/404.html;
 
-location ~ ^/([a-zA-Z0-9=\?\-]+)$ {
+location ~ ^/([a-zA-Z0-9=\?\-\_]+)$ {
     rewrite ^/(.*)$ / break;
 }
 


### PR DESCRIPTION
If you create an instance with a subdomain containing a dash, it will not be reachable. This commit fixes it