### PR TITLE
Fix websocket

### DIFF
--- a/jvb/rootfs/defaults/jvb.conf
+++ b/jvb/rootfs/defaults/jvb.conf
@@ -42,8 +42,9 @@ videobridge {
         server-id = "{{ $WS_SERVER_ID }}"
     }
     http-servers {
-        private {
+        public {
             host = 0.0.0.0
+            port = 9090
         }
     }
 }

--- a/jvb/rootfs/defaults/jvb.conf
+++ b/jvb/rootfs/defaults/jvb.conf
@@ -42,6 +42,9 @@ videobridge {
         server-id = "{{ $WS_SERVER_ID }}"
     }
     http-servers {
+        private { 
+          host = 0.0.0.0
+        }
         public {
             host = 0.0.0.0
             port = 9090


### PR DESCRIPTION
We noticed that websocket were broken with this config.

We believe that the translation from old config to new config in [this commit](https://github.com/jitsi/docker-jitsi-meet/commit/130eb551a7666a9a143343e4ac7e707e3d6c6c02#diff-6f9b0c296a7ff789834c1414349f64f956f2b64df6e405fd45f62c6a11edad3fL34) didn't translate it well.

We are actually wondering what does private stands for in this context.

With this change, we can confirm that wss works again as expected.