### PR TITLE
ldap: fix anonymous binds without breaking template rendering (Fixes #234)

### DIFF
--- a/prosody/rootfs/defaults/saslauthd.conf
+++ b/prosody/rootfs/defaults/saslauthd.conf
@@ -1,7 +1,7 @@
 {{ if eq (.Env.AUTH_TYPE | default "internal") "ldap" }}
 ldap_servers: {{ .Env.LDAP_URL }}
 ldap_search_base: {{ .Env.LDAP_BASE }}
-{{ if .Env.LDAP_BINDDN }}
+{{ if .Env.LDAP_BINDDN | default "" | toBool }}
 ldap_bind_dn: {{ .Env.LDAP_BINDDN }}
 ldap_bind_pw: {{ .Env.LDAP_BINDPW }}
 {{ end }}


### PR DESCRIPTION
Commit e92a00ca199ab4f64acc39a245f354164ce8f13a took the first steps towards fixing `<no value>` expansions during rendering for LDAP_BINDDN and LDAP_BINDPW.

In our deployment, this breaks template rendering if LDAP_BINDDN is not defined.
Only the first two lines of the template are evaluated.

A simple solution is provided in this pull request: expand LDAP_BINDDN to a default value and cast it to a boolean, similar to line 14 of the same file.

This fixes #234 