### PR TITLE
prosody: fix ldap config template

### DIFF
--- a/prosody/rootfs/defaults/saslauthd.conf
+++ b/prosody/rootfs/defaults/saslauthd.conf
@@ -1,7 +1,7 @@
 {{ if eq (.Env.AUTH_TYPE | default "internal") "ldap" }}
 ldap_servers: {{ .Env.LDAP_URL }}
 ldap_search_base: {{ .Env.LDAP_BASE }}
-{{ if .Env.LDAP_BINDDN | default "" | toBool }}
+{{ if .Env.LDAP_BINDDN | default "" }}
 ldap_bind_dn: {{ .Env.LDAP_BINDDN }}
 ldap_bind_pw: {{ .Env.LDAP_BINDPW }}
 {{ end }}


### PR DESCRIPTION
https://github.com/jitsi/docker-jitsi-meet/pull/238 caused a regression in the prosody ldap template that resulted in breaking non-anonymous ldap login. `toBool` converts values that are not in `1, t, T, TRUE, true, True` to false. More details can be found here: https://github.com/jitsi/docker-jitsi-meet/pull/238.