### PR TITLE
Always install acme.sh when container starts

### DIFF
--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -10,12 +10,10 @@ mkdir -p \
 # generate keys (maybe)
 if [[ $DISABLE_HTTPS -ne 1 ]]; then
     if [[ $ENABLE_LETSENCRYPT -eq 1 ]]; then
-        if [[ ! -f /config/acme.sh/acme.sh ]]; then
-            mkdir /config/acme.sh
-            pushd /opt
-            sh ./acme.sh --install --home /config/acme.sh --accountemail $LETSENCRYPT_EMAIL
-            popd
-        fi
+        mkdir -p /config/acme.sh
+        pushd /opt
+        sh ./acme.sh --install --home /config/acme.sh --accountemail $LETSENCRYPT_EMAIL
+        popd
         if [[ ! -f /config/acme-certs/$LETSENCRYPT_DOMAIN/fullchain.pem ]]; then
             STAGING=""
             if [[ $LETSENCRYPT_USE_STAGING -eq 1 ]]; then


### PR DESCRIPTION
The previous version only installed acme.sh if it was not previously
installed. However, the check for a previous installation was based on
the existence of /config/acme.sh/acme.sh which is in the
external/persisted storage. The result was that acme.sh installation
would be skipped even for a new build of the web container if the
installation had been run on any previous build of the container. When
the web container is rebuilt, such as during an upgrade to a new stable
version, the new container would lack the cron job needed to
automatically updated the TLS certificates. Additionally, the version of
acme.sh installed in /config/acme.sh would never update even if the
pinned version in the Dockerfile was changed.

This patch sets the init script to always re-install acme.sh on
container start. The cron job installation from acme.sh is guarded by a
check for an existing job so there is no duplication. Re-installing also
has the effect of replacing the persisted /config/acme.sh/acme.sh with
the latest version set in the Dockerfile during upgrades.