### PR TITLE
jvb: Allow `TCP_HARVESTER_MAPPED_PORT` to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Variable | Description | Default value
 `JVB_PORT` | UDP port for media used by Jitsi Videobridge | 10000
 `JVB_TCP_HARVESTER_DISABLED` | Disable the additional harvester which allows video over TCP (rather than just UDP) | true
 `JVB_TCP_PORT` | TCP port for media used by Jitsi Videobridge when the TCP Harvester is enabled | 4443
+`JVB_TCP_MAPPED_PORT` | TCP port advertised by Jitsi Videobridge | 4443
 `JVB_BREWERY_MUC` | MUC name for the JVB pool | jvbbrewery
 `JVB_ENABLE_APIS` | Comma separated list of JVB APIs to enable | none
 `JIGASI_XMPP_USER` | XMPP user for Jigasi MUC client connections | jigasi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,7 +140,7 @@ services:
         restart: ${RESTART_POLICY}
         ports:
             - '${JVB_PORT}:${JVB_PORT}/udp'
-            - '${JVB_TCP_PORT}:${JVB_TCP_PORT}'
+            - '${JVB_TCP_MAPPED_PORT}:${JVB_TCP_PORT}'
         volumes:
             - ${CONFIG}/jvb:/config
         environment:

--- a/env.example
+++ b/env.example
@@ -215,6 +215,7 @@ JVB_PORT=10000
 # TCP Fallback for Jitsi Videobridge for when UDP isn't available
 JVB_TCP_HARVESTER_DISABLED=true
 JVB_TCP_PORT=4443
+# JVB_TCP_MAPPED_PORT=4443
 
 # A comma separated list of APIs to enable when the JVB is started [default: none]
 # See https://github.com/jitsi/jitsi-videobridge/blob/master/doc/rest.md for more information

--- a/examples/traefik-v2/docker-compose.yml
+++ b/examples/traefik-v2/docker-compose.yml
@@ -144,7 +144,7 @@ services:
         image: jitsi/jvb
         ports:
             - '${JVB_PORT}:${JVB_PORT}/udp'
-            - '${JVB_TCP_PORT}:${JVB_TCP_PORT}'
+            - '${JVB_TCP_MAPPED_PORT}:${JVB_TCP_PORT}'
         volumes:
             - ${CONFIG}/jvb:/config
         environment:

--- a/jvb/rootfs/defaults/sip-communicator.properties
+++ b/jvb/rootfs/defaults/sip-communicator.properties
@@ -4,6 +4,11 @@ org.jitsi.videobridge.TCP_HARVESTER_PORT={{ .Env.JVB_TCP_PORT }}
 {{ if .Env.JVB_STUN_SERVERS }}
 org.ice4j.ice.harvest.STUN_MAPPING_HARVESTER_ADDRESSES={{ .Env.JVB_STUN_SERVERS }}
 {{ end }}
+{{ $JVB_TCP_PORT := .Env.JVB_TCP_PORT | default "4443" }}
+{{ $JVB_TCP_MAPPED_PORT := .Env.JVB_TCP_MAPPED_PORT | default $JVB_TCP_PORT }}
+{{ if not (eq $JVB_TCP_PORT $JVB_TCP_MAPPED_PORT) }}
+org.jitsi.videobridge.TCP_HARVESTER_MAPPED_PORT={{ $JVB_TCP_MAPPED_PORT }}
+{{ end }}
 
 org.jitsi.videobridge.xmpp.user.shard.HOSTNAME={{ .Env.XMPP_SERVER }}
 org.jitsi.videobridge.xmpp.user.shard.DOMAIN={{ .Env.XMPP_AUTH_DOMAIN }}


### PR DESCRIPTION
In environment where only port TCP 80 and 443 are allowed, `jitsi/web` could expose port 443 (to allow  screen-sharing for example as `MediaDevices.getUserMedia()` api is only allowed on HTTPS), `jvb` container could then bind to port 80.

This requires `TCP_HARVESTER_MAPPED_PORT` to be configured as documented [here](https://github.com/jitsi/jitsi-videobridge/blob/master/doc/tcp.md#configuration).