### PR TITLE
wrong skin name for etherpad

### DIFF
--- a/env.example
+++ b/env.example
@@ -104,7 +104,7 @@ ETHERPAD_TITLE="Video Chat"
 ETHERPAD_DEFAULT_PAD_TEXT="Welcome to Web Chat!\n\n"
 
 # Name of the skin for etherpad
-ETHERPAD_SKIN_NAME="colibris"
+ETHERPAD_SKIN_NAME=colibris
 
 # Skin variants for etherpad
 ETHERPAD_SKIN_VARIANTS="super-light-toolbar super-light-editor light-background full-width-editor"


### PR DESCRIPTION
[2021-03-04 12:42:10.788] [ERROR] console - Skin path /opt/etherpad-lite/src/static/skins/"colibris" does not exist. Falling back to the default "colibris".
[2021-03-04 12:42:10.788] [INFO] console - Using skin "colibris" in dir: /opt/etherpad-lite/src/static/skins/colibris