### PR TITLE
Fix: Dockerfile cleanup

### DIFF
--- a/base-java/Dockerfile
+++ b/base-java/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_TAG=latest
 FROM ${JITSI_REPO}/base:${BASE_TAG}
 
 RUN mkdir -p /usr/share/man/man1 && \
-    wget -q https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public -O /etc/apt/trusted.gpg.d/openjdk.asc && \
+    wget -qO /etc/apt/trusted.gpg.d/openjdk.asc https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public && \
     echo "deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ buster main" > /etc/apt/sources.list.d/openjdk.list && \
     apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y adoptopenjdk-8-hotspot-jre && \

--- a/base-java/Dockerfile
+++ b/base-java/Dockerfile
@@ -2,8 +2,7 @@ ARG JITSI_REPO=jitsi
 ARG BASE_TAG=latest
 FROM ${JITSI_REPO}/base:${BASE_TAG}
 
-RUN    \
-    mkdir -p /usr/share/man/man1 && \
+RUN mkdir -p /usr/share/man/man1 && \
     wget -q https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public -O /etc/apt/trusted.gpg.d/openjdk.asc && \
     echo "deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ buster main" > /etc/apt/sources.list.d/openjdk.list && \
     apt-dpkg-wrap apt-get update && \

--- a/base-java/Dockerfile
+++ b/base-java/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_TAG=latest
 FROM ${JITSI_REPO}/base:${BASE_TAG}
 
 RUN mkdir -p /usr/share/man/man1 && \
-    wget -qO /etc/apt/trusted.gpg.d/openjdk.asc https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public && \
+    wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | gpg --dearmour > /etc/apt/trusted.gpg.d/openjdk.gpg && \
     echo "deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ buster main" > /etc/apt/sources.list.d/openjdk.list && \
     apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y adoptopenjdk-8-hotspot-jre && \

--- a/base-java/Dockerfile
+++ b/base-java/Dockerfile
@@ -2,10 +2,10 @@ ARG JITSI_REPO=jitsi
 ARG BASE_TAG=latest
 FROM ${JITSI_REPO}/base:${BASE_TAG}
 
-RUN	\
-	mkdir -p /usr/share/man/man1 && \
-	wget -q https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public -O /etc/apt/trusted.gpg.d/openjdk.asc && \
-	echo "deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ buster main" > /etc/apt/sources.list.d/openjdk.list && \
-	apt-dpkg-wrap apt-get update && \
-	apt-dpkg-wrap apt-get install -y adoptopenjdk-8-hotspot-jre && \
-	apt-cleanup
+RUN    \
+    mkdir -p /usr/share/man/man1 && \
+    wget -q https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public -O /etc/apt/trusted.gpg.d/openjdk.asc && \
+    echo "deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ buster main" > /etc/apt/sources.list.d/openjdk.list && \
+    apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y adoptopenjdk-8-hotspot-jre && \
+    apt-cleanup

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -10,7 +10,7 @@ COPY rootfs /
 RUN apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y apt-transport-https apt-utils ca-certificates gnupg wget && \
     wget -qO - https://github.com/just-containers/s6-overlay/releases/download/v1.22.1.0/s6-overlay-amd64.tar.gz | tar xfz - -C / && \
-    wget -qO /etc/apt/trusted.gpg.d/jitsi.asc https://download.jitsi.org/jitsi-key.gpg.key && \
+    wget -qO - https://download.jitsi.org/jitsi-key.gpg.key | gpg --dearmour > /etc/apt/trusted.gpg.d/jitsi.gpg && \
     wget -qO /usr/bin/frep https://github.com/subchen/frep/releases/download/v$FREP_VERSION/frep-$FREP_VERSION-linux-amd64 && \
     echo "deb https://download.jitsi.org $JITSI_RELEASE/" > /etc/apt/sources.list.d/jitsi.list && \
     echo "deb http://ftp.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -10,8 +10,8 @@ COPY rootfs /
 RUN apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y apt-transport-https apt-utils ca-certificates gnupg wget && \
     wget -qO - https://github.com/just-containers/s6-overlay/releases/download/v1.22.1.0/s6-overlay-amd64.tar.gz | tar xfz - -C / && \
