### PR TITLE
A Helm chart for jitsi-meet

### DIFF
--- a/examples/helm/.helmignore
+++ b/examples/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/examples/helm/Chart.lock
+++ b/examples/helm/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: prosody
+  repository: ""
+  version: '*'
+digest: sha256:fa9f3f9cfe91aefb81520e7b941b3412241dba7e1631a69138f0fe328c3795ff
+generated: "2020-07-15T11:12:58.968506151+02:00"

--- a/examples/helm/Chart.yaml
+++ b/examples/helm/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: jitsi-meet
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: stable-5390-3
+
+dependencies:
+  - name: prosody
+    condition: prosody.enabled
+    version: '*'

--- a/examples/helm/README.md
+++ b/examples/helm/README.md
@@ -1,0 +1,120 @@
+# jitsi-meet
+
+[jitsi-meet](https://jitsi.org/jitsi-meet/) Secure, Simple and Scalable Video Conferences that you use as a standalone app or embed in your web application.
+
+## TL;DR;
+
+```console
+$ git clone https://github.com/jitsi/docker-jitsi-meet
+$ helm install ./docker-jitsi-meet/examples/helm
+```
+
+## Introduction
+
+This chart bootstraps a jitsi-meet deployment, like the official [one](https://meet.jit.si).
+
+## Different topology
+
+To be able to do video conferencing with other people, the jvb component should be reachable by all participants (eg: a public IP).
+Thus the default behaviour of advertised the internal IP of jvb, is not really suitable in many cases.
+Kubernetes offers multiple possibilities to work around the problem. Not all options are available depending on the Kubernetes cluster setup.
+The chart tries to make all options available without enforcing one.
+
+### Option 1: service of type `LoadBalancer`
+
+This requires a cloud setup that enables a Loadbalancer attachement.
+This could be enabled via values:
+
+```yaml
+jvb:
+  service:
+    type: LoadBalancer
+
+  # Depending on the cloud, publicIP cannot be know in advance, so deploy first, without the next option.
+  # Next: redeploy with the following option set to the public IP you retrieved from the API.
+  publicIP: 1.2.3.4
+```
+
+In this case you're not allowed to change the `jvb.replicaCount` to more than `1`, UDP packets will be routed to random `jvb`, which would not allow for a working video setup.
+
+### Option 2: NodePort and node with Public IP or external loadbalancer
+
+```yaml
+jvb:
+  service:
+    type: NodePort
+  # It may be required to change the default port to a value allowed by Kubernetes (30000-32768)
+  UDPPort: 30000
+  TCPPort: 30443
+
+  # Use public IP of one of your node, or the public IP of a loadbalancer in front of the nodes
+  publicIP: 1.2.3.4
+```
+
+In this case you're not allowed to change the `jvb.replicaCount` to more than `1`, UDP packets will be routed to random `jvb`, which would not allow for a working video setup.
+
+### Option 3: hostPort and node with Public IP
+
+Assuming that the node knows the PublicIP it holds, you can enable this setup:
+
+```yaml
+jvb:
+  useHostPort: true
+  # This option requires kubernetes >= 1.17
+  useNodeIP: true
+```
+
+In this case you can have more the one `jvb` but you're putting you cluster at risk by having it directly exposed on the Internet.
+
+### Option 4: Use ingress TCP/UDP forward capabilities
+
+In case of an ingress capable of doing tcp/udp forwarding (like nginx-ingress), it can be setup to forward the video streams.
+
+```yaml
+# Don't forget to configure the ingress properly (separate configuration)
+jvb:
+  # 1.2.3.4 being one of the IP of the ingress controller
+  publicIP: 1.2.3.4
+
+```
+
+Again in this case, only one jvb will work in this case.
+
+### Option 5: Bring your own setup
+
+There are multiple other possibilities combining the available parameters, depending of your cluster/network setup.
+
+
+
+## Configuration
+
+The following table lists the configurable parameters of the jisti-meet chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`imagePullSecrets` | List of names of secrets resources containing private registry credentials | `[]`
+`enableAuth` | Enable authentication | `false`
+`enableGuests` | Enable guest access | `true`
+`jicofo.replicaCount` | Number of replica of the jicofo pods | `1`
+`jicofo.image.repository` | Name of the image to use for the jicofo pods | `jitsi/jicofo`
+`jicofo.extraEnvs` | Map containing additional environment variables for jicofo | '{}'
+`jicofo.livenessProbe` | Map that holds the liveness probe, you can add parameters such as timeout or retries following the Kubernetes spec | A livenessProbe map
+`jicofo.readinessProbe` | Map that holds the liveness probe, you can add parameters such as timeout or retries following the Kubernetes spec | A readinessProbe map
+`jicofo.xmpp.user` | Name of the XMPP user used by jicofo to authenticate | `focus`
+`jicofo.xmpp.password` | Password used by jicofo to authenticate on the XMPP service | 10 random chars
+`jicofo.xmpp.componentSecret` | Values of the secret used by jicofo for the xmpp-component | 10 random chars
+`jvb.service.enabled` | Boolean to enable os disable the jvb service creation | `false` if `jvb.useHostPort` is `true` otherwise `true`
+`jvb.service.type` | Type of the jvb service | `ClusterIP`
+`jvb.UDPPort` | UDP port used by jvb, also affects port of service, and hostPort | `10000`
+`jvb.TCPPort` | TCP port used by jvb, also affects port of service, and hostPort | `4443`
+`jvb.extraEnvs` | Map containing additional environment variables to jvb | '{}'
+`jvb.xmpp.user` | Name of the XMPP user used by jvb to authenticate | `jvb`
+`jvb.xmpp.password` | Password used by jvb to authenticate on the XMPP service | 10 random chars
+`jvb.livenessProbe` | Map that holds the liveness probe, you can add parameters such as timeout or retries following the Kubernetes spec | A livenessProbe map
+`jvb.readinessProbe` | Map that holds the liveness probe, you can add parameters such as timeout or retries following the Kubernetes spec | A readinessProbe map
+`web.httpsEnabled` | Boolean that enabled tls-termination on the web pods. Useful if you expose the UI via a `Loadbalancer` IP instead of an ingress | `false`
+`web.httpRedirect` | Boolean that enabled http-to-https redirection. Useful for ingress that don't support this feature (ex: GKE ingress) | `false`
+`web.extraEnvs` | Map containing additional environment variable to web pods | '{}'
+`web.livenessProbe` | Map that holds the liveness probe, you can add parameters such as timeout or retries following the Kubernetes spec | A livenessProbe map
+`web.readinessProbe` | Map that holds the liveness probe, you can add parameters such as timeout or retries following the Kubernetes spec | A readinessProbe map
+`tz` | System Time Zone | `Europe/Amsterdam`

--- a/examples/helm/charts/prosody/.helmignore
+++ b/examples/helm/charts/prosody/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/examples/helm/charts/prosody/Chart.yaml
+++ b/examples/helm/charts/prosody/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: prosody
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 1.16.0

--- a/examples/helm/charts/prosody/templates/NOTES.txt
+++ b/examples/helm/charts/prosody/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "prosody.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "prosody.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "prosody.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "prosody.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+{{- end }}

--- a/examples/helm/charts/prosody/templates/_helpers.tpl
+++ b/examples/helm/charts/prosody/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prosody.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prosody.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prosody.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "prosody.labels" -}}
+helm.sh/chart: {{ include "prosody.chart" . }}
+{{ include "prosody.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "prosody.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "prosody.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "prosody.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "prosody.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/examples/helm/charts/prosody/templates/envs-configmap.yaml
+++ b/examples/helm/charts/prosody/templates/envs-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "prosody.fullname" . }}
+  labels:
+    {{- include "prosody.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.env }}
+  {{- if not (kindIs "invalid" $value) }}
+  {{ $key }}: {{ tpl $value $ | quote }}
+  {{- end }}
+  {{- end }}

--- a/examples/helm/charts/prosody/templates/envs-secret.yaml
+++ b/examples/helm/charts/prosody/templates/envs-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "prosody.fullname" . }}
+  labels:
+    {{- include "prosody.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- range $key, $value := .Values.secretEnvs }}
+  {{- if not (kindIs "invalid" $value) }}
+  {{ $key }}: {{ tpl $value $ | quote }}
+  {{- end }}
+  {{- end }}

--- a/examples/helm/charts/prosody/templates/ingress.yaml
+++ b/examples/helm/charts/prosody/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "prosody.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "prosody.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/examples/helm/charts/prosody/templates/service.yaml
+++ b/examples/helm/charts/prosody/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "prosody.fullname" . }}
+  labels:
+    {{- include "prosody.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ index .Values.service.ports "bosh-insecure" }}
+      targetPort: bosh-insecure
+      protocol: TCP
+      name: bosh-insecure
+    - port: {{ index .Values.service.ports "xmpp-component" }}
+      targetPort: xmpp-component
+      protocol: TCP
+      name: xmpp-component
+    - port: {{ index .Values.service.ports "xmpp-c2s" }}
+      targetPort: xmpp-c2s
+      protocol: TCP
+      name: xmpp-c2
+  selector:
+    {{- include "prosody.selectorLabels" . | nindent 4 }}

--- a/examples/helm/charts/prosody/templates/serviceaccount.yaml
+++ b/examples/helm/charts/prosody/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "prosody.serviceAccountName" . }}
+  labels:
+    {{- include "prosody.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/examples/helm/charts/prosody/templates/statefulset.yaml
+++ b/examples/helm/charts/prosody/templates/statefulset.yaml
@@ -1,0 +1,111 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "prosody.fullname" . }}
+  labels:
+    {{- include "prosody.labels" . | nindent 4 }}
+spec:
+  serviceName: "prosody"
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "prosody.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "prosody.selectorLabels" . | nindent 8 }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "prosody.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ tpl (default .Chart.AppVersion .Values.image.tag ) . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+          - configMapRef:
+              name: {{ include "prosody.fullname" . }}
+          - secretRef:
+              name: {{ include "prosody.fullname" . }}
+          {{- range .Values.extraEnvFrom }}
+          - {{ tpl (toYaml . ) $ | indent 12 | trim }}
+          {{- end }}
+          ports:
+            - name: xmpp-c2s
+              containerPort: {{ index .Values.service.ports "xmpp-c2s" }}
+              protocol: TCP
+            - name: xmpp-s2s
+              containerPort: {{ index .Values.service.ports "xmpp-s2s" }}
+              protocol: TCP
+            - name: xmpp-component
+              containerPort: {{ index .Values.service.ports "xmpp-component" }}
+              protocol: TCP
+            - name: bosh-insecure
+              containerPort: {{ index .Values.service.ports "bosh-insecure" }}
+              protocol: TCP
+            - name: bosh-secure
+              containerPort: {{ index .Values.service.ports "bosh-secure" }}
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          - name: prosody-data
+            mountPath: {{ .Values.dataDir }}
+          {{- with .Values.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+      volumes:
+      - name: prosody-data
+        {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: prosody-data
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
+      {{- with .Values.extraVolumes }}
+      {(- toYaml . | nindent 6 }}
+      {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- if or .Values.persistence.enabled .Values.extraVolumeClaimTemplates }}
+  volumeClaimTemplates:
+  - metadata:
+      name: prosody-data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      volumeMode: Filesystem
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size }}
+      {{- with .Values.persistence.storageClassName }}
+      storageClassName: {{ . | quote }}
+      {{- end }}
+  {{- with .Values.extraVolumeClaimTemplates }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}

