### PR TITLE
jibri: allow graceful shutdown of the container

### DIFF
--- a/jibri/rootfs/etc/services.d/30-jibri/finish
+++ b/jibri/rootfs/etc/services.d/30-jibri/finish
@@ -1,0 +1,9 @@
+#!/usr/bin/with-contenv bash
+
+# When jibri is shutdown (or gracefully shutdown), it exits with code 255.
+# In this case, we don't want S6 to restart the service. We want to stop all
+# services and shutdown the container.
+
+if [[ $1 -eq 255 ]]; then
+  s6-svscanctl -t /var/run/s6/services
+fi


### PR DESCRIPTION
With its internal API, jibri provides a way to shutdown (gracefully or not) its service. But since jibri is managed by s6 supervisor in this docker image, the jibri service is always restarted.

s6 allows to write custom finish scripts for each service. They are called when the service process is stopped.
This commit introduces a custom handler that stops all s6 services when jibri has been shutdown via its API.
