### PR TITLE
Support/encourage usage of ShellCheck

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,3 +1,5 @@
+# shellcheck disable=SC2034
+
 # Security
 #
 # Set these to strong passwords to avoid intruders from impersonating a service account


### PR DESCRIPTION
My editor detected `.env` as shell script and thus automatically checked it with ShellCheck. I would propose to make it a valid shell script that complies with ShellCheck by default. To do this, we just need to disable
https://github.com/koalaman/shellcheck/wiki/SC2034 because the variables are not used (in that file).

When you search for "docker-compose .env shellcheck SC2034" it turns out that I am not the first one to do this :)