### PR TITLE
Use JVB_TCP_PORT for docker image instead of JVB_TCP_MAPPED_PORT

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,7 +142,7 @@ services:
         restart: ${RESTART_POLICY}
         ports:
             - '${JVB_PORT}:${JVB_PORT}/udp'
-            - '${JVB_TCP_MAPPED_PORT}:${JVB_TCP_PORT}'
+            - '${JVB_TCP_PORT}:${JVB_TCP_PORT}'
         volumes:
             - ${CONFIG}/jvb:/config:Z
         environment:


### PR DESCRIPTION
The JVB_TCP_MAPPED_PORT shall be used when the jvb is
behind a NAT server. Not for the docker external interface I think.
So the JVB_TCP_MAPPED_PORT is the port of on the public
external interface which may be on a completely different computer.

https://github.com/jitsi/jitsi-videobridge/blob/master/doc/tcp.md

In our case, we have the JVB bahind a NAT server and the changes introduced in https://github.com/jitsi/docker-jitsi-meet/commit/12051700562d9826f9e024ad649c4dd9b88f94de brakes our configuration since the mapped port is the port on the public IP and the JVB_TCP_PORT is the port used both internally in docker and the docker exposed port.

