### PR TITLE
feat(config): expose JVB API port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,6 +197,7 @@ services:
         ports:
             - '${JVB_PORT}:${JVB_PORT}/udp'
             - '${JVB_TCP_PORT}:${JVB_TCP_PORT}'
+            - '${JVB_TCP_MAPPED_API_PORT}:8080'
         volumes:
             - ${CONFIG}/jvb:/config:Z
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,7 +197,7 @@ services:
         ports:
             - '${JVB_PORT}:${JVB_PORT}/udp'
             - '${JVB_TCP_PORT}:${JVB_TCP_PORT}'
-            - '${JVB_TCP_MAPPED_API_PORT}:8080'
+            - '${JVB_API_PORT}:8080'
         volumes:
             - ${CONFIG}/jvb:/config:Z
         environment:

--- a/env.example
+++ b/env.example
@@ -226,7 +226,7 @@ JVB_TCP_MAPPED_PORT=4443
 #JVB_ENABLE_APIS=rest,colibri
 
 # Map JVB API to server's port
-JVB_TCP_MAPPED_API_PORT=8080
+JVB_API_PORT=8080
 
 # XMPP user for Jicofo client connections.
 # NOTE: this option doesn't currently work due to a bug

--- a/env.example
+++ b/env.example
@@ -225,6 +225,9 @@ JVB_TCP_MAPPED_PORT=4443
 # See https://github.com/jitsi/jitsi-videobridge/blob/master/doc/rest.md for more information
 #JVB_ENABLE_APIS=rest,colibri
 
+# Map JVB API to server's port
+JVB_TCP_MAPPED_API_PORT=8080
+
 # XMPP user for Jicofo client connections.
 # NOTE: this option doesn't currently work due to a bug
 JICOFO_AUTH_USER=focus


### PR DESCRIPTION
I had to expose JVB API port to read Colibri stats (http://jitsi.example.com:8080/colibri/stats) from remote monitoring system. Added new config variable: `JVB_TCP_MAPPED_API_PORT`