### PR TITLE
Add XMPP WebSocket / Stream Management support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
         environment:
             - ENABLE_LETSENCRYPT
             - ENABLE_HTTP_REDIRECT
+            - ENABLE_XMPP_WEBSOCKET
             - DISABLE_HTTPS
             - LETSENCRYPT_DOMAIN
             - LETSENCRYPT_EMAIL
@@ -110,6 +111,7 @@ services:
             - ENABLE_AUTH
             - ENABLE_GUESTS
             - ENABLE_LOBBY
+            - ENABLE_XMPP_WEBSOCKET
             - GLOBAL_MODULES
             - GLOBAL_CONFIG
             - LDAP_URL
@@ -154,6 +156,7 @@ services:
             - JWT_AUTH_TYPE
             - JWT_TOKEN_AUTH_MODULE
             - LOG_LEVEL
+            - PUBLIC_URL
             - TZ
         networks:
             meet.jitsi:

--- a/env.example
+++ b/env.example
@@ -329,6 +329,9 @@ JIBRI_LOGS_DIR=/config/logs
 # Necessary for Let's Encrypt, relies on standard HTTPS port (443)
 #ENABLE_HTTP_REDIRECT=1
 
+# Enabled XMPP traffic over WebSocket (PUBLIC_URL must be defined!)
+#ENABLE_XMPP_WEBSOCKET=1
+
 # Container restart policy
 # Defaults to unless-stopped
 RESTART_POLICY=unless-stopped

--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -48,7 +48,6 @@ RUN \
     && rm -rf /tmp/pkg /var/cache/apt
 
 RUN patch -d /usr/lib/prosody/modules/muc -p0 < /prosody-plugins/muc_owner_allow_kick.patch
-RUN patch -d /usr/lib/prosody/modules/ -p0 < /prosody-plugins/mod_websocket_smacks.patch
 
 COPY rootfs/ /
 

--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -48,6 +48,7 @@ RUN \
     && rm -rf /tmp/pkg /var/cache/apt
 
 RUN patch -d /usr/lib/prosody/modules/muc -p0 < /prosody-plugins/muc_owner_allow_kick.patch
+RUN patch -d /usr/lib/prosody/modules/ -p0 < /prosody-plugins/mod_websocket_smacks.patch
 
 COPY rootfs/ /
 

--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -15,12 +15,22 @@ http_default_host = "{{ .Env.XMPP_DOMAIN }}"
 {{ $JWT_TOKEN_AUTH_MODULE := .Env.JWT_TOKEN_AUTH_MODULE | default "token_verification" }}
 {{ $ENABLE_LOBBY := .Env.ENABLE_LOBBY | default "0" | toBool }}
 
+{{ $ENABLE_XMPP_WEBSOCKET := .Env.ENABLE_XMPP_WEBSOCKET | default "0" | toBool }}
+{{ $PUBLIC_URL_DOMAIN := .Env.PUBLIC_URL | default "https://localhost:8443" -}}
+
 {{ if and $ENABLE_AUTH (eq $AUTH_TYPE "jwt") .Env.JWT_ACCEPTED_ISSUERS }}
 asap_accepted_issuers = { "{{ join "\",\"" (splitList "," .Env.JWT_ACCEPTED_ISSUERS) }}" }
 {{ end }}
 
 {{ if and $ENABLE_AUTH (eq $AUTH_TYPE "jwt") .Env.JWT_ACCEPTED_AUDIENCES }}
 asap_accepted_audiences = { "{{ join "\",\"" (splitList "," .Env.JWT_ACCEPTED_AUDIENCES) }}" }
+{{ end }}
+
+{{ if $ENABLE_XMPP_WEBSOCKET }}
+-- Deprecated in 0.12
+-- https://github.com/bjc/prosody/commit/26542811eafd9c708a130272d7b7de77b92712de
+cross_domain_websocket = { "{{ $PUBLIC_URL_DOMAIN }}" };
+consider_bosh_secure = true;
 {{ end }}
 
 VirtualHost "{{ .Env.XMPP_DOMAIN }}"
@@ -42,7 +52,15 @@ VirtualHost "{{ .Env.XMPP_DOMAIN }}"
     authentication = "internal_hashed"
   {{ end }}
 {{ else }}
+    -- https://github.com/jitsi/docker-jitsi-meet/pull/502#issuecomment-619146339
+    {{ if $ENABLE_XMPP_WEBSOCKET }}
+    authentication = "token"
+    {{ else }}
     authentication = "anonymous"
