### PR TITLE
Be able to add custom parameters at sip-communicator.properties

### DIFF
--- a/jicofo/rootfs/defaults/sip-communicator.properties
+++ b/jicofo/rootfs/defaults/sip-communicator.properties
@@ -32,3 +32,7 @@ org.jitsi.jicofo.auth.URL=EXT_JWT:{{ .Env.XMPP_DOMAIN }}
 org.jitsi.jicofo.auth.URL=XMPP:{{ .Env.XMPP_DOMAIN }}
   {{ end }}
 {{ end }}
+
+{{ if .Env.JICOFO_EXTRA_CONFIG }}
+{{ .Env.JICOFO_EXTRA_CONFIG }}
+{{ end }}


### PR DESCRIPTION
With this tiny patch you can define a multiline variable containing any missing config entries.

In our case, we need it to ease OCTO's configuration, tweaking and testing.

