### PR TITLE
Add jq dep for upload integrations in Jibri #535

### DIFF
--- a/jibri/Dockerfile
+++ b/jibri/Dockerfile
@@ -40,7 +40,7 @@ RUN \
 RUN \
         [ "$JITSI_RELEASE" = "unstable" ] \
         && apt-dpkg-wrap apt-get update \
-        && apt-dpkg-wrap apt-get install -y jitsi-upload-integrations \
+        && apt-dpkg-wrap apt-get install -y jitsi-upload-integrations jq \
         && apt-cleanup \
         || true
 


### PR DESCRIPTION
The [Jitsi Upload Integration](https://github.com/jitsi/jitsi-upload-integrations) scripts do not work since Jibri's container does not install the dependencies required for these scripts, specifically `jq`. When attempting to run dropbox_uploader.sh for example, `jq` will not be found. This fixes #535 