### PR TITLE
web: brandingDataUrl -> dynamicBrandingUrl

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,6 @@ services:
             - ANALYTICS_SCRIPT_URLS
             - ANALYTICS_WHITELISTED_EVENTS
             - BRIDGE_CHANNEL
-            - BRANDING_DATA_URL
             - CALLSTATS_CUSTOM_SCRIPT_URL
             - CALLSTATS_ID
             - CALLSTATS_SECRET
@@ -41,6 +40,7 @@ services:
             - DIALOUT_CODES_URL
             - DROPBOX_APPKEY
             - DROPBOX_REDIRECT_URI
+            - DYNAMIC_BRANDING_URL
             - ENABLE_AUDIO_PROCESSING
             - ENABLE_AUTH
             - ENABLE_CALENDAR

--- a/web/rootfs/defaults/settings-config.js
+++ b/web/rootfs/defaults/settings-config.js
@@ -267,9 +267,9 @@ config.useIPv6 = {{ $ENABLE_IPV6 }};
 // Transcriptions (subtitles and buttons can be configured in interface_config)
 config.transcribingEnabled = {{ $ENABLE_TRANSCRIPTIONS }};
 
-{{ if .Env.BRANDING_DATA_URL -}}
+{{ if .Env.DYNAMIC_BRANDING_URL -}}
 // External API url used to receive branding specific information.
-config.brandingDataUrl = '{{ .Env.BRANDING_DATA_URL }}';
+config.dynamicBrandingUrl = '{{ .Env.DYNAMIC_BRANDING_URL }}';
 {{ end -}}
 
 {{ if .Env.TOKEN_AUTH_URL -}}


### PR DESCRIPTION
This commit https://github.com/jitsi/jitsi-meet/commit/33e4324f6de7b4360182d39669b8095bd0dff43a renamed `brandingDataUrl` to `dynamicBrandingUrl` in the configuration file.

I also updated the name of the environment variable to also reflect this change: `BRANDING_DATA_URL` is now `DYNAMIC_BRANDING_URL`.