### PR TITLE
Update images to buster

### DIFF
--- a/base-java/Dockerfile
+++ b/base-java/Dockerfile
@@ -4,6 +4,6 @@ FROM ${JITSI_REPO}/base
 RUN	\
 	mkdir -p /usr/share/man/man1 && \
 	apt-dpkg-wrap apt-get update && \
-	apt-dpkg-wrap apt-get install -y openjdk-8-jre-headless && \
+	apt-dpkg-wrap apt-get install -y openjdk-11-jre-headless && \
 	apt-cleanup
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 ARG JITSI_RELEASE=stable
 
@@ -18,7 +18,7 @@ RUN \
 	apt-key add /tmp/jitsi.key && \
 	rm -f /tmp/jitsi.key && \
 	echo "deb https://download.jitsi.org $JITSI_RELEASE/" > /etc/apt/sources.list.d/jitsi.list && \
-	echo "deb http://ftp.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list && \
+	echo "deb http://ftp.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && \
 	apt-dpkg-wrap apt-get update && \
 	apt-dpkg-wrap apt-get dist-upgrade -y && \
 	apt-cleanup && \

--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -9,12 +9,12 @@ RUN \
     && echo "deb http://packages.prosody.im/debian stretch main" > /etc/apt/sources.list.d/prosody.list \
     && apt-dpkg-wrap apt-get update \
     && apt-dpkg-wrap apt-get install -y prosody \
-    && apt-dpkg-wrap apt-get install -t stretch-backports -y \
+    && apt-dpkg-wrap apt-get install -t buster-backports -y \
       liblua5.2-dev \
       sasl2-bin \
       libsasl2-modules-ldap \
       libsasl2-dev \
-      libssl1.0-dev \
+      libssl-dev \
       lua-basexx \
       lua-ldap \
       lua-sec \
@@ -22,13 +22,22 @@ RUN \
       git \
       gcc \
       patch \
+      make \
+    && wget https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz \
+    && tar xf openssl-1.0.2u.tar.gz \
+    && cd openssl-1.0.2u \
+    && ./Configure -fPIC --prefix=/usr/local linux-x86_64 \
+    && make install \
+    && cd .. \
+    && rm -rf openssl-1.0.2u openssl-1.0.2u.tar.gz \
     && luarocks install cyrussasl 1.1.0-1 \
     && luarocks install lua-cjson 2.1.0-1 \
     && luarocks install luajwtjitsi 1.3-7 \
     && luarocks install net-url 0.9-1 \
-    && apt-dpkg-wrap apt-get remove -t stretch-backports -y \
+    && apt-dpkg-wrap apt-get remove -t buster-backports -y \
       git \
       gcc \
+      make \
       luarocks \
       libsasl2-dev \
       libssl1.0-dev \

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -6,7 +6,7 @@ COPY rootfs/ /
 RUN \
 	apt-dpkg-wrap apt-get update && \
 	apt-dpkg-wrap apt-get install -y cron nginx-extras jitsi-meet-web && \
-	apt-dpkg-wrap apt-get install -y -t stretch-backports certbot && \
+	apt-dpkg-wrap apt-get install -y -t buster-backports certbot && \
 	apt-dpkg-wrap apt-get -d install -y jitsi-meet-web-config && \
     dpkg -x /var/cache/apt/archives/jitsi-meet-web-config*.deb /tmp/pkg && \
     mv /tmp/pkg/usr/share/jitsi-meet-web-config/config.js /defaults && \


### PR DESCRIPTION
This pull request update all images to Debian Buster.

I've compiled a Openssl 1.0 in the prosody image cause I didn't find any other way to get Luacrypto install correctly.

The images are not well tested but seems to work.  
At least the one I use : jicofo, jvb, web, prosody.

I didn't make any change for using epoll.

Fix #219 ?