### PR TITLE
AIGLX error: dlopen of /usr/lib/x86_64-linux-gnu/dri/swrast_dri.so failed

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:stretch-slim
 
 ARG JITSI_RELEASE=stable
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 ARG JITSI_RELEASE=stable
 

--- a/jibri/Dockerfile
+++ b/jibri/Dockerfile
@@ -8,7 +8,7 @@ ARG CHROMEDRIVER_MAJOR_RELEASE=78
 
 RUN \
 	apt-dpkg-wrap apt-get update \
-	&& apt-dpkg-wrap apt-get install -y jibri \
+	&& apt-dpkg-wrap apt-get install -y jibri libgl1-mesa-dri \
 	&& apt-cleanup
 
 RUN \


### PR DESCRIPTION


jibri /tmp/xorg.log error fix
```
AIGLX error: dlopen of /usr/lib/x86_64-linux-gnu/dri/swrast_dri.so failed (/usr/lib/x86_64-linux-gnu/dri/swrast_dri.so: cannot open shared object file: No such file or directory
```

#240 