### PR TITLE
jvb: set LOCAL_ADDRESS to the correct local IP

### DIFF
--- a/jvb/Dockerfile
+++ b/jvb/Dockerfile
@@ -3,7 +3,7 @@ FROM ${JITSI_REPO}/base-java
 
 RUN \
 	apt-dpkg-wrap apt-get update && \
-	apt-dpkg-wrap apt-get install -y jitsi-videobridge2 jq curl && \
+	apt-dpkg-wrap apt-get install -y jitsi-videobridge2 jq curl iproute2 && \
 	apt-cleanup
 
 COPY rootfs/ /

--- a/jvb/rootfs/etc/services.d/jvb/run
+++ b/jvb/rootfs/etc/services.d/jvb/run
@@ -3,7 +3,7 @@
 JAVA_SYS_PROPS="-Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/ -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=config -Djava.util.logging.config.file=/config/logging.properties"
 
 if [[ ! -z "$DOCKER_HOST_ADDRESS" ]]; then
-    LOCAL_ADDRESS=$(hostname -I | cut -d " " -f1)
+    LOCAL_ADDRESS=$(ip route get "$DOCKER_HOST_ADDRESS" | head -n1 | cut -d " " -f7)
     JAVA_SYS_PROPS="$JAVA_SYS_PROPS -Dorg.ice4j.ice.harvest.NAT_HARVESTER_LOCAL_ADDRESS=$LOCAL_ADDRESS -Dorg.ice4j.ice.harvest.NAT_HARVESTER_PUBLIC_ADDRESS=$DOCKER_HOST_ADDRESS"
 fi
 


### PR DESCRIPTION
NAT_HARVESTER_LOCAL_ADDRESS needs to bet set to the local IP that is actually
used to communicate with clients.

In Docker containers "hostname -I" returns the IPs of all interfaces. The order
of the IPs depends on the interface create order.

Docker makes no guarantees about the interface order and in my tests it is
random.

As a result NAT_HARVESTER_LOCAL_ADDRESS is sometimes set to the IP of the
internal meet.jitsi interface.

Fix this by setting it to the source IP used for routing to $DOCKER_HOST_ADDRESS

Adds 2803 kB disk space for iproute2 and dependencies.

Partly addresses #338