### PR TITLE
Store secrets in separate .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.swp
 .env
 .env.bak
+/.secrets
 docker-compose.override.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,13 @@ services:
         volumes:
             - ${CONFIG}/prosody/config:/config:Z
             - ${CONFIG}/prosody/prosody-plugins-custom:/prosody-plugins-custom:Z
+        env_file:
+            - .secrets/JICOFO_COMPONENT_SECRET.env
+            - .secrets/JICOFO_AUTH_PASSWORD.env
+            - .secrets/JVB_AUTH_PASSWORD.env
+            - .secrets/JIGASI_XMPP_PASSWORD.env
+            - .secrets/JIBRI_XMPP_PASSWORD.env
+            - .secrets/JIBRI_RECORDER_PASSWORD.env
         environment:
             - AUTH_TYPE
             - ENABLE_AUTH
@@ -134,17 +141,11 @@ services:
             - XMPP_MUC_MODULES
             - XMPP_INTERNAL_MUC_MODULES
             - XMPP_RECORDER_DOMAIN
-            - JICOFO_COMPONENT_SECRET
             - JICOFO_AUTH_USER
-            - JICOFO_AUTH_PASSWORD
             - JVB_AUTH_USER
-            - JVB_AUTH_PASSWORD
             - JIGASI_XMPP_USER
-            - JIGASI_XMPP_PASSWORD
             - JIBRI_XMPP_USER
-            - JIBRI_XMPP_PASSWORD
             - JIBRI_RECORDER_USER
-            - JIBRI_RECORDER_PASSWORD
             - JWT_APP_ID
             - JWT_APP_SECRET
             - JWT_ACCEPTED_ISSUERS
@@ -167,6 +168,9 @@ services:
         restart: ${RESTART_POLICY}
         volumes:
             - ${CONFIG}/jicofo:/config:Z
+        env_file:
+            - .secrets/JICOFO_COMPONENT_SECRET.env
+            - .secrets/JICOFO_AUTH_PASSWORD.env
         environment:
             - AUTH_TYPE
             - ENABLE_AUTH
@@ -175,9 +179,7 @@ services:
             - XMPP_INTERNAL_MUC_DOMAIN
             - XMPP_MUC_DOMAIN
             - XMPP_SERVER
-            - JICOFO_COMPONENT_SECRET
             - JICOFO_AUTH_USER
-            - JICOFO_AUTH_PASSWORD
             - JICOFO_RESERVATION_REST_BASE_URL
             - JVB_BREWERY_MUC
             - JIGASI_BREWERY_MUC
@@ -199,13 +201,14 @@ services:
             - '${JVB_TCP_PORT}:${JVB_TCP_PORT}'
         volumes:
             - ${CONFIG}/jvb:/config:Z
+        env_file:
+            - .secrets/JVB_AUTH_PASSWORD.env
         environment:
             - DOCKER_HOST_ADDRESS
             - XMPP_AUTH_DOMAIN
             - XMPP_INTERNAL_MUC_DOMAIN
             - XMPP_SERVER
             - JVB_AUTH_USER
-            - JVB_AUTH_PASSWORD
             - JVB_BREWERY_MUC
             - JVB_PORT
             - JVB_TCP_HARVESTER_DISABLED

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,7 @@ services:
             - ${CONFIG}/prosody/prosody-plugins-custom:/prosody-plugins-custom:Z
         env_file:
             - .secrets/JICOFO_COMPONENT_SECRET.env
+            - .secrets/JWT_APP_SECRET.env
             - .secrets/JICOFO_AUTH_PASSWORD.env
             - .secrets/JVB_AUTH_PASSWORD.env
             - .secrets/JIGASI_XMPP_PASSWORD.env
@@ -147,7 +148,6 @@ services:
             - JIBRI_XMPP_USER
             - JIBRI_RECORDER_USER
             - JWT_APP_ID
-            - JWT_APP_SECRET
             - JWT_ACCEPTED_ISSUERS
             - JWT_ACCEPTED_AUDIENCES
             - JWT_ASAP_KEYSERVER