-    wget -qO - https://download.jitsi.org/jitsi-key.gpg.key -O /etc/apt/trusted.gpg.d/jitsi.asc && \
-    wget -q https://github.com/subchen/frep/releases/download/v$FREP_VERSION/frep-$FREP_VERSION-linux-amd64 -O /usr/bin/frep && \
+    wget -qO /etc/apt/trusted.gpg.d/jitsi.asc https://download.jitsi.org/jitsi-key.gpg.key && \
+    wget -qO /usr/bin/frep https://github.com/subchen/frep/releases/download/v$FREP_VERSION/frep-$FREP_VERSION-linux-amd64 && \
     echo "deb https://download.jitsi.org $JITSI_RELEASE/" > /etc/apt/sources.list.d/jitsi.list && \
     echo "deb http://ftp.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && \
     apt-dpkg-wrap apt-get update && \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -7,8 +7,7 @@ ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2
 
 COPY rootfs /
 
-RUN \
-    apt-dpkg-wrap apt-get update && \
+RUN apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y apt-transport-https apt-utils ca-certificates gnupg wget && \
     wget -qO - https://github.com/just-containers/s6-overlay/releases/download/v1.22.1.0/s6-overlay-amd64.tar.gz | tar xfz - -C / && \
     wget -qO - https://download.jitsi.org/jitsi-key.gpg.key -O /etc/apt/trusted.gpg.d/jitsi.asc && \
@@ -20,8 +19,7 @@ RUN \
     apt-cleanup && \
     chmod +x /usr/bin/frep
 
-RUN \
-    [ "$JITSI_RELEASE" = "unstable" ] && \
+RUN [ "$JITSI_RELEASE" = "unstable" ] && \
     apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y jq procps curl vim iputils-ping net-tools && \
     apt-cleanup || \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -8,23 +8,23 @@ ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2
 COPY rootfs /
 
 RUN \
-	apt-dpkg-wrap apt-get update && \
-	apt-dpkg-wrap apt-get install -y apt-transport-https apt-utils ca-certificates gnupg wget && \
-	wget -qO - https://github.com/just-containers/s6-overlay/releases/download/v1.22.1.0/s6-overlay-amd64.tar.gz | tar xfz - -C / && \
-	wget -qO - https://download.jitsi.org/jitsi-key.gpg.key -O /etc/apt/trusted.gpg.d/jitsi.asc && \
-	wget -q https://github.com/subchen/frep/releases/download/v$FREP_VERSION/frep-$FREP_VERSION-linux-amd64 -O /usr/bin/frep && \
-	echo "deb https://download.jitsi.org $JITSI_RELEASE/" > /etc/apt/sources.list.d/jitsi.list && \
-	echo "deb http://ftp.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && \
-	apt-dpkg-wrap apt-get update && \
-	apt-dpkg-wrap apt-get dist-upgrade -y && \
-	apt-cleanup && \
-	chmod +x /usr/bin/frep
+    apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y apt-transport-https apt-utils ca-certificates gnupg wget && \
+    wget -qO - https://github.com/just-containers/s6-overlay/releases/download/v1.22.1.0/s6-overlay-amd64.tar.gz | tar xfz - -C / && \
+    wget -qO - https://download.jitsi.org/jitsi-key.gpg.key -O /etc/apt/trusted.gpg.d/jitsi.asc && \
+    wget -q https://github.com/subchen/frep/releases/download/v$FREP_VERSION/frep-$FREP_VERSION-linux-amd64 -O /usr/bin/frep && \
+    echo "deb https://download.jitsi.org $JITSI_RELEASE/" > /etc/apt/sources.list.d/jitsi.list && \
+    echo "deb http://ftp.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && \
+    apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get dist-upgrade -y && \
+    apt-cleanup && \
+    chmod +x /usr/bin/frep
 
 RUN \
-	[ "$JITSI_RELEASE" = "unstable" ] && \
-	apt-dpkg-wrap apt-get update && \
-	apt-dpkg-wrap apt-get install -y jq procps curl vim iputils-ping net-tools && \
-	apt-cleanup || \
-	true
+    [ "$JITSI_RELEASE" = "unstable" ] && \
+    apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y jq procps curl vim iputils-ping net-tools && \
+    apt-cleanup || \
+    true
 
 ENTRYPOINT [ "/init" ]

