### PR TITLE
add CONFCODE_URL and DIALIN_NUMBERS_URL

### DIFF
--- a/env.example
+++ b/env.example
@@ -129,6 +129,12 @@ ETHERPAD_SKIN_VARIANTS="super-light-toolbar super-light-editor light-background 
 # SIP server transport
 #JIGASI_SIP_TRANSPORT=UDP
 
+# URL to the API for checking/generating Dial-In codes
+#CONFCODE_URL=https://jitsi-api.jitsi.net/conferenceMapper
+
+# URL to the JSON containing all Dial-In numbers
+#DIALIN_NUMBERS_URL=https://meet.example.com/dialin.json
+
 #
 # Authentication configuration (see handbook for details)
 #


### PR DESCRIPTION
I've added placeholders for the environment variables `CONFCODE_URL` and `DIALIN_NUMBERS_URL` to the `env.example` file. I believe it should be available in the examples. 