### PR TITLE
Whitelisiting jibri user to allow recording if lobby is enable

### DIFF
--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -68,6 +68,7 @@ VirtualHost "{{ .Env.XMPP_DOMAIN }}"
     {{ if and $ENABLE_LOBBY (not $ENABLE_GUEST_DOMAIN) }}
     main_muc = "{{ .Env.XMPP_MUC_DOMAIN }}"
     lobby_muc = "lobby.{{ .Env.XMPP_DOMAIN }}"
+    muc_lobby_whitelist = "recorder.{{ .Env.XMPP_DOMAIN }}"
     {{ end }}
 
     speakerstats_component = "speakerstats.{{ .Env.XMPP_DOMAIN }}"
@@ -87,6 +88,7 @@ VirtualHost "{{ .Env.XMPP_GUEST_DOMAIN }}"
 
     main_muc = "{{ .Env.XMPP_MUC_DOMAIN }}"
     lobby_muc = "lobby.{{ .Env.XMPP_DOMAIN }}"
+    muc_lobby_whitelist = "recorder.{{ .Env.XMPP_DOMAIN }}"
     {{ end }}
 
 {{ end }}


### PR DESCRIPTION
Currently Jibri is unable to start the recording if lobby is enabled. This is because jibri user is unable to bypass the lobby and hence get timed-out and hence recording fails.  By whitelisting jibri user, we are allowing jibri user to start the recording even if lobby is enabled.

**Reference:**
 https://github.com/jitsi/docker-jitsi-meet/issues/715
https://github.com/jitsi/jitsi-meet/blob/10c2652a4f0fc8480674662883209ebf581bb6d1/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example#L54
