### PR TITLE
Add domain mapper options to default prosody configuration

### DIFF
--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -4,6 +4,8 @@ admins = {
 }
 
 plugin_paths = { "/prosody-plugins/", "/prosody-plugins-custom" }
+-- domain mapper options, must at least have domain base set to use the mapper
+muc_mapper_domain_base = "{{ .Env.XMPP_DOMAIN }}";
 http_default_host = "{{ .Env.XMPP_DOMAIN }}"
 
 {{ $ENABLE_AUTH := .Env.ENABLE_AUTH | default "0" | toBool }}


### PR DESCRIPTION
From https://github.com/jitsi/jitsi-meet/pull/8386#issuecomment-845889288