### PR TITLE
[web] Add IPv6 support

### DIFF
--- a/web/rootfs/defaults/default
+++ b/web/rootfs/defaults/default
@@ -1,5 +1,6 @@
 server {
 	listen 80 default_server;
+	listen [::]:80 default_server;
 
 	{{ if .Env.ENABLE_HTTP_REDIRECT | default "0" | toBool }}
 	return 301 https://$host$request_uri;
@@ -11,6 +12,7 @@ server {
 {{ if not (.Env.DISABLE_HTTPS | default "0" | toBool) }}
 server {
 	listen 443 ssl http2;
+	listen [::]:443 ssl http2;
 
 	include /config/nginx/ssl.conf;
 	include /config/nginx/meet.conf;


### PR DESCRIPTION
This pull requests aims to add IPv6 support to the `web` image by updating nginx default configuration.