### PR TITLE
Add missing MAPPED_PORT variable to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -210,6 +210,7 @@ services:
             - JVB_PORT
             - JVB_TCP_HARVESTER_DISABLED
             - JVB_TCP_PORT
+            - JVB_TCP_MAPPED_PORT
             - JVB_STUN_SERVERS
             - JVB_ENABLE_APIS
             - PUBLIC_URL


### PR DESCRIPTION
Variable JVB_TCP_MAPPED_PORT is used in jvb/roots/defaults/sip-communicator.properties, but is not defined yet in the docker-compose.yml file
(Variable added in commit 12051700562d9826f9e024ad649c4dd9b88f94de)