### PR TITLE
Centralizing Etherpad Host Configuration

### DIFF
--- a/env.example
+++ b/env.example
@@ -69,7 +69,8 @@ TZ=Europe/Amsterdam
 #
 
 # Set etherpad-lite URL (uncomment to enable)
-#ETHERPAD_URL_BASE=http://etherpad.meet.jitsi:9001
+ETHERPAD_HOST=etherpad.meet.jitsi
+#ETHERPAD_URL_BASE=http://${ETHERPAD_HOST}:9001
 
 
 #

--- a/etherpad.yml
+++ b/etherpad.yml
@@ -7,4 +7,4 @@ services:
         networks:
             meet.jitsi:
                 aliases:
-                    - etherpad.meet.jitsi
+                    - ${ETHERPAD_HOST}


### PR DESCRIPTION
Fixing some issues due the hard coded name of the EtherPad host written on the YAML.