### PR TITLE
Maximize S/N ratio of env.example

### DIFF
--- a/env.example
+++ b/env.example
@@ -2,23 +2,23 @@
 # Basic configuration options
 #
 
-# Directory where all configuration will be stored.
+# Directory where all configuration will be stored
 CONFIG=~/.jitsi-meet-cfg
 
-# Exposed HTTP port.
+# Exposed HTTP port
 HTTP_PORT=8000
 
-# Exposed HTTPS port.
+# Exposed HTTPS port
 HTTPS_PORT=8443
 
-# System time zone.
+# System time zone
 TZ=Europe/Amsterdam
 
-# Public URL for the web service.
+# Public URL for the web service
 #PUBLIC_URL=https://meet.example.com
 
 # IP address of the Docker host. 
-# See the "Running behind NAT or on a LAN environment" section in the README.
+# See the "Running behind NAT or on a LAN environment" section in the README
 #DOCKER_HOST_ADDRESS=192.168.1.1
 
 
@@ -26,13 +26,13 @@ TZ=Europe/Amsterdam
 # Let's Encrypt configuration
 #
 
-# Enable Let's Encrypt certificate generation.
+# Enable Let's Encrypt certificate generation
 #ENABLE_LETSENCRYPT=1
 
-# Domain for which to generate the certificate.
+# Domain for which to generate the certificate
 #LETSENCRYPT_DOMAIN=meet.example.com
 
-# E-Mail for receiving important account notifications (mandatory).
+# E-Mail for receiving important account notifications (mandatory)
 #LETSENCRYPT_EMAIL=alice@atlanta.net
 
 
@@ -40,7 +40,7 @@ TZ=Europe/Amsterdam
 # Etherpad integration (for document sharing)
 #
 
-# Set etherpad-lite URL (uncomment to enable).
+# Set etherpad-lite URL (uncomment to enable)
 #ETHERPAD_URL_BASE=http://etherpad.meet.jitsi:9001
 
 
@@ -48,13 +48,13 @@ TZ=Europe/Amsterdam
 # Basic Jigasi configuration options (needed for SIP gateway support)
 #
 
-# SIP URI for incoming / outgoing calls.
+# SIP URI for incoming / outgoing calls
 #JIGASI_SIP_URI=test@sip2sip.info
 
 # Password for the specified SIP account as a clear text
 #JIGASI_SIP_PASSWORD=passw0rd
 
-# SIP server (use the SIP account domain if in doubt).
+# SIP server (use the SIP account domain if in doubt)
 #JIGASI_SIP_SERVER=sip2sip.info
 
 # SIP server port
@@ -67,10 +67,10 @@ TZ=Europe/Amsterdam
 # Authentication configuration (see README for details)
 #
 
-# Enable authentication.
+# Enable authentication
 #ENABLE_AUTH=1
 
-# Enable guest access.
+# Enable guest access
 #ENABLE_GUESTS=1
 
 # Select authentication type: internal, jwt or ldap
@@ -79,38 +79,38 @@ TZ=Europe/Amsterdam
 # JWT authentication
 #
 
-# Application identifier.
+# Application identifier
 #JWT_APP_ID=my_jitsi_app_id
 
-# Application secret known only to your token.
+# Application secret known only to your token
 #JWT_APP_SECRET=my_jitsi_app_secret
 
-# (Optional) Set asap_accepted_issuers as a comma separated list.
+# (Optional) Set asap_accepted_issuers as a comma separated list
 #JWT_ACCEPTED_ISSUERS=my_web_client,my_app_client
 
-# (Optional) Set asap_accepted_audiences as a comma separated list.
+# (Optional) Set asap_accepted_audiences as a comma separated list
 #JWT_ACCEPTED_AUDIENCES=my_server1,my_server2
 
 
 # LDAP authentication (for more information see the Cyrus SASL saslauthd.conf man page)
 #
 
-# LDAP url for connection.
+# LDAP url for connection
 #LDAP_URL=ldaps://ldap.domain.com/
 
 # LDAP base DN. Can be empty
 #LDAP_BASE=DC=example,DC=domain,DC=com
 
-# LDAP user DN. Do not specify this parameter for the anonymous bind.
+# LDAP user DN. Do not specify this parameter for the anonymous bind
 #LDAP_BINDDN=CN=binduser,OU=users,DC=example,DC=domain,DC=com
 