--- a/examples/helm/charts/prosody/templates/statefulset.yaml
+++ b/examples/helm/charts/prosody/templates/statefulset.yaml
@@ -14,6 +14,15 @@ spec:
     metadata:
       labels:
         {{- include "prosody.selectorLabels" . | nindent 8 }}
+      {{- range $label, $value := mergeOverwrite .Values.global.podLabels .Values.podLabels }}
+        {{ $label }}: {{ $value }}
+      {{- end }}
+      {{- with mergeOverwrite .Values.global.podAnnotations .Values.podAnnotations }}
+      annotations:
+      {{- range $annotation, $value := . }}
+        {{ $annotation }}: {{ $value }}
+      {{- end }}
+      {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/examples/helm/charts/prosody/templates/tests/test-connection.yaml
+++ b/examples/helm/charts/prosody/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "prosody.fullname" . }}-test-connection"
+  labels:
+    {{- include "prosody.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "prosody.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/examples/helm/charts/prosody/values.yaml
+++ b/examples/helm/charts/prosody/values.yaml
@@ -1,0 +1,90 @@
+# Default values for prosody.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+domain:
+
+dataDir: /config/data
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  ports:
+    bosh-insecure: 5280
+    bosh-secure: 5281
+    xmpp-c2s: 5222
+    xmpp-s2s: 5269
+    xmpp-component: 5347
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: /http-bind
+    port: bosh-insecure
+readinessProbe:
+  httpGet:
+    path: /http-bind
+    port: bosh-insecure
+
+persistence:
+  enabled: true
+  size: 3G
+  storageClassName:
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+extraEnvFrom: []

--- a/examples/helm/charts/prosody/values.yaml
+++ b/examples/helm/charts/prosody/values.yaml
@@ -22,6 +22,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+podLabels: {}
+podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 

--- a/examples/helm/templates/NOTES.txt
+++ b/examples/helm/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.web.ingress.enabled }}
+{{- range $host := .Values.web.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.web.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.web.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "jitsi-meet.web.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.web.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "jitsi-meet.web.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "jitsi-meet.web.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.web.service.port }}
+{{- else if contains "ClusterIP" .Values.web.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "jitsi-meet.name" . }},app.kubernetes.io/component=web,app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+{{- end }}

--- a/examples/helm/templates/_helpers.tpl
+++ b/examples/helm/templates/_helpers.tpl
@@ -1,0 +1,89 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "jitsi-meet.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "jitsi-meet.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "jitsi-meet.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "jitsi-meet.labels" -}}
+helm.sh/chart: {{ include "jitsi-meet.chart" . }}
+{{ include "jitsi-meet.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "jitsi-meet.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "jitsi-meet.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "jitsi-meet.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "jitsi-meet.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+  https://github.com/helm/helm/issues/4535
+*/}}
+{{- define "call-nested" }}
+{{- $dot := index . 0 }}
+{{- $subchart := index . 1 }}
+{{- $template := index . 2 }}
+{{- include $template (dict "Chart" (dict "Name" $subchart) "Values" (index $dot.Values $subchart) "Release" $dot.Release "Capabilities" $dot.Capabilities) }}
+{{- end }}
+
+{{- define "jitsi-meet.xmpp.domain" -}}
+{{- if  .Values.xmpp.domain -}}
+  {{ .Values.xmpp.domain }}
+{{- else -}}
+  {{ .Release.Namespace }}.svc
+{{- end -}}
+{{- end -}}
+
+{{- define "jitsi-meet.xmpp.server" -}}
+{{- if .Values.prosody.server -}}
+  {{ .Values.prosody.server }}
+{{- else -}}
+  {{ include "call-nested" (list . "prosody" "prosody.fullname") }}.{{ .Release.Namespace }}.svc
+{{- end -}}
+{{- end -}}

--- a/examples/helm/templates/_helpers.tpl
+++ b/examples/helm/templates/_helpers.tpl
@@ -87,3 +87,18 @@ Create the name of the service account to use
   {{ include "call-nested" (list . "prosody" "prosody.fullname") }}.{{ .Release.Namespace }}.svc
 {{- end -}}
 {{- end -}}
+
+
+{{- define "jitsi-meet.publicURL" -}}
+{{- if .Values.publicURL }}
+{{ .Values.pulicURL }}
+{{- else -}}
+{{- if .Values.web.ingress.tls -}}https://{{- else -}}http://{{- end -}}
+{{- if .Values.web.ingress.tls -}}
+{{- (.Values.web.ingress.tls|first).hosts|first -}}
+{{- else if .Values.web.ingress.hosts -}}
+{{- (.Values.web.ingress.hosts|first).host -}}
+{{ required "You need to define a publicURL or some value for ingress" .Values.publicURL }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/examples/helm/templates/common-configmap.yaml
+++ b/examples/helm/templates/common-configmap.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-common
+  labels:
+    {{- include "jitsi-meet.labels" . | nindent 4 }}
+data:
+  ENABLE_AUTH: {{ ternary "1" "0" .Values.enableAuth | quote }}
+  ENABLE_GUESTS: {{ ternary "1" "0" .Values.enableGuests | quote }}
+  XMPP_DOMAIN: {{ include "jitsi-meet.xmpp.domain" . }}
+  XMPP_MUC_DOMAIN: {{ .Values.xmpp.muxDomain | default (printf "muc.%s" (include "jitsi-meet.xmpp.domain" .)) }}
+  XMPP_AUTH_DOMAIN: {{ .Values.xmpp.authDomain | default (printf "auth.%s" (include "jitsi-meet.xmpp.domain" .)) }}
+  XMPP_GUEST_DOMAIN: {{ .Values.xmpp.guestDomain | default (printf "guest.%s" (include "jitsi-meet.xmpp.domain" .)) }}
+  XMPP_RECORDER_DOMAIN: {{ .Values.xmpp.recorderDomain | default (printf "recorder.%s" (include "jitsi-meet.xmpp.domain" .)) }}
+  XMPP_INTERNAL_MUC_DOMAIN: {{ .Values.xmpp.internalMucDomain | default (printf "internal-muc.%s" (include "jitsi-meet.xmpp.domain" .)) }}
+  TZ: '{{ .Values.tz }}'
+  {{- range $key, $value := .Values.extraCommonEnvs }}
+  {{- if not (kindIs "invalid" $value) }}
+  {{ $key }}: {{ tpl $value $ | quote }}
+  {{- end }}
+  {{- end }}

--- a/examples/helm/templates/common-configmap.yaml
+++ b/examples/helm/templates/common-configmap.yaml
@@ -7,6 +7,7 @@ metadata:
 data:
   ENABLE_AUTH: {{ ternary "1" "0" .Values.enableAuth | quote }}
   ENABLE_GUESTS: {{ ternary "1" "0" .Values.enableGuests | quote }}
+  PUBLIC_URL: {{ include "jitsi-meet.publicURL" . }}
   XMPP_DOMAIN: {{ include "jitsi-meet.xmpp.domain" . }}
   XMPP_MUC_DOMAIN: {{ .Values.xmpp.muxDomain | default (printf "muc.%s" (include "jitsi-meet.xmpp.domain" .)) }}
   XMPP_AUTH_DOMAIN: {{ .Values.xmpp.authDomain | default (printf "auth.%s" (include "jitsi-meet.xmpp.domain" .)) }}

--- a/examples/helm/templates/ingress.yaml
+++ b/examples/helm/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.web.ingress.enabled -}}
+{{- $fullName := include "jitsi-meet.web.fullname" . -}}
+{{- $svcPort := .Values.web.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "jitsi-meet.web.labels" . | nindent 4 }}
+  {{- with .Values.web.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.web.ingress.tls }}
+  tls:
+  {{- range .Values.web.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.web.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/examples/helm/templates/jicofo/_helper.tpl
+++ b/examples/helm/templates/jicofo/_helper.tpl
@@ -1,0 +1,18 @@
+
+{{- define "jitsi-meet.jicofo.fullname" -}}
+{{ include "jitsi-meet.fullname" . }}-jicofo
+{{- end -}}
+
+{{- define "jitsi-meet.jicofo.labels" -}}
+{{ include "jitsi-meet.labels" . }}
+app.kubernetes.io/component: jicofo
+{{- end -}}
+
+{{- define "jitsi-meet.jicofo.selectorLabels" -}}
+{{ include "jitsi-meet.selectorLabels" . }}
+app.kubernetes.io/component: jicofo
+{{- end -}}
+
+{{- define "jitsi-meet.jicofo.secret" -}}
+{{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jicofo
+{{- end -}}

--- a/examples/helm/templates/jicofo/configmap.yaml
+++ b/examples/helm/templates/jicofo/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "jitsi-meet.jicofo.fullname" . }}
+  labels:
+    {{- include "jitsi-meet.jicofo.labels" . | nindent 4 }}
+data:
+  JVB_BREWERY_MUC: '{{ .Values.jvb.breweryMuc }}'
+  XMPP_SERVER: '{{ include "jitsi-meet.xmpp.server" . }}'
+  {{- range $key, $value := .Values.jicofo.extraEnvs }}
+  {{- if not (kindIs "invalid" $value) }}
+  {{ $key }}: {{ tpl $value $ | quote }}
+  {{- end }}
+  {{- end }}

--- a/examples/helm/templates/jicofo/deployment.yaml
+++ b/examples/helm/templates/jicofo/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "jitsi-meet.jicofo.fullname" . }}
+  labels:
+    {{- include "jitsi-meet.jicofo.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.jicofo.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "jitsi-meet.jicofo.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "jitsi-meet.jicofo.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/jicofo/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/jicofo/xmpp-secret.yaml") . | sha256sum }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "jitsi-meet.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.jicofo.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.jicofo.securityContext | nindent 12 }}
+          image: "{{ .Values.jicofo.image.repository }}:{{ default .Chart.AppVersion .Values.jicofo.image.tag }}"
+          imagePullPolicy: {{ pluck "pullPolicy" .Values.jicofo.image .Values.image | first }}
+          envFrom:
+          - secretRef:
+              name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jicofo
+          - configMapRef:
+              name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-common
+          - configMapRef:
+              name: {{ include "jitsi-meet.jicofo.fullname" . }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          {{- with .Values.jicofo.livenessProbe }}
+          livenessProbe:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.jicofo.readinessProbe }}
+          readinessProbe:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.jicofo.resources | nindent 12 }}
+
+      {{- with .Values.jicofo.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.jicofo.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.jicofo.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/examples/helm/templates/jicofo/deployment.yaml
+++ b/examples/helm/templates/jicofo/deployment.yaml
@@ -13,9 +13,15 @@ spec:
     metadata:
       labels:
         {{- include "jitsi-meet.jicofo.selectorLabels" . | nindent 8 }}
+      {{- range $label, $value := mergeOverwrite .Values.global.podLabels .Values.jvb.podLabels }}
+        {{ $label }}: {{ $value }}
+      {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/jicofo/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/jicofo/xmpp-secret.yaml") . | sha256sum }}
+      {{- range $annotation, $value := mergeOverwrite .Values.global.podAnnotations .Values.jvb.podAnnotations }}
+        {{ $annotation }}: {{ $value }}
+      {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/examples/helm/templates/jicofo/xmpp-secret.yaml
+++ b/examples/helm/templates/jicofo/xmpp-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jicofo
+  labels:
+    {{- include "jitsi-meet.jicofo.labels" . | nindent 4 }}
+type: Opaque
+data:
+  JICOFO_AUTH_USER: '{{ .Values.jicofo.xmpp.user | b64enc }}'
+  JICOFO_AUTH_PASSWORD: '{{ default (randAlphaNum 10) .Values.jicofo.xmpp.password | b64enc }}'
+  JICOFO_COMPONENT_SECRET: '{{ default (randAlphaNum 10) .Values.jicofo.xmpp.componentSecret | b64enc }}'

--- a/examples/helm/templates/jvb/_helper.tpl
+++ b/examples/helm/templates/jvb/_helper.tpl
@@ -1,0 +1,18 @@
+
+{{- define "jitsi-meet.jvb.fullname" -}}
+{{ include "jitsi-meet.fullname" . }}-jvb
+{{- end -}}
+
+{{- define "jitsi-meet.jvb.labels" -}}
+{{ include "jitsi-meet.labels" . }}
+app.kubernetes.io/component: jvb
+{{- end -}}
+
+{{- define "jitsi-meet.jvb.selectorLabels" -}}
+{{ include "jitsi-meet.selectorLabels" . }}
+app.kubernetes.io/component: jvb
+{{- end -}}
+
+{{- define "jitsi-meet.jvb.secret" -}}
+{{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jvb
+{{- end -}}

--- a/examples/helm/templates/jvb/configmap.yaml
+++ b/examples/helm/templates/jvb/configmap.yaml
@@ -7,8 +7,12 @@ metadata:
 data:
   JVB_BREWERY_MUC: '{{ .Values.jvb.breweryMuc }}'
   JVB_PORT: '{{ .Values.jvb.UDPPort }}'
+  {{- if .Values.jvb.enableTCP }}
   JVB_TCP_PORT: '{{ .Values.jvb.TCPPort }}'
   JVB_TCP_HARVESTER_DISABLED: '0'
+  {{- else }}
+  JVB_TCP_HARVESTER_DISABLED: '1'
+  {{- end }}
   XMPP_SERVER: '{{ include "jitsi-meet.xmpp.server" . }}'
   {{- range $key, $value := .Values.jvb.extraEnvs }}
   {{- if not (kindIs "invalid" $value) }}

--- a/examples/helm/templates/jvb/configmap.yaml
+++ b/examples/helm/templates/jvb/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "jitsi-meet.jvb.fullname" . }}
+  labels:
+    {{- include "jitsi-meet.jvb.labels" . | nindent 4 }}
+data:
+  JVB_BREWERY_MUC: '{{ .Values.jvb.breweryMuc }}'
+  JVB_PORT: '{{ .Values.jvb.UDPPort }}'
+  JVB_TCP_PORT: '{{ .Values.jvb.TCPPort }}'
+  JVB_TCP_HARVESTER_DISABLED: '0'
+  XMPP_SERVER: '{{ include "jitsi-meet.xmpp.server" . }}'
+  {{- range $key, $value := .Values.jvb.extraEnvs }}
+  {{- if not (kindIs "invalid" $value) }}
+  {{ $key }}: {{ tpl $value $ | quote }}
+  {{- end }}
+  {{- end }}

--- a/examples/helm/templates/jvb/configmap.yaml
+++ b/examples/helm/templates/jvb/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
 data:
   JVB_BREWERY_MUC: '{{ .Values.jvb.breweryMuc }}'
   JVB_PORT: '{{ .Values.jvb.UDPPort }}'
+  JVB_STUN_SERVERS: '{{.Values.jvb.stunServers }}'
   {{- if .Values.jvb.enableTCP }}
   JVB_TCP_PORT: '{{ .Values.jvb.TCPPort }}'
   JVB_TCP_HARVESTER_DISABLED: '0'

--- a/examples/helm/templates/jvb/deployment.yaml
+++ b/examples/helm/templates/jvb/deployment.yaml
@@ -1,0 +1,98 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "jitsi-meet.jvb.fullname" . }}
+  labels:
+    {{- include "jitsi-meet.jvb.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.jvb.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "jitsi-meet.jvb.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "jitsi-meet.jvb.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/jvb/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/jvb/xmpp-secret.yaml") . | sha256sum }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "jitsi-meet.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.jvb.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.jvb.securityContext | nindent 12 }}
+          image: "{{ .Values.jvb.image.repository }}:{{ default .Chart.AppVersion .Values.jvb.image.tag }}"
+          imagePullPolicy: {{ pluck "pullPolicy" .Values.jvb.image .Values.image | first }}
+          envFrom:
+          - secretRef:
+              name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jvb
+          - configMapRef:
+              name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-common
+          - configMapRef:
+              name: {{ include "jitsi-meet.jvb.fullname" . }}
+          env:
+          {{- if or .Values.jvb.useNodeIP .Values.jvb.publicIP }}
+          - name: DOCKER_HOST_ADDRESS
+            {{- if .Values.jvb.publicIP }}
+            value: {{ .Values.jvb.publicIP }}
+            {{- else }}
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+            {{- end }}
+          {{- end }}
+          ports:
+            - name: rtp-udp
+              containerPort: {{ .Values.jvb.UDPPort }}
+              {{- if .Values.jvb.useHostPort }}
+              hostPort: {{ .Values.jvb.UDPPort }}
+              {{- end }}
+              protocol: UDP
+            - name: rtp-tcp
+              containerPort: {{ .Values.jvb.TCPPort }}
+              {{- if .Values.jvb.useHostPort }}
+              hostPort: {{ .Values.jvb.TCPPort }}
+              {{- end }}
+              protocol: TCP
+          {{- with .Values.jvb.livenessProbe }}
+          livenessProbe:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.jvb.readinessProbe }}
+          readinessProbe:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.jvb.resources | nindent 12 }}
+
+      {{- with .Values.jvb.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- if or .Values.jvb.useHostPort .Values.jvb.affinity }}
+      affinity:
+      {{- if .Values.jvb.affinity }}
+        {{- toYaml .Values.jvb.affinity | nindent 8 }}
+      {{- else }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - jvb
+            topologyKey: "kubernetes.io/hostname"
+      {{- end }}
+    {{- end }}
+    {{- with .Values.jvb.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/examples/helm/templates/jvb/deployment.yaml
+++ b/examples/helm/templates/jvb/deployment.yaml
@@ -55,12 +55,14 @@ spec:
               hostPort: {{ .Values.jvb.UDPPort }}
               {{- end }}
               protocol: UDP
+          {{- if .Values.jvb.enableTCP }}
             - name: rtp-tcp
               containerPort: {{ .Values.jvb.TCPPort }}
               {{- if .Values.jvb.useHostPort }}
               hostPort: {{ .Values.jvb.TCPPort }}
               {{- end }}
               protocol: TCP
+          {{- end }}
           {{- with .Values.jvb.livenessProbe }}
           livenessProbe:
           {{- toYaml . | nindent 12 }}

--- a/examples/helm/templates/jvb/deployment.yaml
+++ b/examples/helm/templates/jvb/deployment.yaml
@@ -13,9 +13,15 @@ spec:
     metadata:
       labels:
         {{- include "jitsi-meet.jvb.selectorLabels" . | nindent 8 }}
+      {{- range $label, $value := mergeOverwrite .Values.global.podLabels .Values.jvb.podLabels }}
+        {{ $label }}: {{ $value }}
+      {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/jvb/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/jvb/xmpp-secret.yaml") . | sha256sum }}
+      {{- range $annotation, $value := mergeOverwrite .Values.global.podAnnotations .Values.jvb.podAnnotations }}
+        {{ $annotation }}: {{ $value }}
+      {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/examples/helm/templates/jvb/service.yaml
+++ b/examples/helm/templates/jvb/service.yaml
@@ -18,6 +18,7 @@ spec:
       {{- end }}
       protocol: UDP
       name: rtp-udp
+    {{- if and .Values.jvb.enableTCP }}
     - port: {{ .Values.jvb.TCPPort }}
       targetPort: rtp-tcp
       {{- if eq .Values.jvb.service.type "NodePort" }}
@@ -25,6 +26,7 @@ spec:
       {{- end }}
       protocol: TCP
       name: rtp-tcp
+    {{- end }}
   {{- with .Values.jvb.service.externalIPs }}
   externalIPs:
   {{ toYaml . | indent 2 | trim }}

--- a/examples/helm/templates/jvb/service.yaml
+++ b/examples/helm/templates/jvb/service.yaml
@@ -1,0 +1,34 @@
+{{- if or (and (kindIs "invalid" .Values.jvb.service.enabled) (not .Values.jvb.useHostPort)) .Values.jvb.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "jitsi-meet.jvb.fullname" . }}
+  labels:
+    {{- include "jitsi-meet.jvb.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.jvb.service.type }}
+  {{- with .Values.jvb.service.LoadbalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.jvb.UDPPort }}
+      targetPort: rtp-udp
+      {{- if eq .Values.jvb.service.type "NodePort" }}
+      nodePort: {{ .Values.jvb.UDPPort }}
+      {{- end }}
+      protocol: UDP
+      name: rtp-udp
+    - port: {{ .Values.jvb.TCPPort }}
+      targetPort: rtp-tcp
+      {{- if eq .Values.jvb.service.type "NodePort" }}
+      nodePort: {{ .Values.jvb.TCPPort }}
+      {{- end }}
+      protocol: TCP
+      name: rtp-tcp
+  {{- with .Values.jvb.service.externalIPs }}
+  externalIPs:
+  {{ toYaml . | indent 2 | trim }}
+  {{- end }}
+  selector:
+    {{- include "jitsi-meet.jvb.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/examples/helm/templates/jvb/xmpp-secret.yaml
+++ b/examples/helm/templates/jvb/xmpp-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jvb
+  labels:
+    {{- include "jitsi-meet.jvb.labels" . | nindent 4 }}
+type: Opaque
+data:
+  JVB_AUTH_USER: '{{ .Values.jvb.xmpp.user | b64enc }}'
+  JVB_AUTH_PASSWORD: '{{ default (randAlphaNum 10) .Values.jvb.xmpp.password | b64enc }}'

--- a/examples/helm/templates/serviceaccount.yaml
+++ b/examples/helm/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "jitsi-meet.serviceAccountName" . }}
+  labels:
+    {{- include "jitsi-meet.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/examples/helm/templates/tests/test-connection.yaml
+++ b/examples/helm/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "jitsi-meet.web.fullname" . }}-test-connection"
+  labels:
+    {{- include "jitsi-meet.web.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "jitsi-meet.web.fullname" . }}:{{ .Values.web.service.port }}']
+  restartPolicy: Never

--- a/examples/helm/templates/web/_helper.tpl
+++ b/examples/helm/templates/web/_helper.tpl
@@ -1,0 +1,15 @@
+
+{{- define "jitsi-meet.web.fullname" -}}
+{{ include "jitsi-meet.fullname" . }}-web
+{{- end -}}
+
+{{- define "jitsi-meet.web.labels" -}}
+{{ include "jitsi-meet.labels" . }}
+app.kubernetes.io/component: web
+{{- end -}}
+
+{{- define "jitsi-meet.web.selectorLabels" -}}
+{{ include "jitsi-meet.selectorLabels" . }}
+app.kubernetes.io/component: web
+{{- end -}}
+

--- a/examples/helm/templates/web/configmap.yaml
+++ b/examples/helm/templates/web/configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "jitsi-meet.web.fullname" . }}
+  labels:
+    {{- include "jitsi-meet.web.labels" . | nindent 4 }}
+data:
+  DISABLE_HTTPS: {{ ternary "0" "1" .Values.web.httpsEnabled | quote }}
+  ENABLE_HTTP_REDIRECT: {{ ternary "1" "0" .Values.web.httpRedirect | quote }}
+  JICOFO_AUTH_USER: '{{ .Values.jicofo.xmpp.user }}'
+  XMPP_BOSH_URL_BASE: 'http://{{ include "jitsi-meet.xmpp.server" . }}:{{ index .Values.prosody.service.ports "bosh-insecure" }}'
+  {{- range $key, $value := .Values.web.extraEnvs }}
+  {{- if not (kindIs "invalid" $value) }}
+  {{ $key }}: {{ tpl $value $ | quote }}
+  {{- end }}
+  {{- end }}

--- a/examples/helm/templates/web/deployment.yaml
+++ b/examples/helm/templates/web/deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "jitsi-meet.web.fullname" . }}
+  labels:
+    {{- include "jitsi-meet.web.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.web.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "jitsi-meet.web.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "jitsi-meet.web.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/web/configmap.yaml") . | sha256sum }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "jitsi-meet.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.web.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.web.securityContext | nindent 12 }}
+          image: "{{ .Values.web.image.repository }}:{{ default .Chart.AppVersion .Values.web.image.tag }}"
+          imagePullPolicy: {{ pluck "pullPolicy" .Values.web.image .Values.image | first }}
+          envFrom:
+          - configMapRef:
+              name: {{ include "jitsi-meet.web.fullname" . }}
+          - configMapRef:
+              name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-common
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: https
+              containerPort: 443
+              protocol: TCP
+          {{- with .Values.web.livenessProbe }}
+          livenessProbe:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.web.readinessProbe }}
+          readinessProbe:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}
+          {{- with .Values.web.extraVolumeMounts }}
+          volumeMounts:
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+
+      {{- with .Values.web.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.web.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.web.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.web.extraVolumes }}
+    volumes:
+    {{- toYaml . | nindent 4 }}
+    {{- end }}

--- a/examples/helm/templates/web/deployment.yaml
+++ b/examples/helm/templates/web/deployment.yaml
@@ -13,8 +13,14 @@ spec:
     metadata:
       labels:
         {{- include "jitsi-meet.web.selectorLabels" . | nindent 8 }}
+      {{- range $label, $value := mergeOverwrite .Values.global.podLabels .Values.web.podLabels }}
+        {{ $label }}: {{ $value }}
+      {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/web/configmap.yaml") . | sha256sum }}
+      {{- range $annotation, $value := mergeOverwrite .Values.global.podAnnotations .Values.web.podAnnotations }}
+        {{ $annotation }}: {{ $value }}
+      {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/examples/helm/templates/web/service.yaml
+++ b/examples/helm/templates/web/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "jitsi-meet.web.fullname" . }}
+  labels:
+    {{- include "jitsi-meet.web.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.web.service.type }}
+  ports:
+    - port: {{ .Values.web.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  {{- with .Values.web.service.externalIPs }}
+  externalIPs:
+  {{ toYaml . | indent 2 | trim }}
+  {{- end }}
+  selector:
+    {{- include "jitsi-meet.web.selectorLabels" . | nindent 4 }}

--- a/examples/helm/values.yaml
+++ b/examples/helm/values.yaml
@@ -117,6 +117,7 @@ jvb:
     password:
 
   useHostPort: false
+  enableTCP: false
   UDPPort: 10000
   TCPPort: 4443
   service:

--- a/examples/helm/values.yaml
+++ b/examples/helm/values.yaml
@@ -157,7 +157,7 @@ serviceAccount:
   name:
 
 xmpp:
-  domain:
+  domain: meet.jitsi
   authDomain:
   mucDomain:
   internalMucDomain:

--- a/examples/helm/values.yaml
+++ b/examples/helm/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+  podLabels: {}
+  podAnnotations: {}
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -53,6 +56,8 @@ web:
       path: /
       port: http
 
+  podLabels: {}
+  podAnnotations: {}
   podSecurityContext: {}
     # fsGroup: 2000
 
@@ -99,6 +104,8 @@ jicofo:
     tcpSocket:
       port: 8888
 
+  podLabels: {}
+  podAnnotations: {}
   podSecurityContext: {}
   securityContext: {}
   resources: {}
@@ -139,6 +146,8 @@ jvb:
       - pgrep
       - java
 
+  podLabels: {}
+  podAnnotations: {}
   podSecurityContext: {}
   securityContext: {}
   resources: {}

--- a/examples/helm/values.yaml
+++ b/examples/helm/values.yaml
@@ -116,6 +116,7 @@ jvb:
     user: jvb
     password:
 
+  stunServers: 'meet-jit-si-turnrelay.jitsi.net:443'
   useHostPort: false
   enableTCP: false
   UDPPort: 10000

--- a/examples/helm/values.yaml
+++ b/examples/helm/values.yaml
@@ -1,0 +1,178 @@
+# Default values for jitsi-meet.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+enableAuth: false
+enableGuests: true
+
+tz: Europe/Amsterdam
+
+image:
+  pullPolicy: IfNotPresent
+
+web:
+  replicaCount: 1
+  image:
+    repository: jitsi/web
+
+  extraEnvs: {}
+  service:
+    type: ClusterIP
+    port: 80
+    externalIPs: []
+
+  ingress:
+    enabled: false
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    hosts:
+    - host: jitsi.local
+      paths: ['/']
+    tls: []
+    #  - secretName: jits-web-certificate
+    #    hosts:
+    #      - jitsi.local
+
+  # Useful for ingresses that don't support http-to-https redirect by themself, (namely: GKE),
+  httpRedirect: false
+
+  # When tls-termination by the ingress is not wanted, enable this and set web.service.type=Loadbalancer
+  httpsEnabled: false
+
+  livenessProbe:
+    httpGet:
+      path: /
+      port: http
+  readinessProbe:
+    httpGet:
+      path: /
+      port: http
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+jicofo:
+  replicaCount: 1
+  image:
+    repository: jitsi/jicofo
+
+  xmpp:
+    user: focus
+    password:
+    componentSecret:
+
+  livenessProbe:
+    tcpSocket:
+      port: 8888
+  readinessProbe:
+    tcpSocket:
+      port: 8888
+
+  podSecurityContext: {}
+  securityContext: {}
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  extraEnvs: {}
+
+jvb:
+  replicaCount: 1
+  image:
+    repository: jitsi/jvb
+
+  xmpp:
+    user: jvb
+    password:
+
+  useHostPort: false
+  UDPPort: 10000
+  TCPPort: 4443
+  service:
+    enabled:
+    type: ClusterIP
+    externalIPs: []
+
+  breweryMuc: jvbbrewery
+
+  livenessProbe:
+    exec:
+      command:
+      - pgrep
+      - java
+  readinessProbe:
+    exec:
+      command:
+      - pgrep
+      - java
+
+  podSecurityContext: {}
+  securityContext: {}
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  extraEnvs: {}
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+xmpp:
+  domain:
+  authDomain:
+  mucDomain:
+  internalMucDomain:
+  guestDomain:
+
+extraCommonEnvs: {}
+
+prosody:
+  enabled: true
+  server:
+  extraEnvFrom:
+  - secretRef:
+      name: '{{ include "prosody.fullname" . }}-jicofo'
+  - secretRef:
+      name: '{{ include "prosody.fullname" . }}-jvb'
+  - configMapRef:
+      name: '{{ include "prosody.fullname" . }}-common'
+  image:
+    repository: jitsi/prosody
+    tag: 'stable-5390-3'

--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -121,7 +121,7 @@ if [[ ! -f /config/interface_config.js ]]; then
 
     # It will remove parameter 'closedcaptions' from TOOLBAR_BUTTONS if ENABLE_TRANSCRIPTIONS is false,
     # because it enabled by default, but not supported out of the box.
-    if [[ $ENABLE_TRANSCRIPTIONS -ne 1 || "$ENABLE_TRANSCRIPTIONS" != "true" ]]; then
+    if [[ $ENABLE_TRANSCRIPTIONS -ne 1 && "$ENABLE_TRANSCRIPTIONS" != "true" ]]; then
         sed -i \
             -e "s#'closedcaptions', ##" \
             /config/interface_config.js


### PR DESCRIPTION
Add a kubernetes helm chart for jitsi-meet

Featured:
- quite as par with the main docker-compose file
- a separate subchart for prosody, that's the easiest way to disable prosody completely and use an external prosody server
- multiple option to handle the public IP of the jvb (kubernetes could be quite complicated regarding network setup)

Non-featured:
- other components (such as sip gayteway, I don't think the range port could be easily achievable in kubernetes)
- full feature prosody chart, but interface is generic enough to be one day a dependency to an official prosody chart
- the release process to made it available via helm repository (https://helm.sh/docs/topics/chart_repository/#share-your-charts-with-others)

Tested:
 Tested options 2, 3, 4, not the 1 (https://github.com/Zempashi/docker-jitsi-meet/tree/k8s-helm/examples/helm)