### PR TITLE
allow whitespaces in room names

### DIFF
--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -6,7 +6,7 @@ root /usr/share/jitsi-meet;
 index index.html
 error_page 404 /static/404.html;
 
-location ~ ^/([a-zA-Z0-9=\?]+)$ {
+location ~ ^/([a-zA-Z0-9=\?\ ]+)$ {
     rewrite ^/(.*)$ / break;
 }
 


### PR DESCRIPTION
As the welcome page allows whitespaces in room names, nginx should handle whitespaces correctly. Added whitepsace in location regex in meet.conf