### PR TITLE
jigasi: Allow to set default room for new connections

### DIFF
--- a/env.example
+++ b/env.example
@@ -48,6 +48,9 @@ TZ=Europe/Amsterdam
 # Basic Jigasi configuration options (needed for SIP gateway support)
 #
 
+# Default room name to connect incoming calls to if no room header specified
+#JIGASI_DEFAULT_ROOM_NAME=siptest
+
 # SIP URI for incoming / outgoing calls
 #JIGASI_SIP_URI=test@sip2sip.info
 

--- a/jigasi/rootfs/defaults/sip-communicator.properties
+++ b/jigasi/rootfs/defaults/sip-communicator.properties
@@ -107,6 +107,10 @@ org.jitsi.jigasi.HEALTH_CHECK_SIP_URI={{ .Env.JIGASI_HEALTH_CHECK_SIP_URI | defa
 org.jitsi.jigasi.HEALTH_CHECK_INTERVAL={{ .Env.JIGASI_HEALTH_CHECK_INTERVAL | default "300000" }}
 org.jitsi.jigasi.HEALTH_CHECK_TIMEOUT=600000
 
+# Default room and muc address
+org.jitsi.jigasi.MUC_SERVICE_ADDRESS={{ .Env.XMPP_MUC_DOMAIN }}
+org.jitsi.jigasi.DEFAULT_JVB_ROOM_NAME={{ .Env.JIGASI_DEFAULT_ROOM_NAME | default "siptest" }}
+
 org.jitsi.jigasi.xmpp.acc.IS_SERVER_OVERRIDDEN=true
 org.jitsi.jigasi.xmpp.acc.SERVER_ADDRESS={{ .Env.XMPP_SERVER }}
 org.jitsi.jigasi.xmpp.acc.VIDEO_CALLING_DISABLED=true


### PR DESCRIPTION
Set JIGASI_DEFAULT_ROOM_NAME in .env to override the default room for connections

Related to https://github.com/jitsi/docker-jitsi-meet/issues/339