### PR TITLE
Use larger alphabet for generating secure passwords

### DIFF
--- a/gen-passwords.sh
+++ b/gen-passwords.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
+# Generate a new 512-bit random key
 function generatePassword() {
-    openssl rand -hex 16
+    openssl rand -base64 64 | tr '+/' ':.' |tr -d '=\n'
 }
 
 JICOFO_COMPONENT_SECRET=$(generatePassword)


### PR DESCRIPTION
This patch would generate passwords of the same length but with a larger alphabet (and hence greater entropy) than the suggested hex passwords.