### PR TITLE
Add reloadcmd to acme.sh install-cert script

### DIFF
--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -43,7 +43,8 @@ if [[ $DISABLE_HTTPS -ne 1 ]]; then
             if ! /config/acme.sh/acme.sh \
                     --install-cert -d $LETSENCRYPT_DOMAIN \
                     --key-file /config/acme-certs/$LETSENCRYPT_DOMAIN/key.pem  \
-                    --fullchain-file /config/acme-certs/$LETSENCRYPT_DOMAIN/fullchain.pem ; then
+                    --fullchain-file /config/acme-certs/$LETSENCRYPT_DOMAIN/fullchain.pem \
+                    --reloadcmd "if [[ -f /var/run/s6/services/nginx ]]; then s6-svc -h /var/run/s6/services/nginx; fi"; then
                 echo "Failed to install certificate."
                 # this tries to get the user's attention and to spare the
                 # authority's rate limit:


### PR DESCRIPTION
The `README` on https://github.com/acmesh-official/acme.sh states that

> The reloadcmd is very important. The cert can be automatically renewed, but, without a correct 'reloadcmd' the cert may not be flushed to your server [...]

This PR adds a `reloadcmd` to the `--install-cert` routine and sends a SIGHUP to restart nginx gracefully if the service exists.

@saghul 