### PR TITLE
Fix: Dockerfile cleanup

### DIFF
--- a/base-java/Dockerfile
+++ b/base-java/Dockerfile
@@ -1,9 +1,7 @@
 ARG JITSI_REPO=jitsi
 FROM ${JITSI_REPO}/base
 
-RUN	\
-	mkdir -p /usr/share/man/man1 && \
-	apt-dpkg-wrap apt-get update && \
-	apt-dpkg-wrap apt-get install -y openjdk-8-jre-headless && \
-	apt-cleanup
-
+RUN mkdir -p /usr/share/man/man1 && \
+    apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y openjdk-8-jre-headless && \
+    apt-cleanup

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -10,25 +10,20 @@ ADD https://github.com/subchen/frep/releases/download/v1.3.5/frep-1.3.5-linux-am
 
 COPY rootfs /
 
-RUN \
-	tar xfz /tmp/s6-overlay.tar.gz -C / && \
-	rm -f /tmp/*.tar.gz && \
-	apt-dpkg-wrap apt-get update && \
-	apt-dpkg-wrap apt-get install -y apt-transport-https apt-utils ca-certificates gnupg && \
-	apt-key add /tmp/jitsi.key && \
-	rm -f /tmp/jitsi.key && \
-	echo "deb https://download.jitsi.org $JITSI_RELEASE/" > /etc/apt/sources.list.d/jitsi.list && \
-	echo "deb http://ftp.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list && \
-	apt-dpkg-wrap apt-get update && \
-	apt-dpkg-wrap apt-get dist-upgrade -y && \
-	apt-cleanup && \
-	chmod +x /usr/bin/frep
-
-RUN \
-	[ "$JITSI_RELEASE" = "unstable" ] && \
-	apt-dpkg-wrap apt-get update && \
-	apt-dpkg-wrap apt-get install -y jq procps curl vim iputils-ping net-tools && \
-	apt-cleanup || \
-	true
+RUN tar xfz /tmp/s6-overlay.tar.gz -C / && \
+    rm -f /tmp/*.tar.gz && \
+    apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y apt-transport-https apt-utils ca-certificates gnupg && \
+    apt-key add /tmp/jitsi.key && \
+    rm -f /tmp/jitsi.key && \
+    echo "deb https://download.jitsi.org $JITSI_RELEASE/" > /etc/apt/sources.list.d/jitsi.list && \
+    echo "deb http://ftp.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list && \
+    apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get dist-upgrade -y && \
+    chmod +x /usr/bin/frep && \
+    [ "$JITSI_RELEASE" = "unstable" ] && \
+    apt-dpkg-wrap apt-get install -y jq procps curl vim iputils-ping net-tools && \
+    apt-cleanup || \
+    true
 
 ENTRYPOINT [ "/init" ]

--- a/base/rootfs/usr/bin/apt-cleanup
+++ b/base/rootfs/usr/bin/apt-cleanup
@@ -1,3 +1,4 @@
 #!/bin/sh
 
 rm -rf /var/lib/apt/lists/
+rm -rf /var/cache/apt/archives/

--- a/jibri/Dockerfile
+++ b/jibri/Dockerfile
@@ -7,40 +7,29 @@ ARG CHROME_RELEASE=78.0.3904.97
 ARG CHROMEDRIVER_MAJOR_RELEASE=78
 
 RUN \
-	apt-dpkg-wrap apt-get update \
-	&& apt-dpkg-wrap apt-get install -y jibri libgl1-mesa-dri \
-	&& apt-cleanup
-
-RUN \
-	[ "${CHROME_RELEASE}" = "latest" ] \
-	&& curl -4s https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-	&& echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
-	&& apt-dpkg-wrap apt-get update \
-	&& apt-dpkg-wrap apt-get install -y google-chrome-stable \
-	&& apt-cleanup \
-	|| true
-
-RUN \
-        [ "${CHROME_RELEASE}" != "latest" ] \
-        && curl -4so /tmp/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb \
-	&& apt-dpkg-wrap apt-get update \
-        && apt-dpkg-wrap apt-get install -y /tmp/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb \
-	&& apt-cleanup \
-	|| true
-
-RUN \
-	[ "${CHROMEDRIVER_MAJOR_RELEASE}" = "latest" ] \
-	&& CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE)" \
-	|| CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROMEDRIVER_MAJOR_RELEASE})" \
-	&& curl -4Ls https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_RELEASE}/chromedriver_linux64.zip \
-	| zcat >> /usr/bin/chromedriver \
-	&& chmod +x /usr/bin/chromedriver \
-	&& chromedriver --version
-
-RUN \
-        apt-dpkg-wrap apt-get update \
-        && apt-dpkg-wrap apt-get install -y jitsi-upload-integrations jq \
-        && apt-cleanup
+    apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y jibri libgl1-mesa-dri && \
+    apt-cleanup && \
+    [ "${CHROME_RELEASE}" = "latest" ] && \
+    curl -4s https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list && \
+    apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y google-chrome-stable || \
+    [ "${CHROME_RELEASE}" != "latest" ] && \
+    curl -4so /tmp/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb && \
+    apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y /tmp/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb && \
+    apt-cleanup || \
+    [ "${CHROMEDRIVER_MAJOR_RELEASE}" = "latest" ] && \
+    CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE)" || \
+    CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROMEDRIVER_MAJOR_RELEASE})" && \
+    curl -4Ls https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_RELEASE}/chromedriver_linux64.zip \
+    | zcat >> /usr/bin/chromedriver && \
+    chmod +x /usr/bin/chromedriver && \
+    chromedriver --version && \
+    apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y jitsi-upload-integrations jq && \
+    apt-cleanup
 
 COPY rootfs/ /
 

--- a/jicofo/Dockerfile
+++ b/jicofo/Dockerfile
@@ -1,10 +1,9 @@
 ARG JITSI_REPO=jitsi
 FROM ${JITSI_REPO}/base-java
 
-RUN \
-	apt-dpkg-wrap apt-get update && \
-	apt-dpkg-wrap apt-get install -y jicofo && \
-	apt-cleanup
+RUN apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y jicofo && \
+    apt-cleanup
 
 COPY rootfs/ /
 

--- a/jigasi/Dockerfile
+++ b/jigasi/Dockerfile
@@ -3,10 +3,9 @@ FROM ${JITSI_REPO}/base-java
 
 ENV GOOGLE_APPLICATION_CREDENTIALS /config/key.json
 
-RUN \
-	apt-dpkg-wrap apt-get update && \
-	apt-dpkg-wrap apt-get install -y jigasi jq && \
-	apt-cleanup
+RUN apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y jigasi jq && \
+    apt-cleanup
 
 COPY rootfs/ /
 

--- a/jvb/Dockerfile
+++ b/jvb/Dockerfile
@@ -1,10 +1,9 @@
 ARG JITSI_REPO=jitsi
 FROM ${JITSI_REPO}/base-java
 
-RUN \
-	apt-dpkg-wrap apt-get update && \
-	apt-dpkg-wrap apt-get install -y jitsi-videobridge2 jq curl && \
-	apt-cleanup
+RUN apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y jitsi-videobridge2 jq curl && \
+    apt-cleanup
 
 COPY rootfs/ /
 

--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -3,13 +3,12 @@ FROM ${JITSI_REPO}/base
 
 ADD https://prosody.im/files/prosody-debian-packages.key /tmp/prosody.key
 
-RUN \
-    apt-key add /tmp/prosody.key \
-    && rm -f /tmp/prosody.key \
-    && echo "deb http://packages.prosody.im/debian stretch main" > /etc/apt/sources.list.d/prosody.list \
-    && apt-dpkg-wrap apt-get update \
-    && apt-dpkg-wrap apt-get install -y prosody \
-    && apt-dpkg-wrap apt-get install -t stretch-backports -y \
+RUN apt-key add /tmp/prosody.key && \
+    rm -f /tmp/prosody.key && \
+    echo "deb http://packages.prosody.im/debian stretch main" > /etc/apt/sources.list.d/prosody.list && \
+    apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y prosody && \
+    apt-dpkg-wrap apt-get install -t stretch-backports -y \
       liblua5.2-dev \
       sasl2-bin \
       libsasl2-modules-ldap \
@@ -21,30 +20,24 @@ RUN \
       luarocks \
       git \
       gcc \
-      patch \
-    && luarocks install cyrussasl 1.1.0-1 \
-    && luarocks install lua-cjson 2.1.0-1 \
-    && luarocks install luajwtjitsi 1.3-7 \
-    && luarocks install net-url 0.9-1 \
-    && apt-dpkg-wrap apt-get remove -t stretch-backports -y \
+      patch && \
+    luarocks install cyrussasl 1.1.0-1 && \
+    luarocks install lua-cjson 2.1.0-1 && \
+    luarocks install luajwtjitsi 1.3-7 && \
+    luarocks install net-url 0.9-1 && \
+    apt-dpkg-wrap apt-get remove -t stretch-backports -y \
       git \
       gcc \
       luarocks \
       libsasl2-dev \
       libssl1.0-dev \
-      liblua5.2-dev \
-    && apt-cleanup \
-    && rm -rf /etc/prosody /var/cache/apt
-
-RUN \
-    apt-dpkg-wrap apt-get update \
-    && apt-dpkg-wrap apt-get -d install -y jitsi-meet-prosody \
-    && dpkg -x /var/cache/apt/archives/jitsi-meet-prosody*.deb /tmp/pkg \
-    && mv /tmp/pkg/usr/share/jitsi-meet/prosody-plugins /prosody-plugins \
-    && apt-cleanup \
-    && rm -rf /tmp/pkg /var/cache/apt
-
-RUN patch -d /usr/lib/prosody/modules/muc -p0 < /prosody-plugins/muc_owner_allow_kick.patch
+      liblua5.2-dev && \
+    apt-dpkg-wrap apt-get -d install -y jitsi-meet-prosody && \
+    dpkg -x /var/cache/apt/archives/jitsi-meet-prosody*.deb /tmp/pkg && \
+    mv /tmp/pkg/usr/share/jitsi-meet/prosody-plugins /prosody-plugins && \
+    apt-cleanup && \
+    rm -rf /tmp/pkg && \
+    patch -d /usr/lib/prosody/modules/muc -p0 < /prosody-plugins/muc_owner_allow_kick.patch
 
 COPY rootfs/ /
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -5,20 +5,17 @@ ADD https://dl.eff.org/certbot-auto /usr/local/bin/
 
 COPY rootfs/ /
 
-RUN \
-	apt-dpkg-wrap apt-get update && \
-	apt-dpkg-wrap apt-get install -y cron nginx-extras jitsi-meet-web && \
-	apt-dpkg-wrap apt-get -d install -y jitsi-meet-web-config && \
+RUN apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y cron nginx-extras jitsi-meet-web && \
+    apt-dpkg-wrap apt-get -d install -y jitsi-meet-web-config && \
     dpkg -x /var/cache/apt/archives/jitsi-meet-web-config*.deb /tmp/pkg && \
     mv /tmp/pkg/usr/share/jitsi-meet-web-config/config.js /defaults && \
-	mv /usr/share/jitsi-meet/interface_config.js /defaults && \
-	apt-cleanup && \
-	rm -f /etc/nginx/conf.d/default.conf && \
-	rm -rf /tmp/pkg /var/cache/apt
-
-RUN \
-	chmod a+x /usr/local/bin/certbot-auto && \
-	certbot-auto --noninteractive --install-only
+    mv /usr/share/jitsi-meet/interface_config.js /defaults && \
+    apt-cleanup && \
+    rm -f /etc/nginx/conf.d/default.conf && \
+    rm -rf /tmp/pkg && \
+    chmod a+x /usr/local/bin/certbot-auto && \
+    certbot-auto --noninteractive --install-only
 
 EXPOSE 80 443
 


### PR DESCRIPTION
- Minimise the number of `RUN` stages will help reducing the number of Docker layers, make the overall image history leanier, hence more readable/accountable
- Avoid unneeded APT update & clean
- Homogeneise spacing, previously mixing space & tabs indent
- Homogeneise directives linking using a suffix notation: helps readability