### PR TITLE
fix LDAP jigasi auth

### DIFF
--- a/jigasi.yml
+++ b/jigasi.yml
@@ -13,6 +13,7 @@ services:
         environment:
             - ENABLE_AUTH
             - XMPP_AUTH_DOMAIN
+            - XMPP_MUC_DOMAIN
             - XMPP_INTERNAL_MUC_DOMAIN
             - XMPP_SERVER
             - XMPP_DOMAIN

--- a/jigasi.yml
+++ b/jigasi.yml
@@ -42,7 +42,6 @@ services:
             - GC_CLIENT_ID
             - GC_CLIENT_CERT_URL
             - TZ
-            - AUTH_TYPE
         depends_on:
             - prosody
         networks:

--- a/jigasi.yml
+++ b/jigasi.yml
@@ -42,7 +42,7 @@ services:
             - GC_CLIENT_ID
             - GC_CLIENT_CERT_URL
             - TZ
-            - LDAP_URL
+            - AUTH_TYPE
         depends_on:
             - prosody
         networks:

--- a/jigasi.yml
+++ b/jigasi.yml
@@ -42,6 +42,7 @@ services:
             - GC_CLIENT_ID
             - GC_CLIENT_CERT_URL
             - TZ
+            - LDAP_URL
         depends_on:
             - prosody
         networks:

--- a/jigasi/rootfs/defaults/sip-communicator.properties
+++ b/jigasi/rootfs/defaults/sip-communicator.properties
@@ -143,4 +143,4 @@ org.jitsi.jigasi.transcription.RECORD_AUDIO={{ .Env.JIGASI_TRANSCRIBER_RECORD_AU
 org.jitsi.jigasi.transcription.RECORD_AUDIO_FORMAT=wav
 {{end}}
 
-org.jitsi.jigasi.MUC_SERVICE_ADDRESS={{ .Env.XMPP_INTERNAL_MUC_DOMAIN }}
+org.jitsi.jigasi.MUC_SERVICE_ADDRESS={{ .Env.XMPP_MUC_DOMAIN }}

--- a/jigasi/rootfs/defaults/sip-communicator.properties
+++ b/jigasi/rootfs/defaults/sip-communicator.properties
@@ -143,6 +143,6 @@ org.jitsi.jigasi.transcription.RECORD_AUDIO={{ .Env.JIGASI_TRANSCRIBER_RECORD_AU
 org.jitsi.jigasi.transcription.RECORD_AUDIO_FORMAT=wav
 {{end}}
 
-{{ if .Env.LDAP_URL }}
+{{ if eq $AUTH_TYPE "ldap" }}
 org.jitsi.jigasi.MUC_SERVICE_ADDRESS=muc.meet.jitsi
 {{ end }}

--- a/jigasi/rootfs/defaults/sip-communicator.properties
+++ b/jigasi/rootfs/defaults/sip-communicator.properties
@@ -142,3 +142,7 @@ org.jitsi.jigasi.transcription.SEND_TXT={{ .Env.JIGASI_TRANSCRIBER_SEND_TXT | de
 org.jitsi.jigasi.transcription.RECORD_AUDIO={{ .Env.JIGASI_TRANSCRIBER_RECORD_AUDIO | default "false"}}
 org.jitsi.jigasi.transcription.RECORD_AUDIO_FORMAT=wav
 {{end}}
+
+{{ if .Env.LDAP_URL }}
+org.jitsi.jigasi.MUC_SERVICE_ADDRESS=muc.meet.jitsi
+{{ end }}

--- a/jigasi/rootfs/defaults/sip-communicator.properties
+++ b/jigasi/rootfs/defaults/sip-communicator.properties
@@ -143,4 +143,4 @@ org.jitsi.jigasi.transcription.RECORD_AUDIO={{ .Env.JIGASI_TRANSCRIBER_RECORD_AU
 org.jitsi.jigasi.transcription.RECORD_AUDIO_FORMAT=wav
 {{end}}
 
-org.jitsi.jigasi.MUC_SERVICE_ADDRESS=muc.meet.jitsi
+org.jitsi.jigasi.MUC_SERVICE_ADDRESS={{ .Env.XMPP_INTERNAL_MUC_DOMAIN }}

--- a/jigasi/rootfs/defaults/sip-communicator.properties
+++ b/jigasi/rootfs/defaults/sip-communicator.properties
@@ -143,6 +143,4 @@ org.jitsi.jigasi.transcription.RECORD_AUDIO={{ .Env.JIGASI_TRANSCRIBER_RECORD_AU
 org.jitsi.jigasi.transcription.RECORD_AUDIO_FORMAT=wav
 {{end}}
 
-{{ if eq $AUTH_TYPE "ldap" }}
 org.jitsi.jigasi.MUC_SERVICE_ADDRESS=muc.meet.jitsi
-{{ end }}


### PR DESCRIPTION
This merge request is conditionally adding configuration suggested in #500 to jigasi SIP configuration file when LDAP authentication has been selected in .env file.