### PR TITLE
docker: add image tag option to env-file (#461)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
     # Frontend
     web:
-        image: jitsi/web
+        image: jitsi/web:${IMAGE_TAG}
         restart: ${RESTART_POLICY}
         ports:
             - '${HTTP_PORT}:80'
@@ -45,7 +45,7 @@ services:
 
     # XMPP server
     prosody:
-        image: jitsi/prosody
+        image: jitsi/prosody:${IMAGE_TAG}
         restart: ${RESTART_POLICY}
         expose:
             - '5222'
@@ -109,7 +109,7 @@ services:
 
     # Focus component
     jicofo:
-        image: jitsi/jicofo
+        image: jitsi/jicofo:${IMAGE_TAG}
         restart: ${RESTART_POLICY}
         volumes:
             - ${CONFIG}/jicofo:/config
@@ -136,7 +136,7 @@ services:
 
     # Video bridge
     jvb:
-        image: jitsi/jvb
+        image: jitsi/jvb:${IMAGE_TAG}
         restart: ${RESTART_POLICY}
         ports:
             - '${JVB_PORT}:${JVB_PORT}/udp'

--- a/env.example
+++ b/env.example
@@ -25,6 +25,16 @@ JIBRI_RECORDER_PASSWORD=
 # XMPP password for Jibri client connections
 JIBRI_XMPP_PASSWORD=
 
+#
+# Docker Compose options
+#
+
+# Image tag to use
+IMAGE_TAG=latest
+
+# Container restart policy
+# Defaults to unless-stopped
+RESTART_POLICY=unless-stopped
 
 #
 # Basic configuration options
@@ -317,7 +327,3 @@ JIBRI_LOGS_DIR=/config/logs
 # Redirect HTTP traffic to HTTPS
 # Necessary for Let's Encrypt, relies on standard HTTPS port (443)
 #ENABLE_HTTP_REDIRECT=1
-
-# Container restart policy
-# Defaults to unless-stopped
-RESTART_POLICY=unless-stopped

--- a/jibri.yml
+++ b/jibri.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
     jibri:
-        image: jitsi/jibri
+        image: jitsi/jibri:${IMAGE_TAG}
         restart: ${RESTART_POLICY}
         volumes:
             - ${CONFIG}/jibri:/config

--- a/jigasi.yml
+++ b/jigasi.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
     # SIP gateway (audio)
     jigasi:
-        image: jitsi/jigasi
+        image: jitsi/jigasi:${IMAGE_TAG}
         restart: ${RESTART_POLICY}
         ports:
             - '${JIGASI_PORT_MIN}-${JIGASI_PORT_MAX}:${JIGASI_PORT_MIN}-${JIGASI_PORT_MAX}/udp'


### PR DESCRIPTION
This allows to set a fixed image tag instead of 'latest' so that git repository tags can pull the corresponding docker image tags. Change was requested in #461.

This PR adds a new variable to the env-file: IMAGE_TAG which allows to specify a docker image tag. The default var value is 'latest', so equals to the previous implicit tag.