### PR TITLE
change Etherpad skin to "no-skin"

### DIFF
--- a/etherpad/rootfs/defaults/settings.json
+++ b/etherpad/rootfs/defaults/settings.json
@@ -19,6 +19,19 @@
   "favicon": "favicon.ico",
 
   /*
+   * Skin name.
+   *
+   * Its value has to be an existing directory under src/static/skins.
+   * You can write your own, or use one of the included ones:
+   *
+   * - "no-skin":  an empty skin (default). This yields the unmodified,
+   *               traditional Etherpad theme.
+   * - "colibris": the new experimental skin (since Etherpad 1.8), candidate to
+   *               become the default in Etherpad 2.0
+   */
+  "skinName": "no-skin",
+
+  /*
    * IP and port which etherpad should bind at
    */
   "ip": "0.0.0.0",


### PR DESCRIPTION
This commit changes the Etherpad skin back to the default skin before version
1.8.0. The old skin is better suited for embedding.

This commit effectively reverts commit 70bc71c "skins: make "colibris" the
default skin for new installations" to etherpad-lite.