### PR TITLE
update to newer etherpad version 1.8.4 for fixes to reverse proxy etherpad

### DIFF
--- a/etherpad/Dockerfile
+++ b/etherpad/Dockerfile
@@ -1,4 +1,4 @@
-FROM etherpad/etherpad:1.8.3
+FROM etherpad/etherpad:1.8.4
 
 ADD ./rootfs/defaults/settings.json /opt/etherpad-lite/settings.json
 


### PR DESCRIPTION
The issue with fonts not being loaded when etherpad is behind a reverse proxy like mydomain.com/etherpad/static/fontname is resolved in the latest etherpad 1.8.4 as mentioned in https://github.com/ether/etherpad-lite/issues/3956.

Closes #572 and #540 .

Thanks to @sapkra for help.