--- a/jibri/Dockerfile
+++ b/jibri/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y jibri libgl1-mesa-dri procps && \
     apt-cleanup && \
     [ "${CHROME_RELEASE}" = "latest" ] && \
-    wget -q https://dl-ssl.google.com/linux/linux_signing_key.pub -O /etc/apt/trusted.gpg.d/google.asc && \
+    wget -qO /etc/apt/trusted.gpg.d/google.asc https://dl-ssl.google.com/linux/linux_signing_key.pub && \
     echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list && \
     apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y google-chrome-stable && \

--- a/jibri/Dockerfile
+++ b/jibri/Dockerfile
@@ -10,35 +10,35 @@ ARG CHROMEDRIVER_MAJOR_RELEASE=90
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN \
-	apt-dpkg-wrap apt-get update \
-	&& apt-dpkg-wrap apt-get install -y jibri libgl1-mesa-dri procps \
-	&& apt-cleanup
+    apt-dpkg-wrap apt-get update \
+    && apt-dpkg-wrap apt-get install -y jibri libgl1-mesa-dri procps \
+    && apt-cleanup
 
 RUN \
-	[ "${CHROME_RELEASE}" = "latest" ] \
-	&& wget -q https://dl-ssl.google.com/linux/linux_signing_key.pub -O /etc/apt/trusted.gpg.d/google.asc \
-	&& echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
-	&& apt-dpkg-wrap apt-get update \
-	&& apt-dpkg-wrap apt-get install -y google-chrome-stable \
-	&& apt-cleanup \
-	|| true
+    [ "${CHROME_RELEASE}" = "latest" ] \
+    && wget -q https://dl-ssl.google.com/linux/linux_signing_key.pub -O /etc/apt/trusted.gpg.d/google.asc \
+    && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
+    && apt-dpkg-wrap apt-get update \
+    && apt-dpkg-wrap apt-get install -y google-chrome-stable \
+    && apt-cleanup \
+    || true
 
 RUN \
     [ "${CHROME_RELEASE}" != "latest" ] \
     && curl -4so "/tmp/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb" "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb" \
-	&& apt-dpkg-wrap apt-get update \
+    && apt-dpkg-wrap apt-get update \
     && apt-dpkg-wrap apt-get install -y "/tmp/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb" \
-	&& apt-cleanup \
-	|| true
+    && apt-cleanup \
+    || true
 
 RUN \
-	[ "${CHROMEDRIVER_MAJOR_RELEASE}" = "latest" ] \
-	&& CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE)" \
-	|| CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROMEDRIVER_MAJOR_RELEASE})" \
-	&& curl -4Ls "https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_RELEASE}/chromedriver_linux64.zip" \
-	| zcat >> /usr/bin/chromedriver \
-	&& chmod +x /usr/bin/chromedriver \
-	&& chromedriver --version
+    [ "${CHROMEDRIVER_MAJOR_RELEASE}" = "latest" ] \
+    && CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE)" \
+    || CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROMEDRIVER_MAJOR_RELEASE})" \
+    && curl -4Ls "https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_RELEASE}/chromedriver_linux64.zip" \
+    | zcat >> /usr/bin/chromedriver \
+    && chmod +x /usr/bin/chromedriver \
+    && chromedriver --version
 
 RUN \
         apt-dpkg-wrap apt-get update \

--- a/jibri/Dockerfile
+++ b/jibri/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y jibri libgl1-mesa-dri procps && \
     apt-cleanup && \
     [ "${CHROME_RELEASE}" = "latest" ] && \
-    wget -qO /etc/apt/trusted.gpg.d/google.asc https://dl-ssl.google.com/linux/linux_signing_key.pub && \
+    wget -qO - https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmour /etc/apt/trusted.gpg.d/google.gpg && \
     echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list && \
     apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y google-chrome-stable && \

