### PR TITLE
feat(config): configure brandingDataUrl using environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
             - ANALYTICS_SCRIPT_URLS
             - ANALYTICS_WHITELISTED_EVENTS
             - BRIDGE_CHANNEL
+            - BRANDING_DATA_URL
             - CALLSTATS_CUSTOM_SCRIPT_URL
             - CALLSTATS_ID
             - CALLSTATS_SECRET

--- a/web/rootfs/defaults/settings-config.js
+++ b/web/rootfs/defaults/settings-config.js
@@ -240,6 +240,11 @@ config.useStunTurn = {{ $USE_STUN_TURN }};
 // Transcriptions (subtitles and buttons can be configured in interface_config)
 config.transcribingEnabled = {{ $ENABLE_TRANSCRIPTIONS }};
 
+{{ if .Env.BRANDING_DATA_URL -}}
+// External API url used to receive branding specific information.
+config.brandingDataUrl = '{{ .Env.BRANDING_DATA_URL }}';
+{{ end -}}
+
 
 // Deployment information.
 //


### PR DESCRIPTION
This PR let you configure the `brandingDataUrl` configuration key using the `BRANDING_DATA_URL` environment variable.

This can help for #527.