### PR TITLE
Add support for sentry logging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -210,6 +210,9 @@ services:
             - JVB_BREWERY_MUC
             - MAX_BRIDGE_PARTICIPANTS
             - OCTO_BRIDGE_SELECTION_STRATEGY
+            - SENTRY_DSN="${JICOFO_SENTRY_DSN}"
+            - SENTRY_ENVIRONMENT
+            - SENTRY_RELEASE
             - TZ
             - XMPP_DOMAIN
             - XMPP_AUTH_DOMAIN
@@ -253,6 +256,9 @@ services:
             - JVB_OCTO_PUBLIC_ADDRESS
             - JVB_OCTO_BIND_PORT
             - JVB_OCTO_REGION
+            - SENTRY_DSN="${JVB_SENTRY_DSN}"
+            - SENTRY_ENVIRONMENT
+            - SENTRY_RELEASE
             - TZ
         depends_on:
             - prosody

--- a/env.example
+++ b/env.example
@@ -376,3 +376,15 @@ RESTART_POLICY=unless-stopped
 
 # Authenticate using external service or just focus external auth window if there is one already.
 # TOKEN_AUTH_URL=https://auth.meet.example.com/{room}
+
+# Sentry Error Tracking
+# Sentry Data Source Name (Endpoint for Sentry project)
+#JVB_SENTRY_DSN=https://public:private@host:port/1
+#JICOFO_SENTRY_DSN=https://public:private@host:port/1
+#JIGASI_SENTRY_DSN=https://public:private@host:port/1
+
+# Optional environment info to filter events
+#SENTRY_ENVIRONMENT=production
+
+# Optional release info to filter events
+#SENTRY_RELEASE=1.0.0

--- a/jicofo/rootfs/defaults/logging.properties
+++ b/jicofo/rootfs/defaults/logging.properties
@@ -1,4 +1,8 @@
+{{ if .Env.SENTRY_DSN }}
+handlers=java.util.logging.ConsoleHandler,io.sentry.jul.SentryHandler
+{{ else }}
 handlers= java.util.logging.ConsoleHandler
+{{ end }}
 
 java.util.logging.ConsoleHandler.level = ALL
 java.util.logging.ConsoleHandler.formatter = net.java.sip.communicator.util.ScLogFormatter
@@ -10,6 +14,7 @@ net.sf.level=SEVERE
 net.java.sip.communicator.plugin.reconnectplugin.level=FINE
 org.ice4j.level=SEVERE
 org.jitsi.impl.neomedia.level=SEVERE
+io.sentry.jul.SentryHandler.level=WARNING
 
 # Do not worry about missing strings
 net.java.sip.communicator.service.resources.AbstractResourcesService.level=SEVERE

--- a/jicofo/rootfs/etc/cont-init.d/10-config
+++ b/jicofo/rootfs/etc/cont-init.d/10-config
@@ -13,10 +13,7 @@ if [[ "$JICOFO_AUTH_PASSWORD" == "$OLD_JICOFO_AUTH_PASSWORD" ]]; then
     exit 1
 fi
 
+tpl /defaults/logging.properties > /config/logging.properties
 tpl /defaults/jicofo.conf > /config/jicofo.conf
-
-if [[ ! -f /config/logging.properties ]]; then
-    tpl /defaults/logging.properties > /config/logging.properties
-fi
 
 chown -R jicofo:jitsi /config

--- a/jicofo/rootfs/etc/cont-init.d/10-config
+++ b/jicofo/rootfs/etc/cont-init.d/10-config
@@ -1,5 +1,7 @@
 #!/usr/bin/with-contenv bash
 
+export SENTRY_RELEASE="${SENTRY_RELEASE:-$(apt-cache policy jicofo | sed -n '/Installed/p' | sed -e 's/[^:]*: //')}"
+
 if [[ -z $JICOFO_AUTH_PASSWORD ]]; then
     echo 'FATAL ERROR: Jicofo auth password must be set'
     exit 1
@@ -14,7 +16,7 @@ fi
 tpl /defaults/jicofo.conf > /config/jicofo.conf
 
 if [[ ! -f /config/logging.properties ]]; then
-    cp /defaults/logging.properties /config
+    tpl /defaults/logging.properties > /config/logging.properties
 fi
 
 chown -R jicofo:jitsi /config

--- a/jigasi.yml
+++ b/jigasi.yml
@@ -43,6 +43,9 @@ services:
             - GC_CLIENT_EMAIL
             - GC_CLIENT_ID
             - GC_CLIENT_CERT_URL
+            - SENTRY_DSN="${JIGASI_SENTRY_DSN}"
+            - SENTRY_ENVIRONMENT
+            - SENTRY_RELEASE
             - TZ
         depends_on:
             - prosody

--- a/jigasi/rootfs/defaults/logging.properties
+++ b/jigasi/rootfs/defaults/logging.properties
@@ -1,4 +1,8 @@
+{{ if .Env.SENTRY_DSN }}
+handlers=java.util.logging.ConsoleHandler,io.sentry.jul.SentryHandler
+{{ else }}
 handlers= java.util.logging.ConsoleHandler
+{{ end }}
 
 java.util.logging.ConsoleHandler.level = ALL
 java.util.logging.ConsoleHandler.formatter = net.java.sip.communicator.util.ScLogFormatter
