### PR TITLE
Clean up gen-passwords.sh shell code

### DIFF
--- a/gen-passwords.sh
+++ b/gen-passwords.sh
@@ -4,12 +4,12 @@ function generatePassword() {
     openssl rand -hex 16
 }
 
-JICOFO_COMPONENT_SECRET=`generatePassword`
-JICOFO_AUTH_PASSWORD=`generatePassword`
-JVB_AUTH_PASSWORD=`generatePassword`
-JIGASI_XMPP_PASSWORD=`generatePassword`
-JIBRI_RECORDER_PASSWORD=`generatePassword`
-JIBRI_XMPP_PASSWORD=`generatePassword`
+JICOFO_COMPONENT_SECRET=$(generatePassword)
+JICOFO_AUTH_PASSWORD=$(generatePassword)
+JVB_AUTH_PASSWORD=$(generatePassword)
+JIGASI_XMPP_PASSWORD=$(generatePassword)
+JIBRI_RECORDER_PASSWORD=$(generatePassword)
+JIBRI_XMPP_PASSWORD=$(generatePassword)
 
 sed -i.bak \
     -e "s#JICOFO_COMPONENT_SECRET=.*#JICOFO_COMPONENT_SECRET=${JICOFO_COMPONENT_SECRET}#g" \
@@ -18,4 +18,4 @@ sed -i.bak \
     -e "s#JIGASI_XMPP_PASSWORD=.*#JIGASI_XMPP_PASSWORD=${JIGASI_XMPP_PASSWORD}#g" \
     -e "s#JIBRI_RECORDER_PASSWORD=.*#JIBRI_RECORDER_PASSWORD=${JIBRI_RECORDER_PASSWORD}#g" \
     -e "s#JIBRI_XMPP_PASSWORD=.*#JIBRI_XMPP_PASSWORD=${JIBRI_XMPP_PASSWORD}#g" \
-    .env
+    "$(dirname "$0")/.env"


### PR DESCRIPTION
The shell script for generating the passwords uses old style backticks for executing the commands and expects the .env file to be placed in the current working directory.

Converting the backticks to $() style execution for better readability and also passing the script through dirname to enforce the placement of the .env to the CWD of the script.