### PR TITLE
update nginx config from upstream

### DIFF
--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -3,34 +3,46 @@ server_name _;
 client_max_body_size 0;
 
 root /usr/share/jitsi-meet;
-index index.html
+
+# ssi on with javascript for multidomain variables in config.js
+ssi on;
+ssi_types application/x-javascript application/javascript;
+
+index index.html index.htm;
 error_page 404 /static/404.html;
 
-location ~ ^/([a-zA-Z0-9=\?]+)$ {
-    rewrite ^/(.*)$ / break;
-}
-
-location /config.js {
+location = /config.js {
     alias /config/config.js;
 }
 
-location /interface_config.js {
+location = /interface_config.js {
     alias /config/interface_config.js;
 }
 
-location /external_api.js {
+location = /external_api.js {
     alias /usr/share/jitsi-meet/libs/external_api.min.js;
 }
 
-location / {
-    ssi on;
+# ensure all static content can always be found first
+location ~ ^/(libs|css|static|images|fonts|lang|sounds|connection_optimization|.well-known)/(.*)$
+{
+    add_header 'Access-Control-Allow-Origin' '*';
+    alias /usr/share/jitsi-meet/$1/$2;
 }
 
 # BOSH
-location /http-bind {
+location = /http-bind {
     proxy_pass {{ .Env.XMPP_BOSH_URL_BASE }}/http-bind;
     proxy_set_header X-Forwarded-For $remote_addr;
     proxy_set_header Host {{ .Env.XMPP_DOMAIN }};
+}
+
+location ~ ^/([^/?&:'"]+)$ {
+    try_files $uri @root_path;
+}
+
+location @root_path {
+    rewrite ^/(.*)$ / break;
 }
 
 {{ if .Env.ETHERPAD_URL_BASE }}


### PR DESCRIPTION
The current `meet.conf` for nginx is outdated. This updates the config, closes #164 and makes #222 and #153 obsolete. The configuration has been tested on my instance.