### PR TITLE
Fix WASM MIME type

### DIFF
--- a/web/rootfs/defaults/nginx.conf
+++ b/web/rootfs/defaults/nginx.conf
@@ -26,7 +26,11 @@ http {
 
 	client_max_body_size 0;
 
-	include /etc/nginx/mime.types;
+ 	include /etc/nginx/mime.types;
+	types {
+		# add support for wasm MIME type, that is required by specification and it is not part of default mime.types file
+		application/wasm wasm;
+	}
 	default_type application/octet-stream;
 
 	##


### PR DESCRIPTION
MIME type application/wasm is required by WebAssembly specification, but this MIME type is not part of of nginx default mime.types file.

This change should remove warning from logs at least for Firefox:

```
wasm streaming compile failed: TypeError: Response has unsupported MIME type index.js:8:9333
falling back to ArrayBuffer instantiation index.js:8:9375
```

I didn't check other browsers.