### PR TITLE
Configuration fix for issue #691.

### DIFF
--- a/jicofo/rootfs/defaults/sip-communicator.properties
+++ b/jicofo/rootfs/defaults/sip-communicator.properties
@@ -1,5 +1,6 @@
 org.jitsi.jicofo.ALWAYS_TRUST_MODE_ENABLED=true
 org.jitsi.jicofo.BRIDGE_MUC={{ .Env.JVB_BREWERY_MUC }}@{{ .Env.XMPP_INTERNAL_MUC_DOMAIN }}
+org.jitsi.jicofo.XMPP_MUC_COMPONENT_PREFIX=muc
 
 {{ if and .Env.JIBRI_BREWERY_MUC .Env.JIBRI_PENDING_TIMEOUT }}
 org.jitsi.jicofo.jibri.BREWERY={{ .Env.JIBRI_BREWERY_MUC}}@{{ .Env.XMPP_INTERNAL_MUC_DOMAIN }}

--- a/jicofo/rootfs/defaults/sip-communicator.properties
+++ b/jicofo/rootfs/defaults/sip-communicator.properties
@@ -1,6 +1,5 @@
 org.jitsi.jicofo.ALWAYS_TRUST_MODE_ENABLED=true
 org.jitsi.jicofo.BRIDGE_MUC={{ .Env.JVB_BREWERY_MUC }}@{{ .Env.XMPP_INTERNAL_MUC_DOMAIN }}
-org.jitsi.jicofo.XMPP_MUC_COMPONENT_PREFIX=muc
 
 {{ if and .Env.JIBRI_BREWERY_MUC .Env.JIBRI_PENDING_TIMEOUT }}
 org.jitsi.jicofo.jibri.BREWERY={{ .Env.JIBRI_BREWERY_MUC}}@{{ .Env.XMPP_INTERNAL_MUC_DOMAIN }}
@@ -17,6 +16,10 @@ org.jitsi.impl.reservation.rest.BASE_URL={{ .Env.JICOFO_RESERVATION_REST_BASE_UR
 
 {{ if .Env.JICOFO_ENABLE_HEALTH_CHECKS | default "0" | toBool }}
 org.jitsi.jicofo.health.ENABLE_HEALTH_CHECKS=true
+{{ end }}
+
+{{ if .Env.XMPP_MUC_DOMAIN }}
+org.jitsi.jicofo.XMPP_MUC_COMPONENT_PREFIX={{ first (splitList "." .Env.XMPP_MUC_DOMAIN) }}
 {{ end }}
 
 {{ $ENABLE_AUTH := .Env.ENABLE_AUTH | default "0" | toBool }}


### PR DESCRIPTION
Set `org.jitsi.jicofo.XMPP_MUC_COMPONENT_PREFIX` to `muc` to resolve issues between jicofo and jvb.