--- a/env.example
+++ b/env.example
@@ -92,9 +92,6 @@ TZ=UTC
 # Application identifier
 #JWT_APP_ID=my_jitsi_app_id
 
-# Application secret known only to your token
-#JWT_APP_SECRET=my_jitsi_app_secret
-
 # (Optional) Set asap_accepted_issuers as a comma separated list
 #JWT_ACCEPTED_ISSUERS=my_web_client,my_app_client
 

--- a/env.example
+++ b/env.example
@@ -1,33 +1,5 @@
 # shellcheck disable=SC2034
 
-# Security
-#
-# Set these to strong passwords to avoid intruders from impersonating a service account
-# The service(s) won't start unless these are specified
-# Running ./gen-passwords.sh will update .env with strong passwords
-# You may skip the Jigasi and Jibri passwords if you are not using those
-# DO NOT reuse passwords
-#
-
-# XMPP component password for Jicofo
-JICOFO_COMPONENT_SECRET=
-
-# XMPP password for Jicofo client connections
-JICOFO_AUTH_PASSWORD=
-
-# XMPP password for JVB client connections
-JVB_AUTH_PASSWORD=
-
-# XMPP password for Jigasi MUC client connections
-JIGASI_XMPP_PASSWORD=
-
-# XMPP recorder password for Jibri client connections
-JIBRI_RECORDER_PASSWORD=
-
-# XMPP password for Jibri client connections
-JIBRI_XMPP_PASSWORD=
-
-
 #
 # Basic configuration options
 #

--- a/env.example
+++ b/env.example
@@ -251,8 +251,8 @@ JIGASI_PORT_MAX=20050
 # section "Before you begin" paragraph 1 to 5
 # Copy the values from the json to the related env vars
 #GC_PROJECT_ID=
-#GC_PRIVATE_KEY_ID=
-#GC_PRIVATE_KEY=
+# (See .secrets/GC_PRIVATE_KEY_ID.env for GC_PRIVATE_KEY_ID)
+# (See .secrets/GC_PRIVATE_KEY.env for GC_PRIVATE_KEY)
 #GC_CLIENT_EMAIL=
 #GC_CLIENT_ID=
 #GC_CLIENT_CERT_URL=

--- a/env.example
+++ b/env.example
@@ -62,7 +62,7 @@ TZ=UTC
 #JIGASI_SIP_URI=test@sip2sip.info
 
 # Password for the specified SIP account as a clear text
-#JIGASI_SIP_PASSWORD=passw0rd
+# (See .secrets/JIGASI_SIP_PASSWORD)
 
 # SIP server (use the SIP account domain if in doubt)
 #JIGASI_SIP_SERVER=sip2sip.info

--- a/gen-passwords.sh
+++ b/gen-passwords.sh
@@ -40,9 +40,21 @@ GENERATED_ENV_VARIABLES=(
     JWT_APP_SECRET
 )
 
+MANUAL_ENV_VARIABLES=(
+    GC_PRIVATE_KEY_ID
+    GC_PRIVATE_KEY
+)
+
 for ENV_VARIABLE in "${GENERATED_ENV_VARIABLES[@]}"; do
     if [[ -e ".secrets/${ENV_VARIABLE}.env" ]]; then
 	mv ".secrets/${ENV_VARIABLE}.env" ".secrets/${ENV_VARIABLE}.env.bak"
     fi
     echo "${ENV_VARIABLE}=$(generatePassword)" > ".secrets/${ENV_VARIABLE}.env"
+done
+
+for ENV_VARIABLE in "${MANUAL_ENV_VARIABLES[@]}"; do
+    if [[ -e ".secrets/${ENV_VARIABLE}.env" ]]; then
+	mv ".secrets/${ENV_VARIABLE}.env" ".secrets/${ENV_VARIABLE}.env.bak"
+    fi
+    echo "${ENV_VARIABLE}=" > ".secrets/${ENV_VARIABLE}.env"
 done

--- a/gen-passwords.sh
+++ b/gen-passwords.sh
@@ -1,21 +1,41 @@
 #!/bin/bash
 
