### PR TITLE
prosody: add env var to configure cross-domain policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,6 +135,7 @@ services:
             - XMPP_MUC_MODULES
             - XMPP_INTERNAL_MUC_MODULES
             - XMPP_RECORDER_DOMAIN
+            - XMPP_CROSS_DOMAIN
             - JICOFO_COMPONENT_SECRET
             - JICOFO_AUTH_USER
             - JICOFO_AUTH_PASSWORD

--- a/env.example
+++ b/env.example
@@ -217,6 +217,10 @@ XMPP_INTERNAL_MUC_DOMAIN=internal-muc.meet.jitsi
 # XMPP domain for unauthenticated users
 XMPP_GUEST_DOMAIN=guest.meet.jitsi
 
+# Comma separated list of domains for cross domain policy or "true" to allow all
+# The PUBLIC_URL is always allowed
+#XMPP_CROSS_DOMAIN=true
+
 # Custom Prosody modules for XMPP_DOMAIN (comma separated)
 XMPP_MODULES=
 

--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -18,6 +18,8 @@ RUN \
 
 FROM ${JITSI_REPO}/base
 
+ENV XMPP_CROSS_DOMAIN="false"
+
 RUN \
     wget -q https://prosody.im/files/prosody-debian-packages.key -O - | gpg --enarmor > /etc/apt/trusted.gpg.d/prosody.asc \
     && echo "deb http://packages.prosody.im/debian buster main" > /etc/apt/sources.list.d/prosody.list \

--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -26,11 +26,20 @@ asap_accepted_issuers = { "{{ join "\",\"" (splitList "," .Env.JWT_ACCEPTED_ISSU
 asap_accepted_audiences = { "{{ join "\",\"" (splitList "," .Env.JWT_ACCEPTED_AUDIENCES) }}" }
 {{ end }}
 
-{{ if $ENABLE_XMPP_WEBSOCKET }}
+consider_bosh_secure = true;
+
 -- Deprecated in 0.12
 -- https://github.com/bjc/prosody/commit/26542811eafd9c708a130272d7b7de77b92712de
-cross_domain_websocket = { "{{ $PUBLIC_URL }}" };
-consider_bosh_secure = true;
+{{ $XMPP_CROSS_DOMAINS := $PUBLIC_URL }}
+{{ if eq .Env.XMPP_CROSS_DOMAIN "true"}}
+cross_domain_websocket = true
+cross_domain_bosh = true
+{{ else }}
+{{ if and .Env.XMPP_CROSS_DOMAIN (not (eq .Env.XMPP_CROSS_DOMAIN "false" )) }}
+  {{ $XMPP_CROSS_DOMAINS = list $PUBLIC_URL .Env.XMPP_CROSS_DOMAIN | join "," }}
+{{ end }}
+cross_domain_websocket = { "{{ join "\",\"" (splitList "," $XMPP_CROSS_DOMAINS) }}" }
+cross_domain_bosh = { "{{ join "\",\"" (splitList "," $XMPP_CROSS_DOMAINS) }}" }
 {{ end }}
 
 VirtualHost "{{ .Env.XMPP_DOMAIN }}"


### PR DESCRIPTION
Possible values:
- comma separated list of domains, but PUBLIC_URL will automatically be included
- `true` to enable cross domain policy for all domains