@@ -10,6 +14,7 @@ net.sf.level=SEVERE
 net.java.sip.communicator.plugin.reconnectplugin.level=FINE
 org.ice4j.level=SEVERE
 org.jitsi.impl.neomedia.level=SEVERE
+io.sentry.jul.SentryHandler.level=WARNING
 
 # Do not worry about missing strings
 net.java.sip.communicator.service.resources.AbstractResourcesService.level=SEVERE

--- a/jigasi/rootfs/etc/cont-init.d/10-config
+++ b/jigasi/rootfs/etc/cont-init.d/10-config
@@ -13,13 +13,11 @@ if [[ "$JIGASI_XMPP_PASSWORD" == "$OLD_JIGASI_XMPP_PASSWORD" ]]; then
     exit 1
 fi
 
+tpl /defaults/logging.properties > /config/logging.properties
 tpl /defaults/sip-communicator.properties > /config/sip-communicator.properties
+
 if [[ -f /config/custom-sip-communicator.properties ]]; then
     cat /config/custom-sip-communicator.properties >> /config/sip-communicator.properties
-fi
-
-if [[ ! -f /config/logging.properties ]]; then
-    tpl /defaults/logging.properties > /config/logging.properties
 fi
 
 mkdir -pm777 /tmp/transcripts

--- a/jigasi/rootfs/etc/cont-init.d/10-config
+++ b/jigasi/rootfs/etc/cont-init.d/10-config
@@ -1,5 +1,7 @@
 #!/usr/bin/with-contenv bash
 
+export SENTRY_RELEASE="${SENTRY_RELEASE:-$(apt-cache policy jigasi | sed -n '/Installed/p' | sed -e 's/[^:]*: //')}"
+
 if [[ -z $JIGASI_XMPP_PASSWORD ]]; then
     echo 'FATAL ERROR: Jigasi auth password must be set'
     exit 1
@@ -17,7 +19,7 @@ if [[ -f /config/custom-sip-communicator.properties ]]; then
 fi
 
 if [[ ! -f /config/logging.properties ]]; then
-    cp /defaults/logging.properties /config
+    tpl /defaults/logging.properties > /config/logging.properties
 fi
 
 mkdir -pm777 /tmp/transcripts

--- a/jvb/rootfs/defaults/logging.properties
+++ b/jvb/rootfs/defaults/logging.properties
@@ -1,4 +1,8 @@
+{{ if .Env.SENTRY_DSN }}
+handlers=java.util.logging.ConsoleHandler,io.sentry.jul.SentryHandler
+{{ else }}
 handlers= java.util.logging.ConsoleHandler
+{{ end }}
 
 java.util.logging.ConsoleHandler.level = ALL
 java.util.logging.ConsoleHandler.formatter = net.java.sip.communicator.util.ScLogFormatter
@@ -6,9 +10,8 @@ java.util.logging.ConsoleHandler.formatter = net.java.sip.communicator.util.ScLo
 net.java.sip.communicator.util.ScLogFormatter.programname=JVB
 
 .level=INFO
-
 org.jitsi.videobridge.xmpp.ComponentImpl.level=FINE
+io.sentry.jul.SentryHandler.level=WARNING
 
 # All of the INFO level logs from MediaStreamImpl are unnecessary in the context of jitsi-videobridge.
 org.jitsi.impl.neomedia.MediaStreamImpl.level=WARNING
-

--- a/jvb/rootfs/etc/cont-init.d/10-config
+++ b/jvb/rootfs/etc/cont-init.d/10-config
@@ -1,6 +1,7 @@
 #!/usr/bin/with-contenv bash
 
 export LOCAL_ADDRESS=$(ip addr show dev "$(ip route|awk '/^default/ { print $5 }')" | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
+export SENTRY_RELEASE="${SENTRY_RELEASE:-$(apt-cache policy jitsi-videobridge2 | sed -n '/Installed/p' | sed -e 's/[^:]*: //')}"
 
 if [[ -z $JVB_AUTH_PASSWORD ]]; then
     echo 'FATAL ERROR: JVB auth password must be set'
@@ -21,7 +22,7 @@ fi
 tpl /defaults/jvb.conf > /config/jvb.conf
 
 if [[ ! -f /config/logging.properties ]]; then
-    cp /defaults/logging.properties /config
+    tpl /defaults/logging.properties > /config/logging.properties
 fi
 
 chown -R jvb:jitsi /config

--- a/jvb/rootfs/etc/cont-init.d/10-config
+++ b/jvb/rootfs/etc/cont-init.d/10-config
@@ -19,10 +19,7 @@ if [[ -f /config/custom-sip-communicator.properties ]]; then
     cat /config/custom-sip-communicator.properties >> /config/sip-communicator.properties
 fi
 
+tpl /defaults/logging.properties > /config/logging.properties
 tpl /defaults/jvb.conf > /config/jvb.conf
-
-if [[ ! -f /config/logging.properties ]]; then
-    tpl /defaults/logging.properties > /config/logging.properties
-fi
 
 chown -R jvb:jitsi /config


### PR DESCRIPTION
This is adding the possibility to track warnings and errors for jicofo, jigasi and jvb with [Sentry](https://sentry.io).

depends on:
* https://github.com/jitsi/jigasi/pull/247
* https://github.com/jitsi/jicofo/pull/449
* https://github.com/jitsi/jitsi-videobridge/pull/1152