### PR TITLE
Jvb new config

### DIFF
--- a/jvb/rootfs/defaults/jvb.conf
+++ b/jvb/rootfs/defaults/jvb.conf
@@ -1,0 +1,61 @@
+{{ $JVB_TCP_PORT := .Env.JVB_TCP_PORT | default "4443" }}
+{{ $JVB_TCP_MAPPED_PORT := .Env.JVB_TCP_MAPPED_PORT | default $JVB_TCP_PORT }}
+{{ $PUBLIC_URL_DOMAIN := .Env.PUBLIC_URL | default "https://localhost:8443" | trimPrefix "https://" | trimSuffix "/" -}}
+{{ $WS_DOMAIN := .Env.JVB_WS_DOMAIN | default $PUBLIC_URL_DOMAIN -}}
+{{ $WS_SERVER_ID := .Env.JVB_WS_SERVER_ID | default .Env.LOCAL_ADDRESS -}}
+
+videobridge {
+    ice {
+        udp {
+            port = {{ .Env.JVB_PORT }}
+        {
+        tcp {
+            enabled = {{ not .Env.JVB_TCP_HARVESTER_DISABLED }}
+            port = {{ .Env.JVB_TCP_PORT }}
+{{ if not (eq $JVB_TCP_PORT $JVB_TCP_MAPPED_PORT) }}
+            mapped-port = {{ $JVB_TCP_MAPPED_PORT }}
+{{ end }}
+        }
+    }
+    apis {
+        xmpp-client {
+            configs {
+                shard {
+                    HOSTNAME = "{{ .Env.XMPP_SERVER }}"
+                    DOMAIN = "{{ .Env.XMPP_AUTH_DOMAIN }}"
+                    USERNAME = "{{ .Env.JVB_AUTH_USER }}"
+                    PASSWORD = "{{ .Env.JVB_AUTH_PASSWORD }}"
+                    MUC_JIDS = "{{ .Env.JVB_BREWERY_MUC }}@{{ .Env.XMPP_INTERNAL_MUC_DOMAIN }}"
+                    MUC_NICKNAME = "{{ .Env.HOSTNAME }}"
+                    DISABLE_CERTIFICATE_VERIFICATION = true
+                }
+            }
+        }
+    }
+    stats {
+        enabled = true
+    }
+    websockets {
+        enabled = true
+        domain = "{{ $WS_DOMAIN }}"
+        tls = true
+        server-id = "{{ $WS_SERVER_ID }}"
+    }
+    http-servers {
+        private {
+            host = 0.0.0.0
+        }
+    }
+}
+
+ice4j {
+    harvest {
+        mapping {
+            stun {
+{{ if .Env.JVB_STUN_SERVERS }}
+                addresses = [ "{{ join "\",\"" (splitList "," .Env.JVB_STUN_SERVERS) }}" ]
+{{ end }}
+            }
+        }
+    }
+}

--- a/jvb/rootfs/defaults/jvb.conf
+++ b/jvb/rootfs/defaults/jvb.conf
@@ -8,7 +8,7 @@ videobridge {
     ice {
         udp {
             port = {{ .Env.JVB_PORT }}
-        {
+        }
         tcp {
             enabled = {{ not .Env.JVB_TCP_HARVESTER_DISABLED }}
             port = {{ .Env.JVB_TCP_PORT }}

--- a/jvb/rootfs/defaults/sip-communicator.properties
+++ b/jvb/rootfs/defaults/sip-communicator.properties
@@ -1,39 +1,5 @@
-org.jitsi.videobridge.SINGLE_PORT_HARVESTER_PORT={{ .Env.JVB_PORT }}
-org.jitsi.videobridge.DISABLE_TCP_HARVESTER={{ .Env.JVB_TCP_HARVESTER_DISABLED }}
-org.jitsi.videobridge.TCP_HARVESTER_PORT={{ .Env.JVB_TCP_PORT }}
-{{ if .Env.JVB_STUN_SERVERS }}
-org.ice4j.ice.harvest.STUN_MAPPING_HARVESTER_ADDRESSES={{ .Env.JVB_STUN_SERVERS }}
-{{ end }}
 {{ if .Env.DOCKER_HOST_ADDRESS }}
 org.ice4j.ice.harvest.NAT_HARVESTER_LOCAL_ADDRESS={{ .Env.LOCAL_ADDRESS }}
 org.ice4j.ice.harvest.NAT_HARVESTER_PUBLIC_ADDRESS={{ .Env.DOCKER_HOST_ADDRESS }}
 {{ end }}
-{{ $JVB_TCP_PORT := .Env.JVB_TCP_PORT | default "4443" }}
-{{ $JVB_TCP_MAPPED_PORT := .Env.JVB_TCP_MAPPED_PORT | default $JVB_TCP_PORT }}
-{{ if not (eq $JVB_TCP_PORT $JVB_TCP_MAPPED_PORT) }}
-org.jitsi.videobridge.TCP_HARVESTER_MAPPED_PORT={{ $JVB_TCP_MAPPED_PORT }}
-{{ end }}
 
-org.jitsi.videobridge.xmpp.user.shard.HOSTNAME={{ .Env.XMPP_SERVER }}
-org.jitsi.videobridge.xmpp.user.shard.DOMAIN={{ .Env.XMPP_AUTH_DOMAIN }}
-org.jitsi.videobridge.xmpp.user.shard.USERNAME={{ .Env.JVB_AUTH_USER }}
-org.jitsi.videobridge.xmpp.user.shard.PASSWORD={{ .Env.JVB_AUTH_PASSWORD }}
-org.jitsi.videobridge.xmpp.user.shard.MUC_JIDS={{ .Env.JVB_BREWERY_MUC }}@{{ .Env.XMPP_INTERNAL_MUC_DOMAIN }}
-org.jitsi.videobridge.xmpp.user.shard.MUC_NICKNAME={{ .Env.HOSTNAME }}
-org.jitsi.videobridge.xmpp.user.shard.DISABLE_CERTIFICATE_VERIFICATION=true
-
-org.jitsi.videobridge.ENABLE_STATISTICS=true
-org.jitsi.videobridge.STATISTICS_TRANSPORT=muc
-org.jitsi.videobridge.STATISTICS_INTERVAL=5000
-
-{{ $PUBLIC_URL_DOMAIN := .Env.PUBLIC_URL | default "https://localhost:8443" | trimPrefix "https://" | trimSuffix "/" -}}
-{{ $WS_DOMAIN := .Env.JVB_WS_DOMAIN | default $PUBLIC_URL_DOMAIN -}}
-{{ $WS_SERVER_ID := .Env.JVB_WS_SERVER_ID | default .Env.LOCAL_ADDRESS -}}
-
-org.jitsi.videobridge.rest.COLIBRI_WS_DISABLE=false
-org.jitsi.videobridge.rest.jetty.port=9090
-org.jitsi.videobridge.rest.COLIBRI_WS_DOMAIN={{ $WS_DOMAIN }}
-org.jitsi.videobridge.rest.COLIBRI_WS_TLS=true
-org.jitsi.videobridge.rest.COLIBRI_WS_SERVER_ID={{ $WS_SERVER_ID }}
-
-org.jitsi.videobridge.rest.private.jetty.host=0.0.0.0

--- a/jvb/rootfs/etc/cont-init.d/10-config
+++ b/jvb/rootfs/etc/cont-init.d/10-config
@@ -18,6 +18,8 @@ if [[ -f /config/custom-sip-communicator.properties ]]; then
     cat /config/custom-sip-communicator.properties >> /config/sip-communicator.properties
 fi
 
+tpl /defaults/jvb.conf > /config/jvb.conf
+
 if [[ ! -f /config/logging.properties ]]; then
     cp /defaults/logging.properties /config
 fi

--- a/jvb/rootfs/etc/services.d/jvb/run
+++ b/jvb/rootfs/etc/services.d/jvb/run
@@ -1,6 +1,6 @@
 #!/usr/bin/with-contenv bash
 
-export JAVA_SYS_PROPS="-Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/ -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=config -Djava.util.logging.config.file=/config/logging.properties" -Dconfig.file=/config/jvb.conf
+export JAVA_SYS_PROPS="-Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/ -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=config -Djava.util.logging.config.file=/config/logging.properties -Dconfig.file=/config/jvb.conf"
 
 DAEMON=/usr/share/jitsi-videobridge/jvb.sh
 

--- a/jvb/rootfs/etc/services.d/jvb/run
+++ b/jvb/rootfs/etc/services.d/jvb/run
@@ -1,6 +1,6 @@
 #!/usr/bin/with-contenv bash
 
-export JAVA_SYS_PROPS="-Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/ -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=config -Djava.util.logging.config.file=/config/logging.properties"
+export JAVA_SYS_PROPS="-Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/ -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=config -Djava.util.logging.config.file=/config/logging.properties" -Dconfig.file=/config/jvb.conf
 
 DAEMON=/usr/share/jitsi-videobridge/jvb.sh
 


### PR DESCRIPTION
This PR generates a new-style jvb config file (`jvb.conf`) and ports all supported properties from `sip-communicator.properties` over to it.  There is one property in ice4j which has not been ported yet which will have to stay, for now, in `sip-communicator.properties`--this is not ideal from a confusion perspective, but the config value itself is fine and it will still be observed.