### PR TITLE
Provide a more consistent behavior on multi-homed docker hosts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
         image: jitsi/web:latest
         restart: ${RESTART_POLICY}
         ports:
-            - '${HTTP_PORT}:80'
-            - '${HTTPS_PORT}:443'
+            - '${DOCKER_HOST_ADDRESS}:${HTTP_PORT}:80'
+            - '${DOCKER_HOST_ADDRESS}:${HTTPS_PORT}:443'
         volumes:
             - ${CONFIG}/web:/config:Z
             - ${CONFIG}/web/letsencrypt:/etc/letsencrypt:Z

--- a/env.example
+++ b/env.example
@@ -47,7 +47,7 @@ TZ=UTC
 
 # IP address of the Docker host
 # See the "Running behind NAT or on a LAN environment" section in the README
-#DOCKER_HOST_ADDRESS=192.168.1.1
+DOCKER_HOST_ADDRESS=0.0.0.0
 
 
 #


### PR DESCRIPTION
A simple change, adding DOCKER_HOST_ADDRESS to the ports declarations in docker-compose.yaml such that the host address selection as set in the .env file will be honored. Also uncommented DOCKER_HOST_ADDRESS in env.eample, with a sane default for single-homed docker hosts. Not sure whether this minor adjustment necessitates update of related documentation referenced in the comment above DOCKER_HOST_ADDRESS in env.example...