### PR TITLE
Add jq, curl deps for graceful_shutdown.sh in JVB #535

### DIFF
--- a/jvb/Dockerfile
+++ b/jvb/Dockerfile
@@ -3,7 +3,7 @@ FROM ${JITSI_REPO}/base-java
 
 RUN \
 	apt-dpkg-wrap apt-get update && \
-	apt-dpkg-wrap apt-get install -y jitsi-videobridge2 && \
+	apt-dpkg-wrap apt-get install -y jitsi-videobridge2 jq curl && \
 	apt-cleanup
 
 COPY rootfs/ /


### PR DESCRIPTION
When attempting to run the `graceful_shutdown.sh` script in `/usr/share/jitsi-videobridge` of the JVB container, `jq` and `curl` cannot be found. This fixes #535 in combination with the PR in https://github.com/jitsi/docker-jitsi-meet/pull/545