### PR TITLE
Doc: Add missing config directories to QuickStart

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ follow these steps:
   * `cp env.example .env`
   * Set strong passwords in the security section options: `./gen-passwords.sh`
 * Create required `CONFIG` directories
-  * `mkdir -p ~/.jitsi-meet-cfg/{web/letsencrypt,transcripts,prosody,jicofo,jvb,jigasi,jibri}`
+  * `mkdir -p ~/.jitsi-meet-cfg/{web/letsencrypt,transcripts,prosody/config,prosody/prosody-plugins-custom,jicofo,jvb,jigasi,jibri}`
 * Run ``docker-compose up -d``
 * Access the web UI at [``https://localhost:8443``](https://localhost:8443) (or a different port, in case you edited the compose file).
 


### PR DESCRIPTION
This adds the two config directories introduced via f7796a160e8d621f307bdd36a60d3d1d96afe902 to the quick start section in the readme.md as the containers would not start without them.