### PR TITLE
Secondary IP: Allows running Jitsi around corporate firewalls

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -210,6 +210,7 @@ services:
             - JVB_PORT
             - JVB_TCP_HARVESTER_DISABLED
             - JVB_TCP_PORT
+            - JVB_TCP_MAPPED_PORT
             - JVB_STUN_SERVERS
             - JVB_ENABLE_APIS
             - PUBLIC_URL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -201,6 +201,7 @@ services:
             - ${CONFIG}/jvb:/config:Z
         environment:
             - DOCKER_HOST_ADDRESS
+            - DOCKER_HOST_ADDRESS2
             - XMPP_AUTH_DOMAIN
             - XMPP_INTERNAL_MUC_DOMAIN
             - XMPP_SERVER

--- a/env.example
+++ b/env.example
@@ -48,6 +48,9 @@ TZ=UTC
 # IP address of the Docker host
 # See the "Running behind NAT or on a LAN environment" section in the README
 #DOCKER_HOST_ADDRESS=192.168.1.1
+# Secondary IP address can be used to enable JVB over port 443 - used to make Jitsi work for users behind corporate firewalls
+# See https://community.jitsi.org/t/corporate-firewalls-use-port-443-for-videobridge-with-jitsi-docker/28285/5
+#DOCKER_HOST_ADDRESS2=192.168.1.2
 
 # Control whether the lobby feature should be enabled or not
 #ENABLE_LOBBY=1

--- a/jvb/rootfs/etc/services.d/jvb/run
+++ b/jvb/rootfs/etc/services.d/jvb/run
@@ -5,7 +5,7 @@ JAVA_SYS_PROPS="-Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/ -Dnet.java.si
 if [[ -z "$DOCKER_HOST_ADDRESS2" && ! -z "$DOCKER_HOST_ADDRESS" ]]; then
     DOCKER_HOST_ADDRESS2=$DOCKER_HOST_ADDRESS
 fi
-if [[ ! -z "$DOCKER_HOST_ADDRESS" ]]; then
+if [[ ! -z "$DOCKER_HOST_ADDRESS2" ]]; then
     LOCAL_ADDRESS=$(ip route get "$DOCKER_HOST_ADDRESS2" | head -n1 | cut -d " " -f7)
     JAVA_SYS_PROPS="$JAVA_SYS_PROPS -Dorg.ice4j.ice.harvest.NAT_HARVESTER_LOCAL_ADDRESS=$LOCAL_ADDRESS -Dorg.ice4j.ice.harvest.NAT_HARVESTER_PUBLIC_ADDRESS=$DOCKER_HOST_ADDRESS2"
 fi

--- a/jvb/rootfs/etc/services.d/jvb/run
+++ b/jvb/rootfs/etc/services.d/jvb/run
@@ -2,9 +2,12 @@
 
 JAVA_SYS_PROPS="-Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/ -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=config -Djava.util.logging.config.file=/config/logging.properties"
 
+if [[ -z "$DOCKER_HOST_ADDRESS2" && ! -z "$DOCKER_HOST_ADDRESS" ]]; then
+    DOCKER_HOST_ADDRESS2=$DOCKER_HOST_ADDRESS
+fi
 if [[ ! -z "$DOCKER_HOST_ADDRESS" ]]; then
-    LOCAL_ADDRESS=$(ip route get "$DOCKER_HOST_ADDRESS" | head -n1 | cut -d " " -f7)
-    JAVA_SYS_PROPS="$JAVA_SYS_PROPS -Dorg.ice4j.ice.harvest.NAT_HARVESTER_LOCAL_ADDRESS=$LOCAL_ADDRESS -Dorg.ice4j.ice.harvest.NAT_HARVESTER_PUBLIC_ADDRESS=$DOCKER_HOST_ADDRESS"
+    LOCAL_ADDRESS=$(ip route get "$DOCKER_HOST_ADDRESS2" | head -n1 | cut -d " " -f7)
+    JAVA_SYS_PROPS="$JAVA_SYS_PROPS -Dorg.ice4j.ice.harvest.NAT_HARVESTER_LOCAL_ADDRESS=$LOCAL_ADDRESS -Dorg.ice4j.ice.harvest.NAT_HARVESTER_PUBLIC_ADDRESS=$DOCKER_HOST_ADDRESS2"
 fi
 
 DAEMON=/usr/share/jitsi-videobridge/jvb.sh


### PR DESCRIPTION
A rather simple way to run Jitsi with less problems caused by corporate firewalls is described by @dammsugare here:
https://community.jitsi.org/t/corporate-firewalls-use-port-443-for-videobridge-with-jitsi-docker/28285/5

This allows easily running JVB over port 443, but requries a secondary IP address for the server to be defined.

Most settings @dammsugare describes can be implemented in the environment, but it requires changing a settings file in jvb. With this commit, an environment variable called DOCKER_HOST_ADDRESS2 can be used instead. If this is not defined, the behaviour returns to the default, using DOCKER_HOST_ADDRESS


