### PR TITLE
Fixes #548

### DIFF
--- a/jibri/Dockerfile
+++ b/jibri/Dockerfile
@@ -38,11 +38,9 @@ RUN \
 	&& chromedriver --version
 
 RUN \
-        [ "$JITSI_RELEASE" = "unstable" ] \
-        && apt-dpkg-wrap apt-get update \
+        apt-dpkg-wrap apt-get update \
         && apt-dpkg-wrap apt-get install -y jitsi-upload-integrations jq \
-        && apt-cleanup \
-        || true
+        && apt-cleanup
 
 COPY rootfs/ /
 


### PR DESCRIPTION
Forces installation of jitsi-upload-integrations for all releases. Fixes #548