### PR TITLE
fix #956 - reintroduce shibboleth auth

### DIFF
--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -9,10 +9,17 @@ jicofo {
       // The type of authentication. Supported values are XMPP, JWT or SHIBBOLETH (default).
       {{ if eq $AUTH_TYPE "jwt" }}
       type = JWT
+      {{ else if eq $AUTH_TYPE "shibboleth" }}
+      type = SHIBBOLETH
       {{ else }}
       type = XMPP
       {{ end }}
+      {{ if eq $AUTH_TYPE "shibboleth" }}
+      login-url = "shibboleth:default"
+      logout-url = "shibboleth:default"
+      {{ else }}
       login-url = "{{ .Env.XMPP_DOMAIN }}"
+      {{ end }}
     }
     {{ end }}
 


### PR DESCRIPTION
Instead of configuring sip-communicator.properties as in the past,
set the following ENV variables:

```
ENABLE_AUTH=1
AUTH_TYPE=shibboleth
```