-# LDAP user password. Do not specify this parameter for the anonymous bind.
+# LDAP user password. Do not specify this parameter for the anonymous bind
 #LDAP_BINDPW=LdapUserPassw0rd
 
 # LDAP filter. Tokens example:
-# %1-9 - if the input key is user@mail.domain.com, then %1 is com, %2 is domain and %3 is mail.
-# %s - %s is replaced by the complete service string.
-# %r - %r is replaced by the complete realm string.
+# %1-9 - if the input key is user@mail.domain.com, then %1 is com, %2 is domain and %3 is mail
+# %s - %s is replaced by the complete service string
+# %r - %r is replaced by the complete realm string
 #LDAP_FILTER=(sAMAccountName=%u)
 
 # LDAP authentication method
@@ -122,16 +122,16 @@ TZ=Europe/Amsterdam
 # LDAP TLS using
 #LDAP_USE_TLS=1
 
-# List of SSL/TLS ciphers to allow.
+# List of SSL/TLS ciphers to allow
 #LDAP_TLS_CIPHERS=SECURE256:SECURE128:!AES-128-CBC:!ARCFOUR-128:!CAMELLIA-128-CBC:!3DES-CBC:!CAMELLIA-128-CBC
 
 # Require and verify server certificate
 #LDAP_TLS_CHECK_PEER=1
 
-# Path to CA cert file. Used when server sertificate verify is enabled.
+# Path to CA cert file. Used when server sertificate verify is enabled
 #LDAP_TLS_CACERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
-# Path to CA certs directory. Used when server sertificate verify is enabled.
+# Path to CA certs directory. Used when server sertificate verify is enabled
 #LDAP_TLS_CACERT_DIR=/etc/ssl/certs
 
 # Wether to use starttls, implies LDAPv3 and requires ldap:// instead of ldaps://
@@ -142,7 +142,7 @@ TZ=Europe/Amsterdam
 # Advanced configuration options (you generally don't need to change these)
 #
 
-# Internal XMPP domain.
+# Internal XMPP domain
 XMPP_DOMAIN=meet.jitsi
 
 # Internal XMPP server
@@ -151,16 +151,16 @@ XMPP_SERVER=xmpp.meet.jitsi
 # Internal XMPP server URL
 XMPP_BOSH_URL_BASE=http://xmpp.meet.jitsi:5280
 
-# Internal XMPP domain for authenticated services.
+# Internal XMPP domain for authenticated services
 XMPP_AUTH_DOMAIN=auth.meet.jitsi
 
-# XMPP domain for the MUC.
+# XMPP domain for the MUC
 XMPP_MUC_DOMAIN=muc.meet.jitsi
 
-# XMPP domain for the internal MUC used for jibri, jigasi and jvb pools.
+# XMPP domain for the internal MUC used for jibri, jigasi and jvb pools
 XMPP_INTERNAL_MUC_DOMAIN=internal-muc.meet.jitsi
 
-# XMPP domain for unauthenticated users.
+# XMPP domain for unauthenticated users
 XMPP_GUEST_DOMAIN=guest.meet.jitsi
 
 # Custom Prosody modules for XMPP_DOMAIN (comma separated)
@@ -172,16 +172,16 @@ XMPP_MUC_MODULES=
 # Custom Prosody modules for internal MUC component (comma separated)
 XMPP_INTERNAL_MUC_MODULES=
 
-# MUC for the JVB pool.
+# MUC for the JVB pool
 JVB_BREWERY_MUC=jvbbrewery
 
-# XMPP user for JVB client connections.
+# XMPP user for JVB client connections
 JVB_AUTH_USER=jvb
 
-# XMPP password for JVB client connections.
+# XMPP password for JVB client connections
 JVB_AUTH_PASSWORD=passw0rd
 
-# STUN servers used to discover the server's public IP.
+# STUN servers used to discover the server's public IP
 JVB_STUN_SERVERS=meet-jit-si-turnrelay.jitsi.net:443
 
 # Media port for the Jitsi Videobridge
@@ -191,35 +191,35 @@ JVB_PORT=10000
 JVB_TCP_HARVESTER_DISABLED=true
 JVB_TCP_PORT=4443
 
-# A comma separated list of APIs to enable when the JVB is started. The default is none.
+# A comma separated list of APIs to enable when the JVB is started. The default is none
 # See https://github.com/jitsi/jitsi-videobridge/blob/master/doc/rest.md for more information
 #JVB_ENABLE_APIS=rest,colibri
 
