### PR TITLE
Provide component secret to jicofo - fix fatal jicofo startup error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,6 +189,7 @@ services:
             - ENABLE_CODEC_H264
             - ENABLE_RECORDING
             - ENABLE_SCTP
+            - JICOFO_COMPONENT_SECRET
             - JICOFO_AUTH_USER
             - JICOFO_AUTH_PASSWORD
             - JICOFO_ENABLE_BRIDGE_HEALTH_CHECKS


### PR DESCRIPTION
Connection to a session fails after setting up a fresh docker installation.

Jicofo failed with:
FATAL ERROR: Jicofo component secret and auth password must be set

so this commit adds 
- JICOFO_COMPONENT_SECRET
in jicofo.environment