### PR TITLE
Add codecs to config, fixing issue with simulcast

### DIFF
--- a/env.example
+++ b/env.example
@@ -376,3 +376,11 @@ RESTART_POLICY=unless-stopped
 
 # Authenticate using external service or just focus external auth window if there is one already.
 # TOKEN_AUTH_URL=https://auth.meet.example.com/{room}
+
+# Codec configuration
+ENABLE_CODEC_VP8: "true"
+ENABLE_CODEC_VP9: "true"
+ENABLE_CODEC_H264: "true"
+
+# If you wish to use h.264 as codec, then you must disable simulcast below since JVB does not support it with h.264
+ENABLE_SIMULCAST: "true"


### PR DESCRIPTION
Added environment variables to the default Docker configuration.
Added a little note to disable simulcast when H264 is used.

This fixes #981