### PR TITLE
Delete unnecessary dot

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ follow these steps:
   * Set strong passwords in the security section options: `./gen-passwords.sh`
 * Create required `CONFIG` directories
   * `mkdir -p ~/.jitsi-meet-cfg/{web/letsencrypt,transcripts,prosody,jicofo,jvb,jigasi,jibri}`
-* Run ``docker-compose up -d``.
+* Run ``docker-compose up -d``
 * Access the web UI at [``https://localhost:8443``](https://localhost:8443) (or a different port, in case you edited the compose file).
 
 Note that HTTP (not HTTPS) is also available (on port 8000, by default), but that's e.g. for a reverse proxy setup;


### PR DESCRIPTION
This dot can be misleading and the deleting is easier for "copy and paste"