### PR TITLE
fix(jicofo): no auth URL in JWT auth mode

### DIFF
--- a/jicofo/rootfs/defaults/sip-communicator.properties
+++ b/jicofo/rootfs/defaults/sip-communicator.properties
@@ -25,10 +25,6 @@ org.jitsi.jicofo.XMPP_MUC_COMPONENT_PREFIX={{ first (splitList "." .Env.XMPP_MUC
 {{ $ENABLE_AUTH := .Env.ENABLE_AUTH | default "0" | toBool }}
 {{ $AUTH_TYPE := .Env.AUTH_TYPE | default "internal" }}
 
-{{ if $ENABLE_AUTH }}
-  {{ if eq $AUTH_TYPE "jwt" }}
-org.jitsi.jicofo.auth.URL=EXT_JWT:{{ .Env.XMPP_DOMAIN }}
-  {{ else }}
+{{ if and $ENABLE_AUTH (ne $AUTH_TYPE "jwt") }}
 org.jitsi.jicofo.auth.URL=XMPP:{{ .Env.XMPP_DOMAIN }}
-  {{ end }}
 {{ end }}


### PR DESCRIPTION
There's no need to have Jicofo involved in authentication
when JWT authentication type is configured in Prosody in which case
Prosody plugins are validating the token when user tries to enter
a MUC.

This mechanism was initially designed for 'internal' Prosody
XMPP authentication with guest access. In this mode only admin users
are allowed to create MUC rooms and Jicofo is an admin. In this flow,
a user first joins from domain with authentication enabled and it
will receive a session ID from Jicofo. Now the client will store this
session ID in the local storage and use it next time when coming back
to Jitsi Meet to make Jicofo create a MUC room for him/her.

https://jitsi.github.io/handbook/docs/devops-guide/secure-domain

The EXT_JWT mode was an experiment at some point, but now should
probably be removed. It may come handy only in case where there is
no JWT verification in Prosody and all users connect as anonymous and
MUC creation is only allowed to Jicofo.