+# Security
+#
+# Set these to strong passwords to avoid intruders from impersonating a service account
+# The service(s) won't start unless these are specified
+# Running ./gen-passwords.sh will update .env with strong passwords
+# You may skip the Jigasi and Jibri passwords if you are not using those
+# DO NOT reuse passwords
+#
+
 function generatePassword() {
     openssl rand -hex 16
 }
 
-JICOFO_COMPONENT_SECRET=$(generatePassword)
-JICOFO_AUTH_PASSWORD=$(generatePassword)
-JVB_AUTH_PASSWORD=$(generatePassword)
-JIGASI_XMPP_PASSWORD=$(generatePassword)
-JIBRI_RECORDER_PASSWORD=$(generatePassword)
-JIBRI_XMPP_PASSWORD=$(generatePassword)
+GENERATED_ENV_VARIABLES=(
+    # XMPP component password for Jicofo
+    JICOFO_COMPONENT_SECRET
 
-sed -i.bak \
-    -e "s#JICOFO_COMPONENT_SECRET=.*#JICOFO_COMPONENT_SECRET=${JICOFO_COMPONENT_SECRET}#g" \
-    -e "s#JICOFO_AUTH_PASSWORD=.*#JICOFO_AUTH_PASSWORD=${JICOFO_AUTH_PASSWORD}#g" \
-    -e "s#JVB_AUTH_PASSWORD=.*#JVB_AUTH_PASSWORD=${JVB_AUTH_PASSWORD}#g" \
-    -e "s#JIGASI_XMPP_PASSWORD=.*#JIGASI_XMPP_PASSWORD=${JIGASI_XMPP_PASSWORD}#g" \
-    -e "s#JIBRI_RECORDER_PASSWORD=.*#JIBRI_RECORDER_PASSWORD=${JIBRI_RECORDER_PASSWORD}#g" \
-    -e "s#JIBRI_XMPP_PASSWORD=.*#JIBRI_XMPP_PASSWORD=${JIBRI_XMPP_PASSWORD}#g" \
-    "$(dirname "$0")/.env"
+    # XMPP password for Jicofo client connections
+    JICOFO_AUTH_PASSWORD
+
+    # XMPP password for JVB client connections
+    JVB_AUTH_PASSWORD
+
+    # XMPP password for Jigasi MUC client connections
+    JIGASI_XMPP_PASSWORD
+
+    # XMPP recorder password for Jibri client connections
+    JIBRI_RECORDER_PASSWORD
+
+    # XMPP password for Jibri client connections
+    JIBRI_XMPP_PASSWORD
+)
+
+for ENV_VARIABLE in "${GENERATED_ENV_VARIABLES[@]}"; do
+    if [[ -e ".secrets/${ENV_VARIABLE}.env" ]]; then
+	mv ".secrets/${ENV_VARIABLE}.env" ".secrets/${ENV_VARIABLE}.env.bak"
+    fi
+    echo "${ENV_VARIABLE}=$(generatePassword)" > ".secrets/${ENV_VARIABLE}.env"
+done

--- a/gen-passwords.sh
+++ b/gen-passwords.sh
@@ -32,6 +32,9 @@ GENERATED_ENV_VARIABLES=(
     # XMPP password for Jibri client connections
     JIBRI_XMPP_PASSWORD
 
+    # Password for the specified SIP account as a clear text
+    JIGASI_SIP_PASSWORD
+
     # JWT Authentication
     # Application secret known only to your token
     JWT_APP_SECRET

--- a/gen-passwords.sh
+++ b/gen-passwords.sh
@@ -31,6 +31,10 @@ GENERATED_ENV_VARIABLES=(
 
     # XMPP password for Jibri client connections
     JIBRI_XMPP_PASSWORD
+
+    # JWT Authentication
+    # Application secret known only to your token
+    JWT_APP_SECRET
 )
 
 for ENV_VARIABLE in "${GENERATED_ENV_VARIABLES[@]}"; do


### PR DESCRIPTION
This allows a downstream-user to keep `.env` under some version control without worrying about password leakage.