### PR TITLE
Add missing websockets config to example .env

### DIFF
--- a/env.example
+++ b/env.example
@@ -44,6 +44,9 @@ TZ=UTC
 # Public URL for the web service (required)
 #PUBLIC_URL=https://meet.example.com:8443
 
+# Enable websocket connections required for participating video calls
+ENABLE_WEBSOCKETS=true
+
 # IP address of the Docker host
 # See the "Running behind NAT or on a LAN environment" section in the Handbook:
 # https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-docker#running-behind-nat-or-on-a-lan-environment
@@ -229,6 +232,9 @@ XMPP_GUEST_DOMAIN=guest.meet.jitsi
 # Comma separated list of domains for cross domain policy or "true" to allow all
 # The PUBLIC_URL is always allowed
 #XMPP_CROSS_DOMAIN=true
+
+# Enable websocket connections required for participating video calls
+ENABLE_XMPP_WEBSOCKETS=true
 
 # Custom Prosody modules for XMPP_DOMAIN (comma separated)
 XMPP_MODULES=


### PR DESCRIPTION
The example environment file lacks the ENABLE_XMPP_WEBSOCKETS variable
which has to be configured in order for video calls to work. This should
be part of the initial example configuration so new folks won't get
confused and frustrated.