--- a/jibri/Dockerfile
+++ b/jibri/Dockerfile
@@ -9,43 +9,31 @@ ARG CHROMEDRIVER_MAJOR_RELEASE=90
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN \
-    apt-dpkg-wrap apt-get update \
-    && apt-dpkg-wrap apt-get install -y jibri libgl1-mesa-dri procps \
-    && apt-cleanup
-
-RUN \
-    [ "${CHROME_RELEASE}" = "latest" ] \
-    && wget -q https://dl-ssl.google.com/linux/linux_signing_key.pub -O /etc/apt/trusted.gpg.d/google.asc \
-    && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
-    && apt-dpkg-wrap apt-get update \
-    && apt-dpkg-wrap apt-get install -y google-chrome-stable \
-    && apt-cleanup \
-    || true
-
-RUN \
-    [ "${CHROME_RELEASE}" != "latest" ] \
-    && curl -4so "/tmp/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb" "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb" \
-    && apt-dpkg-wrap apt-get update \
-    && apt-dpkg-wrap apt-get install -y "/tmp/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb" \
-    && apt-cleanup \
-    || true
-
-RUN \
-    [ "${CHROMEDRIVER_MAJOR_RELEASE}" = "latest" ] \
-    && CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE)" \
-    || CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROMEDRIVER_MAJOR_RELEASE})" \
-    && curl -4Ls "https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_RELEASE}/chromedriver_linux64.zip" \
-    | zcat >> /usr/bin/chromedriver \
-    && chmod +x /usr/bin/chromedriver \
-    && chromedriver --version
-
-RUN \
-        apt-dpkg-wrap apt-get update \
-        && apt-dpkg-wrap apt-get install -y jitsi-upload-integrations jq \
-        && apt-cleanup
+RUN apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y jibri libgl1-mesa-dri procps && \
+    apt-cleanup && \
+    [ "${CHROME_RELEASE}" = "latest" ] && \
+    wget -q https://dl-ssl.google.com/linux/linux_signing_key.pub -O /etc/apt/trusted.gpg.d/google.asc && \
+    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list && \
+    apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y google-chrome-stable && \
+    apt-cleanup || \
+    [ "${CHROME_RELEASE}" != "latest" ] && \
+    curl -4so "/tmp/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb" "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb" && \
+    apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y "/tmp/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb" && \
+    apt-cleanup || \
+    [ "${CHROMEDRIVER_MAJOR_RELEASE}" = "latest" ] && \
+    CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE)" || \
+    CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROMEDRIVER_MAJOR_RELEASE})" && \
+    curl -4Ls "https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_RELEASE}/chromedriver_linux64.zip" \
+    | zcat >> /usr/bin/chromedriver && \
+    chmod +x /usr/bin/chromedriver && \
+    chromedriver --version && \
+    apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y jitsi-upload-integrations jq && \
+    apt-cleanup
 
 COPY rootfs/ /
 
 VOLUME /config
-

--- a/jicofo/Dockerfile
+++ b/jicofo/Dockerfile
@@ -2,12 +2,10 @@ ARG JITSI_REPO=jitsi
 ARG BASE_TAG=latest
 FROM ${JITSI_REPO}/base-java:${BASE_TAG}
 
-RUN \
-    apt-dpkg-wrap apt-get update && \
+RUN apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y jicofo && \
     apt-cleanup
 
 COPY rootfs/ /
 
 VOLUME /config
-

--- a/jicofo/Dockerfile
+++ b/jicofo/Dockerfile
@@ -3,9 +3,9 @@ ARG BASE_TAG=latest
 FROM ${JITSI_REPO}/base-java:${BASE_TAG}
 
 RUN \
-	apt-dpkg-wrap apt-get update && \
-	apt-dpkg-wrap apt-get install -y jicofo && \
-	apt-cleanup
+    apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y jicofo && \
+    apt-cleanup
 
 COPY rootfs/ /
 

--- a/jigasi/Dockerfile
+++ b/jigasi/Dockerfile
@@ -4,8 +4,7 @@ FROM ${JITSI_REPO}/base-java:${BASE_TAG}
 
 ENV GOOGLE_APPLICATION_CREDENTIALS /config/key.json
 
-RUN \
-    apt-dpkg-wrap apt-get update && \
+RUN apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y jigasi jq && \
     apt-cleanup
 

