### PR TITLE
Renew LetsEncrypt with webroot config

### DIFF
--- a/web/rootfs/defaults/default
+++ b/web/rootfs/defaults/default
@@ -1,6 +1,16 @@
 server {
 	listen 80 default_server;
 
+	{{ if .Env.ENABLE_LETSENCRYPT | default "0" | toBool }}
+	location ^~ /.well-known/acme-challenge/ {
+		default_type "text/plain";
+		root /var/www/letsencrypt;
+	}
+	location = /.well-known/acme-challenge/ {
+		return 404;
+	}
+	{{ end }}
+
 	{{ if .Env.ENABLE_HTTP_REDIRECT | default "0" | toBool }}
 	return 301 https://$host$request_uri;
 	{{ else }}

--- a/web/rootfs/defaults/default
+++ b/web/rootfs/defaults/default
@@ -12,7 +12,9 @@ server {
 	{{ end }}
 
 	{{ if .Env.ENABLE_HTTP_REDIRECT | default "0" | toBool }}
-	return 301 https://$host$request_uri;
+	location / {
+		return 301 https://$host$request_uri;
+	}
 	{{ else }}
 	include /config/nginx/meet.conf;
 	{{ end }}

--- a/web/rootfs/defaults/letsencrypt-renew
+++ b/web/rootfs/defaults/letsencrypt-renew
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-# stop nginx
-s6-svc -d /var/run/s6/services/nginx
-
 # renew cert
-certbot-auto --no-self-upgrade -n renew >> /config/le-renew.log
+certbot-auto renew \
+  --no-self-upgrade \
+  -n \
+  --webroot \
+  --webroot-path /var/www/letsencrypt \
+  >> /config/le-renew.log
 
 # start nginx
-s6-svc -u /var/run/s6/services/nginx
+s6-svc -h /var/run/s6/services/nginx

--- a/web/rootfs/defaults/letsencrypt-renew
+++ b/web/rootfs/defaults/letsencrypt-renew
@@ -8,5 +8,5 @@ certbot-auto renew \
   --webroot-path /var/www/letsencrypt \
   >> /config/le-renew.log
 
-# start nginx
+# reload nginx
 s6-svc -h /var/run/s6/services/nginx

--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -5,7 +5,8 @@ mkdir -p \
     /config/{nginx/site-confs,keys} \
     /run \
     /var/lib/nginx/tmp/client_body \
-    /var/tmp/nginx
+    /var/tmp/nginx \
+    /var/www/letsencrypt
 
 # generate keys (maybe)
 if [[ $DISABLE_HTTPS -ne 1 ]]; then


### PR DESCRIPTION
To avoid having to stop the nginx server every renewal attempt, the certificate could be renewed using webroot configured with the nginx server.