### PR TITLE
Fix typo in env.example

### DIFF
--- a/env.example
+++ b/env.example
@@ -156,10 +156,10 @@ TZ=Europe/Amsterdam
 # Require and verify server certificate
 #LDAP_TLS_CHECK_PEER=1
 
-# Path to CA cert file. Used when server sertificate verify is enabled
+# Path to CA cert file. Used when server certificate verify is enabled
 #LDAP_TLS_CACERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
-# Path to CA certs directory. Used when server sertificate verify is enabled
+# Path to CA certs directory. Used when server certificate verify is enabled
 #LDAP_TLS_CACERT_DIR=/etc/ssl/certs
 
 # Wether to use starttls, implies LDAPv3 and requires ldap:// instead of ldaps://


### PR DESCRIPTION
Replace **s**ertificate with **c**ertificate