### PR TITLE
[web] Prevent s6 from restarting cron if it shouldn't be run

### DIFF
--- a/web/rootfs/etc/services.d/cron/run
+++ b/web/rootfs/etc/services.d/cron/run
@@ -1,7 +1,10 @@
 #!/usr/bin/with-contenv bash
 
-if [[ $DISABLE_HTTPS -ne 1 ]]; then
-    if [[ $ENABLE_LETSENCRYPT -eq 1 ]]; then
-      exec cron -f
-    fi
+if [[ $DISABLE_HTTPS -ne 1 ]] && \
+   [[ $ENABLE_LETSENCRYPT -eq 1 ]]; then
+    exec cron -f
+else
+    # if cron should not be started,
+    # prevent s6 from restarting this script again and again
+    s6-svc -O /var/run/s6/services/cron
 fi


### PR DESCRIPTION
Hello,

I'm hosting Jitsi behind a HTTPS reverse proxy. So I don't have the letsencrypt renew bot enabled (`ENABLE_LETSENCRYPT=0`).

But I noticed a lot of IO operations on my server. I tracked them down to the cron service, that is started by s6 in the `web` container. The script that starts cron is: `/etc/services.d/cron/run`.

If letsencrypt is disabled (as in my setup), this script does simply exit. But then the s6 supervisor constantly tries to restart the script again and again, because it's treated as a daemon.
On every restart (about every second) the status file of this s6 service is updated on disk, which causes the IO.

With my fix the service is treated as one-shot by s6 if cron should not be started. That means the service is only started once and s6 does not try to restart the service if it exits.
After a restart of the Docker container the cron s6 service is back in its original state. So cron will be started as daemon if environment variables (e.g. `ENABLE_LETSENCRYPT`) changed.