-# XMPP component password for Jicofo.
+# XMPP component password for Jicofo
 JICOFO_COMPONENT_SECRET=s3cr37
 
-# XMPP user for Jicofo client connections. NOTE: this option doesn't currently work due to a bug.
+# XMPP user for Jicofo client connections. NOTE: this option doesn't currently work due to a bug
 JICOFO_AUTH_USER=focus
 
-# XMPP password for Jicofo client connections.
+# XMPP password for Jicofo client connections
 JICOFO_AUTH_PASSWORD=passw0rd
 
 # Base URL of Jicofo's reservation REST API
 #JICOFO_RESERVATION_REST_BASE_URL=http://reservation.example.com
 
-# XMPP user for Jigasi MUC client connections.
+# XMPP user for Jigasi MUC client connections
 JIGASI_XMPP_USER=jigasi
 
-# XMPP password for Jigasi MUC client connections.
+# XMPP password for Jigasi MUC client connections
 JIGASI_XMPP_PASSWORD=passw0rd
 
-# MUC name for the Jigasi pool.
+# MUC name for the Jigasi pool
 JIGASI_BREWERY_MUC=jigasibrewery
 
-# Minimum port for media used by Jigasi.
+# Minimum port for media used by Jigasi
 JIGASI_PORT_MIN=20000
 
-# Maximum port for media used by Jigasi.
+# Maximum port for media used by Jigasi
 JIGASI_PORT_MAX=20050
 
 # Enable SDES srtp
@@ -234,20 +234,20 @@ JIGASI_PORT_MAX=20050
 # Health-check interval
 #JIGASI_HEALTH_CHECK_INTERVAL=300000
 #
-# Enable Jigasi transcription.
+# Enable Jigasi transcription
 #ENABLE_TRANSCRIPTIONS=1
 
-# Jigasi will record audio when transcriber is on. Default false.
+# Jigasi will record audio when transcriber is on. Default false
 #JIGASI_TRANSCRIBER_RECORD_AUDIO=true
 
-# Jigasi will send transcribed text to the chat when transcriber is on. Default false.
+# Jigasi will send transcribed text to the chat when transcriber is on. Default false
 #JIGASI_TRANSCRIBER_SEND_TXT=true
 
-# Jigasi will post an url to the chat with transcription file. Default false.
+# Jigasi will post an url to the chat with transcription file. Default false
 #JIGASI_TRANSCRIBER_ADVERTISE_URL=true
 
 # Credentials for connect to Cloud Google API from Jigasi
-# Please read https://cloud.google.com/text-to-speech/docs/quickstart-protocol section "Before you begin" paragraph 1 to 5.
+# Please read https://cloud.google.com/text-to-speech/docs/quickstart-protocol section "Before you begin" paragraph 1 to 5
 # Copy the values from the json to the related env vars
 #GC_PROJECT_ID=
 #GC_PRIVATE_KEY_ID=
@@ -262,25 +262,25 @@ JIGASI_PORT_MAX=20050
 # XMPP domain for the jibri recorder
 XMPP_RECORDER_DOMAIN=recorder.meet.jitsi
 
-# XMPP recorder user for Jibri client connections.
+# XMPP recorder user for Jibri client connections
 JIBRI_RECORDER_USER=recorder
 
-# XMPP recorder password for Jibri client connections.
+# XMPP recorder password for Jibri client connections
 JIBRI_RECORDER_PASSWORD=passw0rd
 
-# Directory for recordings inside Jibri container.
+# Directory for recordings inside Jibri container
 JIBRI_RECORDING_DIR=/config/recordings
 
-# The finalizing script. Will run after recording is complete.
+# The finalizing script. Will run after recording is complete
 JIBRI_FINALIZE_RECORDING_SCRIPT_PATH=/config/finalize.sh
 
-# XMPP user for Jibri client connections.
+# XMPP user for Jibri client connections
 JIBRI_XMPP_USER=jibri
 
-# XMPP password for Jibri client connections.
+# XMPP password for Jibri client connections
 JIBRI_XMPP_PASSWORD=passw0rd
 
-# MUC name for the Jibri pool.
+# MUC name for the Jibri pool
 JIBRI_BREWERY_MUC=jibribrewery
 
 # MUC connection timeout
@@ -293,15 +293,15 @@ JIBRI_PENDING_TIMEOUT=90
 # So if there are any prefixes in the jid (like jitsi meet, which
 # has its participants join a muc at conference.xmpp_domain) then
 # list that prefix here so it can be stripped out to generate