--- a/jigasi/Dockerfile
+++ b/jigasi/Dockerfile
@@ -5,9 +5,9 @@ FROM ${JITSI_REPO}/base-java:${BASE_TAG}
 ENV GOOGLE_APPLICATION_CREDENTIALS /config/key.json
 
 RUN \
-	apt-dpkg-wrap apt-get update && \
-	apt-dpkg-wrap apt-get install -y jigasi jq && \
-	apt-cleanup
+    apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y jigasi jq && \
+    apt-cleanup
 
 COPY rootfs/ /
 

--- a/jvb/Dockerfile
+++ b/jvb/Dockerfile
@@ -3,9 +3,9 @@ ARG BASE_TAG=latest
 FROM ${JITSI_REPO}/base-java:${BASE_TAG}
 
 RUN \
-	apt-dpkg-wrap apt-get update && \
-	apt-dpkg-wrap apt-get install -y jitsi-videobridge2 jq curl iproute2 && \
-	apt-cleanup
+    apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y jitsi-videobridge2 jq curl iproute2 && \
+    apt-cleanup
 
 COPY rootfs/ /
 

--- a/jvb/Dockerfile
+++ b/jvb/Dockerfile
@@ -2,8 +2,7 @@ ARG JITSI_REPO=jitsi
 ARG BASE_TAG=latest
 FROM ${JITSI_REPO}/base-java:${BASE_TAG}
 
-RUN \
-    apt-dpkg-wrap apt-get update && \
+RUN apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y jitsi-videobridge2 jq curl iproute2 && \
     apt-cleanup
 

--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -3,29 +3,27 @@ ARG BASE_TAG=latest
 
 FROM ${JITSI_REPO}/base:${BASE_TAG} as builder
 
-RUN \
-    apt-dpkg-wrap apt-get update \
-    && apt-dpkg-wrap apt-get install -y \
+RUN apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y \
       lua5.2 \
       liblua5.2-dev \
       libsasl2-dev \
       libssl-dev \
       luarocks \
       git \
-      gcc \
-    && luarocks install cyrussasl 1.1.0-1 \
-    && luarocks install net-url 0.9-1 \
-    && luarocks install luajwtjitsi 2.0-0
+      gcc && \
+    luarocks install cyrussasl 1.1.0-1 && \
+    luarocks install net-url 0.9-1 && \
+    luarocks install luajwtjitsi 2.0-0
 
 FROM ${JITSI_REPO}/base:${BASE_TAG}
 
 ENV XMPP_CROSS_DOMAIN="false"
 
-RUN \
-    wget -q https://prosody.im/files/prosody-debian-packages.key -O - | gpg --enarmor > /etc/apt/trusted.gpg.d/prosody.asc \
-    && echo "deb http://packages.prosody.im/debian buster main" > /etc/apt/sources.list.d/prosody.list \
-    && apt-dpkg-wrap apt-get update \
-    && apt-dpkg-wrap apt-get install -y \
+RUN wget -q https://prosody.im/files/prosody-debian-packages.key -O - | gpg --enarmor > /etc/apt/trusted.gpg.d/prosody.asc && \
+    echo "deb http://packages.prosody.im/debian buster main" > /etc/apt/sources.list.d/prosody.list && \
+    apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y \
       prosody \
       libssl1.1 \
       sasl2-bin \
@@ -33,19 +31,16 @@ RUN \
       lua-basexx \
       lua-ldap \
       lua-sec \
-      patch \
-    && apt-cleanup \
-    && rm -rf /etc/prosody
-
-RUN \
-    apt-dpkg-wrap apt-get update \
-    && apt-dpkg-wrap apt-get -d install -y jitsi-meet-prosody \
-    && dpkg -x /var/cache/apt/archives/jitsi-meet-prosody*.deb /tmp/pkg \
-    && mv /tmp/pkg/usr/share/jitsi-meet/prosody-plugins /prosody-plugins \
-    && apt-cleanup \
-    && rm -rf /tmp/pkg /var/cache/apt
-
-RUN patch -d /usr/lib/prosody/modules/muc -p0 < /prosody-plugins/muc_owner_allow_kick.patch
+      patch && \
+    apt-cleanup && \
+    rm -rf /etc/prosody && \
+    apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get -d install -y jitsi-meet-prosody && \
+    dpkg -x /var/cache/apt/archives/jitsi-meet-prosody*.deb /tmp/pkg && \
+    mv /tmp/pkg/usr/share/jitsi-meet/prosody-plugins /prosody-plugins && \
+    apt-cleanup && \
+    rm -rf /tmp/pkg /var/cache/apt && \
+    patch -d /usr/lib/prosody/modules/muc -p0 < /prosody-plugins/muc_owner_allow_kick.patch
 
 COPY rootfs/ /
 

