### PR TITLE
prosody: authentication by matrix user authentication service (jitsi#1083)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,6 +170,10 @@ services:
             - JWT_ALLOW_EMPTY
             - JWT_AUTH_TYPE
             - JWT_TOKEN_AUTH_MODULE
+            - MATRIX_UVS_URL
+            - MATRIX_UVS_ISSUER
+            - MATRIX_UVS_AUTH_TOKEN
+            - MATRIX_UVS_SYNC_POWER_LEVELS
             - LOG_LEVEL
             - PUBLIC_URL
             - TZ

--- a/env.example
+++ b/env.example
@@ -136,7 +136,7 @@ ETHERPAD_SKIN_VARIANTS=super-light-toolbar super-light-editor light-background f
 # Enable guest access
 #ENABLE_GUESTS=1
 
-# Select authentication type: internal, jwt or ldap
+# Select authentication type: internal, jwt, ldap or matrix
 #AUTH_TYPE=internal
 
 # JWT authentication
@@ -199,6 +199,22 @@ ETHERPAD_SKIN_VARIANTS=super-light-toolbar super-light-editor light-background f
 
 # Wether to use starttls, implies LDAPv3 and requires ldap:// instead of ldaps://
 # LDAP_START_TLS=1
+
+
+# Matrix authentication (for more information see the documention of the "Prosody Auth Matrix User Verification" at https://github.com/matrix-org/prosody-mod-auth-matrix-user-verification)
+#
+
+# Base URL to the matrix user verification service (without ending slash)
+#MATRIX_UVS_URL=https://uvs.example.com:3000
+
+# (optional) The issuer of the auth token to be passed through. Must match what is being set as `iss` in the JWT. Defaut value is "issuer".
+#MATRIX_UVS_ISSUER=issuer
+
+# (optional) user verification service auth token, if authentication enabled
+#MATRIX_UVS_AUTH_TOKEN=changeme
+
+# (optional) Make Matrix room moderators owners of the Prosody room.
+#MATRIX_UVS_SYNC_POWER_LEVELS=1
 
 
 #

--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -20,7 +20,6 @@ FROM ${JITSI_REPO}/base:${BASE_TAG}
 
 ENV XMPP_CROSS_DOMAIN="false"
 
-ARG PROSODY_PLUGINS_FOLDER="/prosody-plugins"
 ARG VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN="1.7.0"
 
 RUN wget -qO /etc/apt/trusted.gpg.d/prosody.gpg https://prosody.im/files/prosody-debian-packages.key && \
@@ -40,16 +39,15 @@ RUN wget -qO /etc/apt/trusted.gpg.d/prosody.gpg https://prosody.im/files/prosody
     apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get -d install -y jitsi-meet-prosody && \
     dpkg -x /var/cache/apt/archives/jitsi-meet-prosody*.deb /tmp/pkg && \
-    mv /tmp/pkg/usr/share/jitsi-meet/prosody-plugins $PROSODY_PLUGINS_FOLDER && \
+    mv /tmp/pkg/usr/share/jitsi-meet/prosody-plugins /prosody-plugins && \
     apt-cleanup && \
     rm -rf /tmp/pkg /var/cache/apt && \
-    patch -d /usr/lib/prosody/modules/muc -p0 < $PROSODY_PLUGINS_FOLDER/muc_owner_allow_kick.patch
-
-RUN wget https://github.com/matrix-org/prosody-mod-auth-matrix-user-verification/archive/refs/tags/v$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN.tar.gz \
-    && tar -xf v$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN.tar.gz \
-    && mv prosody-mod-auth-matrix-user-verification-$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN/mod_auth_matrix_user_verification.lua $PROSODY_PLUGINS_FOLDER \
-    && mv prosody-mod-auth-matrix-user-verification-$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN/mod_matrix_power_sync.lua $PROSODY_PLUGINS_FOLDER \
-    && rm -rf prosody-mod-auth-matrix-user-verification-$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN v$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN.tar.gz
+    patch -d /usr/lib/prosody/modules/muc -p0 < /prosody-plugins/muc_owner_allow_kick.patch && \
+    wget https://github.com/matrix-org/prosody-mod-auth-matrix-user-verification/archive/refs/tags/v$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN.tar.gz && \
+    tar -xf v$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN.tar.gz && \
+    mv prosody-mod-auth-matrix-user-verification-$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN/mod_auth_matrix_user_verification.lua $PROSODY_PLUGINS_FOLDER && \
+    mv prosody-mod-auth-matrix-user-verification-$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN/mod_matrix_power_sync.lua $PROSODY_PLUGINS_FOLDER && \
+    rm -rf prosody-mod-auth-matrix-user-verification-$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN v$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN.tar.gz
 
 COPY rootfs/ /
 

--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -21,6 +21,9 @@ FROM ${JITSI_REPO}/base:${BASE_TAG}
 
 ENV XMPP_CROSS_DOMAIN="false"
 
+ARG PROSODY_PLUGINS_FOLDER="/prosody-plugins"
+ARG VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN="1.7.0"
+
 RUN \
     wget -q https://prosody.im/files/prosody-debian-packages.key -O - | gpg --enarmor > /etc/apt/trusted.gpg.d/prosody.asc \
     && echo "deb http://packages.prosody.im/debian buster main" > /etc/apt/sources.list.d/prosody.list \
@@ -41,11 +44,17 @@ RUN \
     apt-dpkg-wrap apt-get update \
     && apt-dpkg-wrap apt-get -d install -y jitsi-meet-prosody \
     && dpkg -x /var/cache/apt/archives/jitsi-meet-prosody*.deb /tmp/pkg \
-    && mv /tmp/pkg/usr/share/jitsi-meet/prosody-plugins /prosody-plugins \
+    && mv /tmp/pkg/usr/share/jitsi-meet/prosody-plugins $PROSODY_PLUGINS_FOLDER \
     && apt-cleanup \
     && rm -rf /tmp/pkg /var/cache/apt
 
-RUN patch -d /usr/lib/prosody/modules/muc -p0 < /prosody-plugins/muc_owner_allow_kick.patch
+RUN patch -d /usr/lib/prosody/modules/muc -p0 < $PROSODY_PLUGINS_FOLDER/muc_owner_allow_kick.patch
+
+RUN wget https://github.com/matrix-org/prosody-mod-auth-matrix-user-verification/archive/refs/tags/v$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN.tar.gz \
+    && tar -xf v$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN.tar.gz \
+    && mv prosody-mod-auth-matrix-user-verification-$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN/mod_auth_matrix_user_verification.lua $PROSODY_PLUGINS_FOLDER \
+    && mv prosody-mod-auth-matrix-user-verification-$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN/mod_matrix_power_sync.lua $PROSODY_PLUGINS_FOLDER \
+    && rm -rf prosody-mod-auth-matrix-user-verification-$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN v$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN.tar.gz
 
 COPY rootfs/ /
 

--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -17,6 +17,8 @@ http_default_host = "{{ .Env.XMPP_DOMAIN }}"
 {{ $JWT_ASAP_KEYSERVER := .Env.JWT_ASAP_KEYSERVER | default "" }}
 {{ $JWT_ALLOW_EMPTY := .Env.JWT_ALLOW_EMPTY | default "0" | toBool }}
 {{ $JWT_AUTH_TYPE := .Env.JWT_AUTH_TYPE | default "token" }}
+{{ $MATRIX_UVS_ISSUER := .Env.MATRIX_UVS_ISSUER | default "issuer" }}
+{{ $MATRIX_UVS_SYNC_POWER_LEVELS := .Env.MATRIX_UVS_SYNC_POWER_LEVELS | default "0" | toBool }}
 {{ $JWT_TOKEN_AUTH_MODULE := .Env.JWT_TOKEN_AUTH_MODULE | default "token_verification" }}
 {{ $ENABLE_LOBBY := .Env.ENABLE_LOBBY | default "0" | toBool }}
 
@@ -58,11 +60,20 @@ VirtualHost "{{ .Env.XMPP_DOMAIN }}"
     {{ if $JWT_ASAP_KEYSERVER }}
     asap_key_server = "{{ .Env.JWT_ASAP_KEYSERVER }}"
     {{ end }}
-
-    {{ else if eq $AUTH_TYPE "ldap" }}
+  {{ else if eq $AUTH_TYPE "ldap" }}
     authentication = "cyrus"
     cyrus_application_name = "xmpp"
     allow_unencrypted_plain_auth = true
+  {{ else if eq $AUTH_TYPE "matrix" }}
+    authentication = "matrix_user_verification"
+    app_id = "{{ $MATRIX_UVS_ISSUER }}"
+    uvs_base_url = "{{ .Env.MATRIX_UVS_URL }}"
+    {{ if .Env.MATRIX_UVS_AUTH_TOKEN }}
+    uvs_auth_token = "{{ .Env.MATRIX_UVS_AUTH_TOKEN }}"
+    {{ end }}
+    {{ if $MATRIX_UVS_SYNC_POWER_LEVELS }}
+    uvs_sync_power_levels = true
+    {{ end }}
   {{ else if eq $AUTH_TYPE "internal" }}
     authentication = "internal_hashed"
   {{ end }}
@@ -169,6 +180,9 @@ Component "{{ .Env.XMPP_MUC_DOMAIN }}" "muc"
         {{ end }}
         {{ if and $ENABLE_AUTH (eq $AUTH_TYPE "jwt") }}
         "{{ $JWT_TOKEN_AUTH_MODULE }}";
+        {{ end }}
+        {{ if and $ENABLE_AUTH (eq $AUTH_TYPE "matrix") $MATRIX_UVS_SYNC_POWER_LEVELS }}
+        "matrix_power_sync";
         {{ end }}
     }
     muc_room_cache_size = 1000


### PR DESCRIPTION
Added env variables and prosody plugins to authenticate prosody users by the matrix user authentication service, refer to https://github.com/matrix-org/prosody-mod-auth-matrix-user-verification