### PR TITLE
disable octo by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -206,6 +206,7 @@ services:
             - JVB_BREWERY_MUC
             - MAX_BRIDGE_PARTICIPANTS
             - OCTO_BRIDGE_SELECTION_STRATEGY
+            - TESTING_OCTO_PROBABILITY
             - TZ
             - XMPP_DOMAIN
             - XMPP_AUTH_DOMAIN

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,6 +187,7 @@ services:
             - ENABLE_CODEC_VP8
             - ENABLE_CODEC_VP9
             - ENABLE_CODEC_H264
+            - ENABLE_OCTO
             - ENABLE_RECORDING
             - ENABLE_SCTP
             - JICOFO_AUTH_USER
@@ -206,7 +207,6 @@ services:
             - JVB_BREWERY_MUC
             - MAX_BRIDGE_PARTICIPANTS
             - OCTO_BRIDGE_SELECTION_STRATEGY
-            - TESTING_OCTO_PROBABILITY
             - TZ
             - XMPP_DOMAIN
             - XMPP_AUTH_DOMAIN

--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -2,7 +2,7 @@
 {{ $ENABLE_SCTP := .Env.ENABLE_SCTP | default "0" | toBool }}
 {{ $AUTH_TYPE := .Env.AUTH_TYPE | default "internal" }}
 {{ $ENABLE_RECORDING := .Env.ENABLE_RECORDING | default "0" | toBool }}
-{{ $ENABLE_OCTO := .Env.TESTING_OCTO_PROBABILITY | default "0" | toBool }}
+{{ $ENABLE_OCTO := .Env.ENABLE_OCTO | default "0" | toBool }}
 
 jicofo {
     {{ if $ENABLE_AUTH }}

--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -2,6 +2,7 @@
 {{ $ENABLE_SCTP := .Env.ENABLE_SCTP | default "0" | toBool }}
 {{ $AUTH_TYPE := .Env.AUTH_TYPE | default "internal" }}
 {{ $ENABLE_RECORDING := .Env.ENABLE_RECORDING | default "0" | toBool }}
+{{ $ENABLE_OCTO := .Env.TESTING_OCTO_PROBABILITY | default "0" | toBool }}
 
 jicofo {
     {{ if $ENABLE_AUTH }}
@@ -114,6 +115,12 @@ jicofo {
     {{ end }}
 
     octo {
+      // Whether or not to use Octo. Note that when enabled, its use will be determined by
+      // $jicofo.bridge.selection-strategy. There's a corresponding flag in the JVB and these
+      // two MUST be in sync (otherwise bridges will crash because they won't know how to
+      // deal with octo channels).
+      enabled = {{ $ENABLE_OCTO }}
+      
       id = "{{ .Env.JICOFO_SHORT_ID | default "1" }}"
     }
 


### PR DESCRIPTION
In the jicofo reference.conf file, Octo is disabled by default hence added an environment variable to enable/disable octo in jicofo.conf. 
