### PR TITLE
Fix acme.sh pre and post hooks

### DIFF
--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -25,8 +25,8 @@ if [[ $DISABLE_HTTPS -ne 1 ]]; then
             $STAGING \
             --issue \
             --standalone \
-            --pre-hook "if [[ -f /var/run/s6/services/nginx ]]; then s6-svc -d /var/run/s6/services/nginx; fi" \
-            --post-hook "if [[ -f /var/run/s6/services/nginx ]]; then s6-svc -u /var/run/s6/services/nginx; fi" \
+            --pre-hook "if [[ -d /var/run/s6/services/nginx ]]; then s6-svc -d /var/run/s6/services/nginx; fi" \
+            --post-hook "if [[ -d /var/run/s6/services/nginx ]]; then s6-svc -u /var/run/s6/services/nginx; fi" \
             -d $LETSENCRYPT_DOMAIN
         rc=$?
         if [[ $rc -eq 1 ]]; then


### PR DESCRIPTION
On my system, letsencrypt did not auto-renew the acme certificate. Desk checking the code, I found the the pre- and post hooks, that stop nginx during the acme processing, check for the existence of a directory with `test -f`. That should probably be `test -d` or `test -e`. After I manually re-ran with `-d` in my container, the certificate was renewed.

I noticed that acme.sh --install writes a cronjob to a non-persistent location in the container, and that this cron job won't work anyway because it doesn't seem to have the pre/post hooks. I did not address those issues because if that amount of work gets put into fixing this, it would probably be better to rework the mechanism to use a `.well-known` directory served by nginx, which seems to be on the roadmap.