### PR TITLE
Feat/can disable ipv6

### DIFF
--- a/env.example
+++ b/env.example
@@ -353,7 +353,7 @@ JIBRI_LOGS_DIR=/config/logs
 #ENABLE_HTTP_REDIRECT=1
 
 # Enable IPv6
-# Provides means to disable ipv6 in environments that don't support it.
+# Provides means to disable IPv6 in environments that don't support it (get with the times, people!)
 #ENABLE_IPV6=1
 
 # Container restart policy

--- a/env.example
+++ b/env.example
@@ -352,6 +352,10 @@ JIBRI_LOGS_DIR=/config/logs
 # Necessary for Let's Encrypt, relies on standard HTTPS port (443)
 #ENABLE_HTTP_REDIRECT=1
 
+# Enable ipv6
+# Provides means to disable ipv6 in environments that don't support it.
+#ENABLE_IPV6=1
+
 # Container restart policy
 # Defaults to unless-stopped
 RESTART_POLICY=unless-stopped

--- a/env.example
+++ b/env.example
@@ -352,7 +352,7 @@ JIBRI_LOGS_DIR=/config/logs
 # Necessary for Let's Encrypt, relies on standard HTTPS port (443)
 #ENABLE_HTTP_REDIRECT=1
 
-# Enable ipv6
+# Enable IPv6
 # Provides means to disable ipv6 in environments that don't support it.
 #ENABLE_IPV6=1
 

--- a/web/rootfs/defaults/default
+++ b/web/rootfs/defaults/default
@@ -1,6 +1,9 @@
 server {
 	listen 80 default_server;
+	
+	{{ if .Env.ENABLE_IPV6 | default "1" | toBool }}
 	listen [::]:80 default_server;
+	{{ end }}
 
 	{{ if .Env.ENABLE_HTTP_REDIRECT | default "0" | toBool }}
 	return 301 https://$host$request_uri;
@@ -12,7 +15,10 @@ server {
 {{ if not (.Env.DISABLE_HTTPS | default "0" | toBool) }}
 server {
 	listen 443 ssl http2;
+	
+	{{ if .Env.ENABLE_IPV6 | default "1" | toBool }}
 	listen [::]:443 ssl http2;
+	{{ end }}
 
 	include /config/nginx/ssl.conf;
 	include /config/nginx/meet.conf;


### PR DESCRIPTION
In some environments it's required to disable ipv6 due to security constraints. It was reported in #805, that docker-jitsi-meet no longer started properly in such environments. The problem was shortly discussed in the related commit: https://github.com/jitsi/docker-jitsi-meet/commit/5ceaf5fd025b005c6ddfbc87b18c77fe402a8893

This PR introduces a new environment parameter, which makes it possible to disable the problem causing ipv6 nginx-listeners. By default, ipv6 is enabled.