### PR TITLE
feat(config): configure Matomo using environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,8 @@ services:
             - GOOGLE_API_APP_CLIENT_ID
             - INVITE_SERVICE_URL
             - JICOFO_AUTH_USER
+            - MATOMO_ENDPOINT
+            - MATOMO_SITE_ID
             - MICROSOFT_API_APP_CLIENT_ID
             - NGINX_RESOLVER
             - P2P_USE_STUN_TURN

--- a/web/rootfs/defaults/settings-config.js
+++ b/web/rootfs/defaults/settings-config.js
@@ -133,6 +133,16 @@ config.analytics.amplitudeAPPKey = '{{ .Env.AMPLITUDE_ID }}';
 config.analytics.googleAnalyticsTrackingId = '{{ .Env.GOOGLE_ANALYTICS_ID }}';
 {{ end -}}
 
+{{ if .Env.MATOMO_ENDPOINT -}}
+// Matomo endpoint:
+config.analytics.matomoEndpoint = '{{ .Env.MATOMO_ENDPOINT }}';
+{{ end -}}
+
+{{ if .Env.MATOMO_SITE_ID -}}
+// Matomo site ID:
+config.analytics.matomoSiteID = '{{ .Env.MATOMO_SITE_ID }}';
+{{ end -}}
+
 {{ if .Env.ANALYTICS_SCRIPT_URLS -}}
 // Array of script URLs to load as lib-jitsi-meet "analytics handlers".
 config.analytics.scriptURLs = [ '{{ join "','" (splitList "," .Env.ANALYTICS_SCRIPT_URLS) }}' ];


### PR DESCRIPTION
This PR adds support for [Matomo configuration](https://github.com/jitsi/jitsi-meet/blob/b5310573fcf86170cf5a2b6c3db144d94ba6f12d/config.js#L487-L489) using following environment variables:
- `MATOMO_ENDPOINT`: Matomo endpoint full URL
- `MATOMO_SITE_ID`: Matomo site ID

This PR can close #529.