### PR TITLE
change meet.conf to work properly for etherpad

### DIFF
--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -47,16 +47,37 @@ location @root_path {
 
 {{ if .Env.ETHERPAD_URL_BASE }}
 # Etherpad-lite
-location /etherpad/ {
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection 'upgrade';
-    proxy_set_header Host $host;
-    proxy_cache_bypass $http_upgrade;
+location ^~ /etherpad {
+        rewrite                /etherpad/(.*) /$1 break;
+        rewrite                ^/etherpad$ /etherpad/ permanent;
+        proxy_pass             {{ .Env.ETHERPAD_URL_BASE }}/;
+        proxy_pass_header Server;
+        proxy_redirect         / /etherpad/;
+        proxy_set_header       Host {{ .Env.XMPP_DOMAIN }};
+        proxy_buffering off;
+    }
 
-    proxy_pass {{ .Env.ETHERPAD_URL_BASE }}/;
-    proxy_set_header X-Forwarded-For $remote_addr;
-    proxy_buffering off;
-    proxy_set_header Host {{ .Env.XMPP_DOMAIN }};
-}
+location ^~ /etherpad/socket.io {
+        rewrite /etherpad/socket.io/(.*) /socket.io/$1 break;
+        proxy_pass {{ .Env.ETHERPAD_URL_BASE }}/;
+        proxy_redirect         / /etherpad/;
+        proxy_set_header Host {{ .Env.XMPP_DOMAIN }};
+        proxy_buffering off;
+        proxy_set_header X-Real-IP $remote_addr;  # http://wiki.nginx.org/HttpProxyModule
+        proxy_set_header X-Forwarded-For $remote_addr; # EP logs to show the actual remote IP
+        proxy_set_header X-Forwarded-Proto $scheme; # for EP to set secure cookie flag when https is used
+        proxy_set_header Host {{ .Env.XMPP_DOMAIN }};  # pass the host header
+        proxy_http_version 1.1;  # recommended with keepalive connections
+        # WebSocket proxying - from http://nginx.org/en/docs/http/websocket.html
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+    }
+
+location ^~ /static {
+        rewrite /static/(.*) /static/$1 break;
+        proxy_pass {{ .Env.ETHERPAD_URL_BASE }}/;
+        proxy_set_header Host {{ .Env.XMPP_DOMAIN }};
+        proxy_buffering off;
+    }
+
 {{ end }}


### PR DESCRIPTION
change meet.conf to work properly for etherpad as well as if jitsi/web is behind another revproxy.

can someone else test this config?
Previous my changes you weren't able to edit collaboratively as well the editor looked ugly as the static (font-) files could not be loaded.