--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -20,7 +20,7 @@ FROM ${JITSI_REPO}/base:${BASE_TAG}
 
 ENV XMPP_CROSS_DOMAIN="false"
 
-RUN wget -qO - https://prosody.im/files/prosody-debian-packages.key | gpg --enarmor > /etc/apt/trusted.gpg.d/prosody.asc && \
+RUN wget -qO /etc/apt/trusted.gpg.d/prosody.gpg https://prosody.im/files/prosody-debian-packages.key && \
     echo "deb http://packages.prosody.im/debian buster main" > /etc/apt/sources.list.d/prosody.list && \
     apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y \

--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -20,7 +20,7 @@ FROM ${JITSI_REPO}/base:${BASE_TAG}
 
 ENV XMPP_CROSS_DOMAIN="false"
 
-RUN wget -q https://prosody.im/files/prosody-debian-packages.key -O - | gpg --enarmor > /etc/apt/trusted.gpg.d/prosody.asc && \
+RUN wget -qO - https://prosody.im/files/prosody-debian-packages.key | gpg --enarmor > /etc/apt/trusted.gpg.d/prosody.asc && \
     echo "deb http://packages.prosody.im/debian buster main" > /etc/apt/sources.list.d/prosody.list && \
     apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y \

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -5,8 +5,7 @@ FROM ${JITSI_REPO}/base:${BASE_TAG}
 ADD https://raw.githubusercontent.com/acmesh-official/acme.sh/2.8.8/acme.sh /opt
 COPY rootfs/ /
 
-RUN \
-    apt-dpkg-wrap apt-get update && \
+RUN apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y cron nginx-extras jitsi-meet-web socat && \
     apt-dpkg-wrap apt-get -d install -y jitsi-meet-web-config && \
     dpkg -x /var/cache/apt/archives/jitsi-meet-web-config*.deb /tmp/pkg && \

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -6,15 +6,15 @@ ADD https://raw.githubusercontent.com/acmesh-official/acme.sh/2.8.8/acme.sh /opt
 COPY rootfs/ /
 
 RUN \
-	apt-dpkg-wrap apt-get update && \
-	apt-dpkg-wrap apt-get install -y cron nginx-extras jitsi-meet-web socat && \
-	apt-dpkg-wrap apt-get -d install -y jitsi-meet-web-config && \
+    apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y cron nginx-extras jitsi-meet-web socat && \
+    apt-dpkg-wrap apt-get -d install -y jitsi-meet-web-config && \
     dpkg -x /var/cache/apt/archives/jitsi-meet-web-config*.deb /tmp/pkg && \
     mv /tmp/pkg/usr/share/jitsi-meet-web-config/config.js /defaults && \
-	mv /usr/share/jitsi-meet/interface_config.js /defaults && \
-	rm -f /etc/nginx/conf.d/default.conf && \
-	apt-cleanup && \
-	rm -rf /tmp/pkg /var/cache/apt
+    mv /usr/share/jitsi-meet/interface_config.js /defaults && \
+    rm -f /etc/nginx/conf.d/default.conf && \
+    apt-cleanup && \
+    rm -rf /tmp/pkg /var/cache/apt
 
 EXPOSE 80 443
 


### PR DESCRIPTION
This is another take at what I shared with you through #560.
In `Dockerfile`s:
* Replace tabulations with spaces
* Minimise the number of `RUN` stages will help reducing the number of Docker layers, make the overall image history leanier, hence more readable/accountable
* Homogeneise `wget` syntax
* Use binary GPG key format (lower size + usual format used in APT package management)