### PR TITLE
Add docker-compose.override.yml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 .env
 .env.bak
+docker-compose.override.yml


### PR DESCRIPTION
I'm using the `docker-compose.override.yml` file to make customization to my instance (bind statistic to localhost). It would make my live easier if the file would be ignored by git. https://docs.docker.com/compose/extends/