### PR TITLE
Don't listen API calls from all hosts when APIs are not enabled

### DIFF
--- a/jvb/rootfs/defaults/sip-communicator.properties
+++ b/jvb/rootfs/defaults/sip-communicator.properties
@@ -29,4 +29,6 @@ org.jitsi.videobridge.rest.jetty.port=9090
 org.jitsi.videobridge.rest.COLIBRI_WS_DOMAIN={{ $WS_DOMAIN }}
 org.jitsi.videobridge.rest.COLIBRI_WS_TLS=true
 
+{{ if .Env.JVB_ENABLE_APIS }}
 org.jitsi.videobridge.rest.private.jetty.host=0.0.0.0
+{{ end }} 


### PR DESCRIPTION
Don't listen API calls from all hosts when APIs are not enabled (which is default behaviour) within `.env` variable `JVB_ENABLE_APIS`