-# the call url correctly.
+# the call url correctly
 JIBRI_STRIP_DOMAIN_JID=muc
 
-# Directory for logs inside Jibri container.
+# Directory for logs inside Jibri container
 JIBRI_LOGS_DIR=/config/logs
 
-# Disable HTTPS. Handle TLS connections outside of this setup.
+# Disable HTTPS. Handle TLS connections outside of this setup
 #DISABLE_HTTPS=1
 
-# Redirect HTTP traffic to HTTPS.
-# Necessary for Let's Encrypt. Relies on standard HTTPS port (443).
+# Redirect HTTP traffic to HTTPS
+# Necessary for Let's Encrypt. Relies on standard HTTPS port (443)
 #ENABLE_HTTP_REDIRECT=1

--- a/env.example
+++ b/env.example
@@ -17,7 +17,7 @@ TZ=Europe/Amsterdam
 # Public URL for the web service
 #PUBLIC_URL=https://meet.example.com
 
-# IP address of the Docker host. 
+# IP address of the Docker host 
 # See the "Running behind NAT or on a LAN environment" section in the README
 #DOCKER_HOST_ADDRESS=192.168.1.1
 
@@ -191,14 +191,15 @@ JVB_PORT=10000
 JVB_TCP_HARVESTER_DISABLED=true
 JVB_TCP_PORT=4443
 
-# A comma separated list of APIs to enable when the JVB is started. The default is none
+# A comma separated list of APIs to enable when the JVB is started [default: none]
 # See https://github.com/jitsi/jitsi-videobridge/blob/master/doc/rest.md for more information
 #JVB_ENABLE_APIS=rest,colibri
 
 # XMPP component password for Jicofo
 JICOFO_COMPONENT_SECRET=s3cr37
 
-# XMPP user for Jicofo client connections. NOTE: this option doesn't currently work due to a bug
+# XMPP user for Jicofo client connections.
+# NOTE: this option doesn't currently work due to a bug
 JICOFO_AUTH_USER=focus
 
 # XMPP password for Jicofo client connections
@@ -237,17 +238,18 @@ JIGASI_PORT_MAX=20050
 # Enable Jigasi transcription
 #ENABLE_TRANSCRIPTIONS=1
 
-# Jigasi will record audio when transcriber is on. Default false
+# Jigasi will record audio when transcriber is on [default: false]
 #JIGASI_TRANSCRIBER_RECORD_AUDIO=true
 
-# Jigasi will send transcribed text to the chat when transcriber is on. Default false
+# Jigasi will send transcribed text to the chat when transcriber is on [default: false]
 #JIGASI_TRANSCRIBER_SEND_TXT=true
 
-# Jigasi will post an url to the chat with transcription file. Default false
+# Jigasi will post an url to the chat with transcription file [default: false]
 #JIGASI_TRANSCRIBER_ADVERTISE_URL=true
 
 # Credentials for connect to Cloud Google API from Jigasi
-# Please read https://cloud.google.com/text-to-speech/docs/quickstart-protocol section "Before you begin" paragraph 1 to 5
+# Please read https://cloud.google.com/text-to-speech/docs/quickstart-protocol
+# section "Before you begin" paragraph 1 to 5
 # Copy the values from the json to the related env vars
 #GC_PROJECT_ID=
 #GC_PRIVATE_KEY_ID=
@@ -299,9 +301,9 @@ JIBRI_STRIP_DOMAIN_JID=muc
 # Directory for logs inside Jibri container
 JIBRI_LOGS_DIR=/config/logs
 
-# Disable HTTPS. Handle TLS connections outside of this setup
+# Disable HTTPS: handle TLS connections outside of this setup
 #DISABLE_HTTPS=1
 
 # Redirect HTTP traffic to HTTPS
-# Necessary for Let's Encrypt. Relies on standard HTTPS port (443)
+# Necessary for Let's Encrypt, relies on standard HTTPS port (443)
 #ENABLE_HTTP_REDIRECT=1


### PR DESCRIPTION
Here's a PR as being discussed. 

@saghul You might want to have a second look, please.

Advantages:
 * comments are consistent across the whole file now
 * easier to read/comprehend
 * spares 62 bytes :wink:

Disadvantages:
 * some churn for everybody (who diffs .env with this file, e.g. me)

I've documented the antidote for the latter issue in the commit message.
There's a chance, that people, who diff things, also read git logs. :smiley: 