### PR TITLE
prosody: Extend configuration via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,8 @@ Variable | Description | Default value
 `XMPP_INTERNAL_MUC_MODULES` | Custom Prosody modules for internal MUC component (comma separated) | info,alert
 `GLOBAL_MODULES` | Custom prosody modules to load in global configuration (comma separated) | statistics,alert
 `GLOBAL_CONFIG` | Custom configuration string with escaped newlines | foo = bar;\nkey = val;
+`PROSODY_VIRTUALHOST_CONFIG` | Custom configuration string with escaped newlines for jitsi VirtualHost | foo = bar;\nkey = val;
+`PROSODY_MUC_CONFIG` | Custom configuration string with escaped newlines for muc.meet.jitsi Component | foo = bar;\nkey = val;
 `RESTART_POLICY` | Container restart policy | defaults to `unless-stopped`
 `JICOFO_COMPONENT_SECRET` | XMPP component password for Jicofo | s3cr37
 `JICOFO_AUTH_USER` | XMPP user for Jicofo client connections | focus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,8 @@ services:
             - ENABLE_GUESTS
             - GLOBAL_MODULES
             - GLOBAL_CONFIG
+            - PROSODY_VIRTUALHOST_CONFIG
+            - PROSODY_MUC_CONFIG
             - LDAP_URL
             - LDAP_BASE
             - LDAP_BINDDN

--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -55,6 +55,9 @@ VirtualHost "{{ .Env.XMPP_DOMAIN }}"
     }
 
     c2s_require_encryption = false
+    {{ if .Env.PROSODY_VIRTUALHOST_CONFIG }}
+    {{ join "\n" (splitList "\\n" .Env.PROSODY_VIRTUALHOST_CONFIG) | indent 4 }}
+    {{ end }}
 
 {{ if and $ENABLE_AUTH (.Env.ENABLE_GUESTS | default "0" | toBool) }}
 VirtualHost "{{ .Env.XMPP_GUEST_DOMAIN }}"
@@ -99,6 +102,9 @@ Component "{{ .Env.XMPP_MUC_DOMAIN }}" "muc"
     }
     muc_room_locking = false
     muc_room_default_public_jids = true
+    {{ if .Env.PROSODY_MUC_CONFIG }}
+    {{ join "\n" (splitList "\\n" .Env.PROSODY_MUC_CONFIG) | indent 4 }}
+    {{ end }}
 
 Component "focus.{{ .Env.XMPP_DOMAIN }}"
     component_secret = "{{ .Env.JICOFO_COMPONENT_SECRET }}"


### PR DESCRIPTION
Hi,

if I want to enable/configuable some jitsi/prosody addons like 

* https://github.com/jitsi/jitsi-meet/blob/master/doc/speakerstats-prosody.md
* https://community.jitsi.org/t/enable-conference-duration-component-and-speakerstats/21573
* https://community.jitsi.org/t/persistent-passwords-on-self-hosted-rooms/20420/10

I have to extend the prosody configuration.

https://github.com/jitsi/docker-jitsi-meet/pull/491 already allows me to add custom modules. In a kubernetes environment I could do it via ConfigMaps.

With the existing environment variable `GLOBAL_CONFIG` I also could create new Components that are required by some addons.

Currently there is no way to extent the jitsi VirtualHost meet.jitsi and the Component muc.meet.jitsi.

This PR adds the functionally.

Example for speakerstats:

```properties
XMPP_MODULES=speakerstats
PROSODY_VIRTUALHOST_CONFIG="speakerstats_component = \"speakerstats.meet.jitsi\""
GLOBAL_CONFIG="Component \"speakerstats.meet.jitsi\" \"speakerstats_component\"\n    muc_component = \"conference.jitsi.example.com\"\n\nComponent \"conference.meet.jitsi\" \"muc\""
```

Abuse `GLOBAL_CONFIG` here is just for demo purpose. In a production environment I would put a new file under `conf.d/*.cfg.lua`.