### PR TITLE
web: add FLoC environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
             - ${CONFIG}/transcripts:/usr/share/jitsi-meet/transcripts:Z
         environment:
             - ENABLE_COLIBRI_WEBSOCKET
+            - ENABLE_FLOC
             - ENABLE_LETSENCRYPT
             - ENABLE_HTTP_REDIRECT
             - ENABLE_HSTS

--- a/env.example
+++ b/env.example
@@ -357,6 +357,10 @@ JIBRI_LOGS_DIR=/config/logs
 # Disable HTTPS: handle TLS connections outside of this setup
 #DISABLE_HTTPS=1
 
+# Enable FLoC
+# Opt-In to Federated Learning of Cohorts tracking
+#ENABLE_FLOC=0
+
 # Redirect HTTP traffic to HTTPS
 # Necessary for Let's Encrypt, relies on standard HTTPS port (443)
 #ENABLE_HTTP_REDIRECT=1

--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -22,6 +22,10 @@ add_header X-XSS-Protection "1; mode=block";
 add_header X-Jitsi-Shard {{ .Env.DEPLOYMENTINFO_SHARD }};
 {{ end }}
 
+{{ if not (.Env.ENABLE_FLOC | default "0" | toBool) }}
+add_header Permissions-Policy "interest-cohort=()";
+{{ end }}
+
 location = /config.js {
     alias /config/config.js;
 }


### PR DESCRIPTION
Dear Jitsi Meet community,

This PR is intended to give users of the Jitsi Web container image an option to Opt-In their site's visitors to a new feature being rolled out in Google Chrome called FLoC (Federated Learning of Cohorts).

FLoC is intended to be a more privacy oriented tracking mechanism then what was previously possible with (now phased out) third-party cookies. IMHO this is still a tracking mechanism, even if it is supposed to be more benign then other tracking methods. Further background on FLoC can be found at the [EFF](https://www.eff.org/deeplinks/2021/03/googles-floc-terrible-idea), [W3C](https://wicg.github.io/floc/) or [Google](https://github.com/google/ads-privacy/blob/master/proposals/FLoC/FLOC-Whitepaper-Google.pdf), to offer some different view points. As far as we know, at this time this feature is only implemented by Google Chrome and not yet enabled for all Chrome users, only for a random subset of Chrome users by way of an experiment.

This PR suggests to introduce a new environment variable `DISABLE_FLOC`. If not set or set to `1`, the following HTTP header is added in the nginx configuration, sent in reply to any request: `Permissions-Policy interest-cohort=()`. The intent of this new flag is to disable this tracking mechanism by default, but provide Jitsi admins a mechanism to Opt-In their site's visitors to this tracking method, by setting `DISABLE_FLOC=0`. This will remove that HTTP header and the Chrome browser may start to include visits to the site into their cohort learning.

I attempted to update all files that refer to environment variables. Please advise if there are any documentations that this should get included into or if you have any policies on the naming or ordering of such variables. And of course any other suggestions for improving this PR, if you consider it for inclusion.