### PR TITLE
Add config for presence_identity module of prosody.

### DIFF
--- a/env.example
+++ b/env.example
@@ -145,6 +145,10 @@ ETHERPAD_SKIN_VARIANTS="super-light-toolbar super-light-editor light-background 
 # (Optional) Set asap_accepted_audiences as a comma separated list
 #JWT_ACCEPTED_AUDIENCES=my_server1,my_server2
 
+# (Optional) Parse user identifiers from token context (presence_identity module)
+# https://github.com/jitsi/lib-jitsi-meet/blob/master/doc/tokens.md#token-identifiers
+#JWT_IDENTIFIERS=1
+
 
 # LDAP authentication (for more information see the Cyrus SASL saslauthd.conf man page)
 #

--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -74,6 +74,9 @@ VirtualHost "{{ .Env.XMPP_DOMAIN }}"
         {{ end }}
         "pubsub";
         "ping";
+        {{ if $JWT_IDENTIFIERS }}
+        "presence_identity";
+        {{ end }}
         "speakerstats";
         "conference_duration";
         {{ if and $ENABLE_LOBBY (not $ENABLE_GUEST_DOMAIN) }}


### PR DESCRIPTION
Add optional env param for parse user identifiers from jwt token.
relates https://github.com/jitsi/lib-jitsi-meet/blob/master/doc/tokens.md#access-token-identifiers--context