### PR TITLE
Env variables to set nginx worker processes and connections, keep original values as defaults

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,8 @@ services:
             - MATOMO_SITE_ID
             - MICROSOFT_API_APP_CLIENT_ID
             - NGINX_RESOLVER
+            - NGINX_WORKER_PROCESSES
+            - NGINX_WORKER_CONNECTIONS
             - PEOPLE_SEARCH_URL
             - RESOLUTION
             - RESOLUTION_MIN

--- a/web/rootfs/defaults/nginx.conf
+++ b/web/rootfs/defaults/nginx.conf
@@ -1,10 +1,10 @@
 user www-data;
-worker_processes 4;
+worker_processes {{ .Env.NGINX_WORKER_PROCESSES | default "4" }};
 pid /run/nginx.pid;
 include /etc/nginx/modules-enabled/*.conf;
 
 events {
-	worker_connections 768;
+	worker_connections {{ .Env.NGINX_WORKER_CONNECTIONS | default "768" }};
 	# multi_accept on;
 }
 


### PR DESCRIPTION
Use 2 new environment variables to allow setting the number of nginx worker processes and connections (NGINX_WORKER_PROCESSES, NGINX_WORKER_CONNECTIONS). Add the variables to the docker-compose file and to the nginx-conf where defaults are also set based on the current default values (4 processes, 768 connections).

Did not add to env-sample as it appears to only have the most commonly changed values.

Tested:
- Not adding new variables to .env file (defaults showed up correctly in nginx-conf)
- Adding variables to .env file (new values used in nginx-conf)
- Changing variable values in .env file (updated values appear in nginx-conf)
- Commented out variables in .env (nginx-conf values return to defaults)


