### PR TITLE
More adaptable setting for worker_processes in nginx

### DIFF
--- a/web/rootfs/defaults/nginx.conf
+++ b/web/rootfs/defaults/nginx.conf
@@ -1,5 +1,5 @@
 user www-data;
-worker_processes 4;
+worker_processes auto;
 pid /run/nginx.pid;
 include /etc/nginx/modules-enabled/*.conf;
 


### PR DESCRIPTION
re: worker_processes: Rather than a fixed number, use auto so that based on the machine that will be running it, Nginx can select the appropriate amount of processes.

From the nginx docs:
"The optimal value depends on many factors including (but not limited to) the number of CPU cores, the number of hard disk drives that store data, and load pattern. When one is in doubt, setting it to the number of available CPU cores would be a good start (the value “auto” will try to autodetect it)."