### PR TITLE
Add DEFAULT_LANGUAGE environment variable for web config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
             - ENABLE_PREJOIN_PAGE
             - ENABLE_WELCOME_PAGE
             - ENABLE_CLOSE_PAGE
+            - DEFAULT_LANGUAGE
             - ENABLE_RECORDING
             - ENABLE_REMB
             - ENABLE_REQUIRE_DISPLAY_NAME

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
             - CHROME_EXTENSION_BANNER_JSON
             - CONFCODE_URL
             - CONFIG_EXTERNAL_CONNECT
+            - DEFAULT_LANGUAGE
             - DEPLOYMENTINFO_ENVIRONMENT
             - DEPLOYMENTINFO_ENVIRONMENT_TYPE
             - DEPLOYMENTINFO_REGION
@@ -57,7 +58,6 @@ services:
             - ENABLE_PREJOIN_PAGE
             - ENABLE_WELCOME_PAGE
             - ENABLE_CLOSE_PAGE
-            - DEFAULT_LANGUAGE
             - ENABLE_RECORDING
             - ENABLE_REMB
             - ENABLE_REQUIRE_DISPLAY_NAME

--- a/web/rootfs/defaults/settings-config.js
+++ b/web/rootfs/defaults/settings-config.js
@@ -246,6 +246,11 @@ config.enableWelcomePage = {{ $ENABLE_WELCOME_PAGE }};
 // Close page.
 config.enableClosePage = {{ $ENABLE_CLOSE_PAGE }};
 
+// Default language.
+{{ if .Env.DEFAULT_LANGUAGE -}}
+config.defaultLanguage = '{{ .Env.DEFAULT_LANGUAGE }}';
+{{ end -}}
+
 // Require users to always specify a display name.
 config.requireDisplayName = {{ $ENABLE_REQUIRE_DISPLAY_NAME }};
 


### PR DESCRIPTION
To set defaultLanguage value in web/config.js, I added support of DEFAULT_LANGUAGE environment variable.

I hope everything is OK. I tried to put it in the same place than in config.js
Thanks!