### PR TITLE
Add restart option in docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
             - JIBRI_RECORDER_USER
             - JIBRI_RECORDER_PASSWORD
             - ENABLE_RECORDING
-        restart: always
+        restart: unless-stopped
         networks:
             meet.jitsi:
                 aliases:
@@ -101,7 +101,7 @@ services:
             - JWT_TOKEN_AUTH_MODULE
             - LOG_LEVEL
             - TZ
-        restart: always
+        restart: unless-stopped
         networks:
             meet.jitsi:
                 aliases:
@@ -130,7 +130,7 @@ services:
             - TZ
         depends_on:
             - prosody
-        restart: always
+        restart: unless-stopped
         networks:
             meet.jitsi:
 
@@ -158,7 +158,7 @@ services:
             - TZ
         depends_on:
             - prosody
-        restart: always
+        restart: unless-stopped
         networks:
             meet.jitsi:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
             - JIBRI_RECORDER_USER
             - JIBRI_RECORDER_PASSWORD
             - ENABLE_RECORDING
+        restart: always
         networks:
             meet.jitsi:
                 aliases:
@@ -100,6 +101,7 @@ services:
             - JWT_TOKEN_AUTH_MODULE
             - LOG_LEVEL
             - TZ
+        restart: always
         networks:
             meet.jitsi:
                 aliases:
@@ -128,6 +130,7 @@ services:
             - TZ
         depends_on:
             - prosody
+        restart: always
         networks:
             meet.jitsi:
 
@@ -155,6 +158,7 @@ services:
             - TZ
         depends_on:
             - prosody
+        restart: always
         networks:
             meet.jitsi:
 


### PR DESCRIPTION
After a server reboot or in case of an error, the Docker containers of Jitsi are not automatically restarted.

This PR starts all Jitsi service containers automatically in all conditions, i. e. for instance after a server reboot or after error 1 due to some failure. 
Thus, this makes the setup a bit more robust.
 