### PR TITLE
Added environment var JICOFO_ENABLE_HEALTH_CHECKS

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ Variable | Description | Default value
 `JICOFO_COMPONENT_SECRET` | XMPP component password for Jicofo | s3cr37
 `JICOFO_AUTH_USER` | XMPP user for Jicofo client connections | focus
 `JICOFO_AUTH_PASSWORD` | XMPP password for Jicofo client connections | passw0rd
+`JICOFO_ENABLE_HEALTH_CHECKS` | Enable health checks inside Jicofo, allowing the use of the REST api to check Jicofo's status | false
 `JVB_AUTH_USER` | XMPP user for JVB MUC client connections | jvb
 `JVB_AUTH_PASSWORD` | XMPP password for JVB MUC client connections | passw0rd
 `JVB_STUN_SERVERS` | STUN servers used to discover the server's public IP | stun.l.google.com:19302, stun1.l.google.com:19302, stun2.l.google.com:19302

--- a/env.example
+++ b/env.example
@@ -228,6 +228,9 @@ JICOFO_AUTH_USER=focus
 # Base URL of Jicofo's reservation REST API
 #JICOFO_RESERVATION_REST_BASE_URL=http://reservation.example.com
 
+# Enable Jicofo's health check REST API (http://<jicofo_base_url>:8888/about/health)
+#JICOFO_ENABLE_HEALTH_CHECKS=true
+
 # XMPP user for Jigasi MUC client connections
 JIGASI_XMPP_USER=jigasi
 

--- a/jicofo/rootfs/defaults/sip-communicator.properties
+++ b/jicofo/rootfs/defaults/sip-communicator.properties
@@ -17,3 +17,7 @@ org.jitsi.jicofo.auth.URL=XMPP:{{ .Env.XMPP_DOMAIN }}
 {{ if .Env.JICOFO_RESERVATION_REST_BASE_URL }}
 org.jitsi.impl.reservation.rest.BASE_URL={{ .Env.JICOFO_RESERVATION_REST_BASE_URL }}
 {{ end }}
+
+{{ if .Env.JICOFO_ENABLE_HEALTH_CHECKS | default "0" | toBool }}
+org.jitsi.jicofo.health.ENABLE_HEALTH_CHECKS=true
+{{ end }}


### PR DESCRIPTION
Since release 4548, health checks are disabled in Jicofo. These can be enabled with configuration key org.jitsi.jicofo.health.ENABLE_HEALTH_CHECKS. Since health checks can be very handy when running Jitsi in a container (i.e. when using the Kubernetes liveness probes) we need an environment variable in the container to switch it on.

This PR introduces environment variable JICOFO_ENABLE_HEALTH_CHECKS with default value false, matching the Jicofo defaults, but an option to set to true to re-enable the REST API health checks, which can then be used in the Kubernetes liveness probe.