### PR TITLE
prosody: fix: restrict room creation to jicofo

### DIFF
--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -148,6 +148,7 @@ Component "{{ .Env.XMPP_INTERNAL_MUC_DOMAIN }}" "muc"
         "{{ join "\";\n\"" (splitList "," .Env.XMPP_INTERNAL_MUC_MODULES) }}";
         {{ end }}
     }
+    restrict_room_creation = true
     muc_room_locking = false
     muc_room_default_public_jids = true
 


### PR DESCRIPTION
This updates prosody to only allow admins such as jicofo to create muc's in the primary muc namespace