### PR TITLE
:sparkles: web: Add ENABLE_HSTS flag to control strict-transport-security header

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
         environment:
             - ENABLE_LETSENCRYPT
             - ENABLE_HTTP_REDIRECT
+            - ENABLE_HSTS
             - ENABLE_XMPP_WEBSOCKET
             - DISABLE_HTTPS
             - LETSENCRYPT_DOMAIN

--- a/env.example
+++ b/env.example
@@ -364,6 +364,11 @@ JIBRI_LOGS_DIR=/config/logs
 # Necessary for Let's Encrypt, relies on standard HTTPS port (443)
 #ENABLE_HTTP_REDIRECT=1
 
+# Send a `strict-transport-security` header to force browsers to use
+# a secure and trusted connection. Recommended for production use.
+# Defaults to 1 (send the header).
+# ENABLE_HSTS=1
+
 # Enable IPv6
 # Provides means to disable IPv6 in environments that don't support it (get with the times, people!)
 #ENABLE_IPV6=1

--- a/web/rootfs/defaults/ssl.conf
+++ b/web/rootfs/defaults/ssl.conf
@@ -23,4 +23,6 @@ ssl_prefer_server_ciphers off;
 ssl_dhparam /defaults/ffdhe2048.txt;
 
 # HSTS (ngx_http_headers_module is required) (63072000 seconds)
+{{ if .Env.ENABLE_HSTS | default "1" | toBool }}
 add_header Strict-Transport-Security "max-age=63072000" always;
+{{ end }}


### PR DESCRIPTION
Closes #878

Feel free to push additional edits to this PR if needed.