### PR TITLE
Make a custom interface config possible

### DIFF
--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -83,6 +83,9 @@ fi
 
 if [[ ! -f /config/interface_config.js ]]; then
     cp /defaults/interface_config.js /config/interface_config.js
+    if [[ -f /config/custom-interface_config.js ]]; then
+        cat /config/custom-interface_config.js >> /config/interface_config.js
+    fi
 
     # It will remove parameter 'closedcaptions' from TOOLBAR_BUTTONS if ENABLE_TRANSCRIPTIONS is false,
     # because it enabled by default, but not supported out of the box.


### PR DESCRIPTION
For the `config.js` you can already add a `custom-config.js` in order to override config variables.
I would like to have this for the interface-config as well, since I need to override values like `DISPLAY_WELCOME_PAGE_CONTENT` that are not currently supported via ENV-variables.