### PR TITLE
Fixes #867, #871 jibri recording websocket error

### DIFF
--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -37,7 +37,7 @@ cross_domain_websocket = true
 cross_domain_bosh = true
 {{ else }}
 {{ if not (eq $XMPP_CROSS_DOMAIN "false") }}
-  {{ $XMPP_CROSS_DOMAINS = list $PUBLIC_URL .Env.XMPP_DOMAIN .Env.XMPP_CROSS_DOMAIN | join "," }}
+  {{ $XMPP_CROSS_DOMAINS = list $PUBLIC_URL (print "https://" .Env.XMPP_DOMAIN) .Env.XMPP_CROSS_DOMAIN | join "," }}
 {{ end }}
 cross_domain_websocket = { "{{ join "\",\"" (splitList "," $XMPP_CROSS_DOMAINS) }}" }
 cross_domain_bosh = { "{{ join "\",\"" (splitList "," $XMPP_CROSS_DOMAINS) }}" }


### PR DESCRIPTION
See commit comments [here](https://github.com/jitsi/docker-jitsi-meet/commit/6f7b2b4a01b3e8566eb874f163a1a8cb22af4964#commitcomment-45846316)

Should fix errors observed in `/config/logs/browser.0.txt` in Jibri when trying to record on `stable-5142-4` like this one:
```
WebSocket connection to 'wss://meet.domain.com/xmpp-websocket?room=testmeeting' failed: Error during WebSocket handshake: Unexpected response code: 403
```