### PR TITLE
JVB HTTP servers should be configurable

### DIFF
--- a/jvb/rootfs/defaults/jvb.conf
+++ b/jvb/rootfs/defaults/jvb.conf
@@ -45,12 +45,12 @@ videobridge {
     }
     http-servers {
         private { 
-          host = "{{ .Env.JVB_HTTP_SERVER_PRIVATE_ADDRESS | default "0.0.0.0" }}"
-          port = "{{ .Env.JVB_HTTP_SERVER_PRIVATE_PORT | default "8080" }}"
+          host = {{ .Env.JVB_HTTP_SERVER_PRIVATE_ADDRESS | default "0.0.0.0" }}
+          port = {{ .Env.JVB_HTTP_SERVER_PRIVATE_PORT | default "8080" }}
         }
         public {
-            host = "{{ .Env.JVB_HTTP_SERVER_PUBLIC_ADDRESS | default "0.0.0.0" }}"
-            port = "{{ .Env.JVB_HTTP_SERVER_PUBLIC_PORT | default "9090" }}"
+            host = {{ .Env.JVB_HTTP_SERVER_PUBLIC_ADDRESS | default "0.0.0.0" }}
+            port = {{ .Env.JVB_HTTP_SERVER_PUBLIC_PORT | default "9090" }}
         }
     }
 

--- a/jvb/rootfs/defaults/jvb.conf
+++ b/jvb/rootfs/defaults/jvb.conf
@@ -45,11 +45,12 @@ videobridge {
     }
     http-servers {
         private { 
-          host = 0.0.0.0
+          host = "{{ .Env.JVB_HTTP_SERVER_PRIVATE_ADDRESS | default "0.0.0.0" }}"
+          port = "{{ .Env.JVB_HTTP_SERVER_PRIVATE_PORT | default "8080" }}"
         }
         public {
-            host = 0.0.0.0
-            port = 9090
+            host = "{{ .Env.JVB_HTTP_SERVER_PUBLIC_ADDRESS | default "0.0.0.0" }}"
+            port = "{{ .Env.JVB_HTTP_SERVER_PUBLIC_PORT | default "9090" }}"
         }
     }
 


### PR DESCRIPTION
Those 4 new envs would enable the http server interface to be configured.
This would be especially helpful in a kubernetes environment, where I use `hostNetwork: true` but I don't want the private http server to be exposed to the public.

Default values would stay the same.

Cheers.