### PR TITLE
✨ Add mod_turncredentials to prosody

### DIFF
--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -44,6 +44,9 @@ RUN \
     && apt-dpkg-wrap apt-get -d install -y jitsi-meet-prosody \
     && dpkg -x /var/cache/apt/archives/jitsi-meet-prosody*.deb /tmp/pkg \
     && mv /tmp/pkg/usr/share/jitsi-meet/prosody-plugins /prosody-plugins \
+    && wget \
+      -O /usr/lib/prosody/modules/mod_turncredentials.lua \
+      https://raw.githubusercontent.com/netaskd/mod_turncredentials/master/mod_turncredentials.lua \
     && apt-cleanup \
     && rm -rf /tmp/pkg /var/cache/apt
 

--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -33,6 +33,7 @@ RUN \
       libsasl2-modules-ldap \
       lua-basexx \
       patch \
+      curl \
     && apt-dpkg-wrap apt-get install -t stretch-backports -y \
       lua-ldap \
       lua-sec \
@@ -44,8 +45,8 @@ RUN \
     && apt-dpkg-wrap apt-get -d install -y jitsi-meet-prosody \
     && dpkg -x /var/cache/apt/archives/jitsi-meet-prosody*.deb /tmp/pkg \
     && mv /tmp/pkg/usr/share/jitsi-meet/prosody-plugins /prosody-plugins \
-    && wget \
-      -O /usr/lib/prosody/modules/mod_turncredentials.lua \
+    && curl -4so \
+      /prosody-plugins/mod_turncredentials.lua \
       https://raw.githubusercontent.com/netaskd/mod_turncredentials/master/mod_turncredentials.lua \
     && apt-cleanup \
     && rm -rf /tmp/pkg /var/cache/apt


### PR DESCRIPTION
:sparkles: Add mod_turncredentials to prosody

There have been so many TURN Pull Requests (latest active being #163) and none being validated yet that I'm thinking it might be good to do it step by step.

- #835 Provides env var to configure Jitsi Web STUN support
- this one just adds mod_turncredentials.lua to prosody. Without any other developments, TURN can be setup simply with GLOBAL_* env var:

```
GLOBAL_MODULES=turncredentials
GLOBAL_CONFIG=turncredentials_secret = "mysupersecuresharedturnsecret";\nturncredentials_host = "turn.example.com";\nturncredentials_port = 5349;
```

@saghul what do you think ?