### PR TITLE
change CONFIG=

### DIFF
--- a/env.example
+++ b/env.example
@@ -31,7 +31,7 @@ JIBRI_XMPP_PASSWORD=
 #
 
 # Directory where all configuration will be stored
-CONFIG=~/.jitsi-meet-cfg
+CONFIG=./jitsi-meet-cfg
 
 # Exposed HTTP port
 HTTP_PORT=8000


### PR DESCRIPTION
better default directory for config, if upgrade installation (git clone, git pull) and leave old cfg dir, 
mistakes are made that difficult explained