+    {{ end }}
+    app_id = ""
+    app_secret = ""
+    allow_empty_token = true
 {{ end }}
     ssl = {
         key = "/config/certs/{{ .Env.XMPP_DOMAIN }}.key";
@@ -50,6 +68,10 @@ VirtualHost "{{ .Env.XMPP_DOMAIN }}"
     }
     modules_enabled = {
         "bosh";
+        {{ if $ENABLE_XMPP_WEBSOCKET }}
+        "websocket";
+        "smacks"; -- XEP-0198: Stream Management
+        {{ end }}
         "pubsub";
         "ping";
         "speakerstats";
@@ -80,7 +102,16 @@ VirtualHost "{{ .Env.XMPP_DOMAIN }}"
 
 {{ if $ENABLE_GUEST_DOMAIN }}
 VirtualHost "{{ .Env.XMPP_GUEST_DOMAIN }}"
+    -- https://github.com/jitsi/docker-jitsi-meet/pull/502#issuecomment-619146339
+    {{ if $ENABLE_XMPP_WEBSOCKET }}
+    authentication = "token"
+    {{ else }}
     authentication = "anonymous"
+    {{ end }}
+    app_id = ""
+    app_secret = ""
+    allow_empty_token = true
+
     c2s_require_encryption = false
 
     {{ if $ENABLE_LOBBY }}

--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -16,7 +16,7 @@ http_default_host = "{{ .Env.XMPP_DOMAIN }}"
 {{ $ENABLE_LOBBY := .Env.ENABLE_LOBBY | default "0" | toBool }}
 
 {{ $ENABLE_XMPP_WEBSOCKET := .Env.ENABLE_XMPP_WEBSOCKET | default "0" | toBool }}
-{{ $PUBLIC_URL_DOMAIN := .Env.PUBLIC_URL | default "https://localhost:8443" -}}
+{{ $PUBLIC_URL := .Env.PUBLIC_URL | default "https://localhost:8443" -}}
 
 {{ if and $ENABLE_AUTH (eq $AUTH_TYPE "jwt") .Env.JWT_ACCEPTED_ISSUERS }}
 asap_accepted_issuers = { "{{ join "\",\"" (splitList "," .Env.JWT_ACCEPTED_ISSUERS) }}" }
@@ -29,7 +29,7 @@ asap_accepted_audiences = { "{{ join "\",\"" (splitList "," .Env.JWT_ACCEPTED_AU
 {{ if $ENABLE_XMPP_WEBSOCKET }}
 -- Deprecated in 0.12
 -- https://github.com/bjc/prosody/commit/26542811eafd9c708a130272d7b7de77b92712de
-cross_domain_websocket = { "{{ $PUBLIC_URL_DOMAIN }}" };
+cross_domain_websocket = { "{{ $PUBLIC_URL }}" };
 consider_bosh_secure = true;
 {{ end }}
 

--- a/prosody/rootfs/defaults/prosody.cfg.lua
+++ b/prosody/rootfs/defaults/prosody.cfg.lua
@@ -43,7 +43,7 @@ modules_enabled = {
 	-- Not essential, but recommended
 		"private"; -- Private XML storage (for room bookmarks, etc.)
 		"vcard"; -- Allow users to set vCards
-	
+
 	-- These are commented by default as they have a performance impact
 		--"privacy"; -- Support privacy lists
 		--"compression"; -- Stream compression (Debian: requires lua-zlib module to work)
@@ -59,7 +59,7 @@ modules_enabled = {
 	-- Admin interfaces
 		"admin_adhoc"; -- Allows administration via an XMPP client that supports ad-hoc commands
 		--"admin_telnet"; -- Opens telnet console interface on localhost port 5582
-	
+
 	-- HTTP modules
 		--"bosh"; -- Enable BOSH clients, aka "Jabber over HTTP"
 		--"http_files"; -- Serve static files from a directory over HTTP
@@ -165,5 +165,10 @@ network_settings = {
 component_interface = { "*" }
 
 data_path = "/config/data"
+
+smacks_max_unacked_stanzas = 5;
+smacks_hibernation_time = 60;
+smacks_max_hibernated_sessions = 1;
+smacks_max_old_sessions = 1;
 
 Include "conf.d/*.cfg.lua"

--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -63,7 +63,6 @@ location = /xmpp-websocket {
 
     proxy_set_header Host {{ .Env.XMPP_DOMAIN }};
     proxy_set_header X-Forwarded-For $remote_addr;
-    proxy_read_timeout 60s;
     tcp_nodelay on;
 }
 {{ end }}

--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -1,3 +1,5 @@
+{{ $ENABLE_XMPP_WEBSOCKET := .Env.ENABLE_XMPP_WEBSOCKET | default "0" | toBool }}
+
 server_name _;
 
 client_max_body_size 0;
@@ -49,6 +51,22 @@ location = /http-bind {
     proxy_set_header X-Forwarded-For $remote_addr;
     proxy_set_header Host {{ .Env.XMPP_DOMAIN }};
 }
+
+{{ if $ENABLE_XMPP_WEBSOCKET }}
+# xmpp websockets
+location = /xmpp-websocket {
+    proxy_pass {{ .Env.XMPP_BOSH_URL_BASE }}/xmpp-websocket;
+    proxy_http_version 1.1;
+
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Upgrade $http_upgrade;
+
+    proxy_set_header Host {{ .Env.XMPP_DOMAIN }};
+    proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_read_timeout 60s;
+    tcp_nodelay on;
+}
+{{ end }}
 
 location ~ ^/([^/?&:'"]+)$ {
     try_files $uri @root_path;


### PR DESCRIPTION
Alternative to: #181 

Works without manual adjustments for end users.

In config.js I have to set

```
websocket: document.location.protocol.replace('http', 'ws') + '//' + document.location.host + '/xmpp-websocket'
```

because unlike bosh, a relative path would not work because the protocol has to be define.

I also set `proxy_read_timeout` as documented: https://prosody.im/doc/websocket