### PR TITLE
control SIP default room for incoming calls

### DIFF
--- a/env.example
+++ b/env.example
@@ -129,9 +129,6 @@ ETHERPAD_SKIN_VARIANTS="super-light-toolbar super-light-editor light-background 
 # SIP server transport
 #JIGASI_SIP_TRANSPORT=UDP
 
-# SIP default room name for incoming calls lacking of Invite header
-#JIGASI_SIP_DEFAULT_ROOM=conference
-
 #
 # Authentication configuration (see handbook for details)
 #

--- a/env.example
+++ b/env.example
@@ -117,6 +117,9 @@ ETHERPAD_SKIN_VARIANTS="super-light-toolbar super-light-editor light-background 
 # SIP server transport
 #JIGASI_SIP_TRANSPORT=UDP
 
+# SIP default room name for incoming calls lacking of Invite header
+#JIGASI_SIP_DEFAULT_ROOM=conference
+
 #
 # Authentication configuration (see handbook for details)
 #

--- a/jigasi.yml
+++ b/jigasi.yml
@@ -22,6 +22,7 @@ services:
             - JIGASI_SIP_SERVER
             - JIGASI_SIP_PORT
             - JIGASI_SIP_TRANSPORT
+            - JIGASI_SIP_DEFAULT_ROOM
             - JIGASI_XMPP_USER
             - JIGASI_XMPP_PASSWORD
             - JIGASI_BREWERY_MUC

--- a/jigasi/rootfs/defaults/sip-communicator.properties
+++ b/jigasi/rootfs/defaults/sip-communicator.properties
@@ -142,3 +142,7 @@ org.jitsi.jigasi.transcription.SEND_TXT={{ .Env.JIGASI_TRANSCRIBER_SEND_TXT | de
 org.jitsi.jigasi.transcription.RECORD_AUDIO={{ .Env.JIGASI_TRANSCRIBER_RECORD_AUDIO | default "false"}}
 org.jitsi.jigasi.transcription.RECORD_AUDIO_FORMAT=wav
 {{end}}
+
+{{ if .Env.JIGASI_SIP_DEFAULT_ROOM }}
+org.jitsi.jigasi.DEFAULT_JVB_ROOM_NAME={{ .Env.JIGASI_SIP_DEFAULT_ROOM }}
+{{ end }}


### PR DESCRIPTION
This merge request is adding support for controlling default room to use on incoming SIP calls lacking of proper Invite header to prevent this setting from requiring manual patching of internal configuration file. It is regarding #616.