### PR TITLE
Adds turn config.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,6 +173,12 @@ services:
             - LOG_LEVEL
             - PUBLIC_URL
             - TZ
+            - ENABLE_TURN
+            - TURN_SECRET
+            - TURN_HOST
+            - TURN_PORT
+            - TURN_TRANSPORT
+            - TURN_TYPE
         networks:
             meet.jitsi:
                 aliases:

--- a/env.example
+++ b/env.example
@@ -380,3 +380,21 @@ RESTART_POLICY=unless-stopped
 
 # Authenticate using external service or just focus external auth window if there is one already.
 # TOKEN_AUTH_URL=https://auth.meet.example.com/{room}
+
+# Use TURN for JVB (bridge mode) connections
+#ENABLE_TURN=0
+
+# Secret for connect to TURN server (required if ENABLE_TURN=1)
+#TURN_SECRET=
+
+# Annonce FQDN or IP address of turn server (required if ENABLE_TURN=1)
+#TURN_HOST=
+
+# TLS/TCP/UDP turn port for connection
+#TURN_PORT=3478
+
+# Type of TURN(s)/STUN. Can be turn or turns.
+#TURN_TYPE=turns
+
+# Transport for stun/turn connection. Can be tcp or udp.
+#TURN_TRANSPORT=tcp

--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -95,6 +95,9 @@ VirtualHost "{{ .Env.XMPP_DOMAIN }}"
         {{ if and $ENABLE_AUTH (eq $AUTH_TYPE "ldap") }}
         "auth_cyrus";
         {{end}}
+        {{ if .Env.ENABLE_TURN | default "0" | toBool }}
+        "turncredentials";
+        {{end}}
     }
 
     {{ if $ENABLE_LOBBY }}

--- a/prosody/rootfs/defaults/prosody.cfg.lua
+++ b/prosody/rootfs/defaults/prosody.cfg.lua
@@ -171,4 +171,17 @@ smacks_hibernation_time = 60;
 smacks_max_hibernated_sessions = 1;
 smacks_max_old_sessions = 1;
 
+{{ if .Env.ENABLE_TURN | default "0" | toBool }}
+turncredentials_secret = "{{ .Env.TURN_SECRET }}";
+turncredentials_ttl = "{{ .Env.TURN_TTL | default "86400" }}";
+turncredentials = {
+    {
+    type = "{{ .Env.TURN_PROTO | default "turns" }}",
+    host = "{{ .Env.TURN_HOST }}",
+    port = "{{ .Env.TURN_PORT | default "3478" }}",
+    transport = "{{ .Env.TURN_TRANSPORT | default "tcp" }}"
+    }
+}
+{{ end }}
+
 Include "conf.d/*.cfg.lua"

--- a/prosody/rootfs/etc/cont-init.d/10-config
+++ b/prosody/rootfs/etc/cont-init.d/10-config
@@ -25,6 +25,17 @@ if [[ "$(stat -c %U /prosody-plugins-custom)" != "prosody" ]]; then
     chown -R prosody /prosody-plugins-custom
 fi
 
+if [[ "${ENABLE_TURN}" == "1" || "${ENABLE_TURN}" == "true" ]]; then
+    if [[ -z $TURN_HOST ]]; then
+        echo 'FATAL ERROR: TURN_HOST must be set when ENABLE_TURN is true.'
+        exit 1
+    fi
+    if [[ -z $TURN_SECRET ]]; then
+        echo 'FATAL ERROR: TURN_SECRET must be set when ENABLE_TURN is true.'
+        exit 1
+    fi
+fi
+
 cp -r /defaults/* /config
 tpl /defaults/prosody.cfg.lua > $PROSODY_CFG
 tpl /defaults/conf.d/jitsi-meet.cfg.lua > /config/conf.d/jitsi-meet.cfg.lua


### PR DESCRIPTION
Based on the work of https://github.com/jitsi/docker-jitsi-meet/pull/163 and https://github.com/jitsi/docker-jitsi-meet/pull/667
I add this PR.

It adds the possibility to configure turn server.

The idea is to first add the possibility to have turn config in another server.

This is already useful per se, and then other PR can build on top to add the possibility to host the turn server directly in docker-compose.

I just tested and deployed to prod on my side.

Hope it can be merged faster than the previous ones ;)