### PR TITLE
Update Traefik v2 example with UDP

### DIFF
--- a/examples/traefik-v2/README.md
+++ b/examples/traefik-v2/README.md
@@ -1,6 +1,6 @@
 # Basic configuration to use with the traefik reverse proxy
 
-Note: Tested with traefik 2.1.3
+Note: Tested with traefik 2.2.0
 
 - When running behind traefik, it's a better practice to remove the port-binds for the web service.
 - The provided example uses an external network with the name "web". This is the network which moste likely was created while setting up traefik.

--- a/examples/traefik-v2/docker-compose.yml
+++ b/examples/traefik-v2/docker-compose.yml
@@ -165,6 +165,10 @@ services:
             - prosody
         networks:
             meet.jitsi:
+        labels:
+            traefik.udp.routers.jvb.entrypoints: video
+            traefik.udp.routers.jvb.service: jvb
+            traefik.udp.services.jvb.loadbalancer.server.port: 10000
 
 # Custom network so all services can communicate using a FQDN
 networks:


### PR DESCRIPTION
Traefik supports UDP as of v2.2

Docs: https://docs.traefik.io/routing/providers/docker/#udp