### PR TITLE
jicofo: fix boolean values in configuration file

### DIFF
--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -47,7 +47,7 @@ jicofo {
 
       {{ if .Env.JICOFO_ENABLE_BRIDGE_HEALTH_CHECKS }}
       health-checks {
-        enabled = "{{ .Env.JICOFO_ENABLE_BRIDGE_HEALTH_CHECKS }}"
+        enabled = {{ .Env.JICOFO_ENABLE_BRIDGE_HEALTH_CHECKS | toBool }}
       }
       {{ end }}
 
@@ -76,7 +76,7 @@ jicofo {
 
     conference {
       {{ if .Env.ENABLE_AUTO_OWNER }}
-      enable-auto-owner = "{{ .Env.ENABLE_AUTO_OWNER }}"
+      enable-auto-owner = {{ .Env.ENABLE_AUTO_OWNER | toBool }}
       {{ end }}
 
       {{ if .Env.JICOFO_CONF_INITIAL_PARTICIPANT_WAIT_TIMEOUT }}
@@ -92,7 +92,7 @@ jicofo {
     // Configuration for the internal health checks performed by jicofo.
     health {
       // Whether to perform health checks.
-      enabled = "{{ .Env.JICOFO_ENABLE_HEALTH_CHECKS }}"
+      enabled = {{ .Env.JICOFO_ENABLE_HEALTH_CHECKS | toBool }}
     }
     {{ end }}
 


### PR DESCRIPTION

A type error is thrown by jicofo if I try to define one of the following environment variables in my `.env` file:
- `ENABLE_AUTO_OWNER`
- `JICOFO_ENABLE_HEALTH_CHECKS`
- `JICOFO_ENABLE_BRIDGE_HEALTH_CHECKS`

Example, if I set `JICOFO_ENABLE_BRIDGE_HEALTH_CHECKS=1`, I get the following error:

```
org.jitsi.metaconfig.ConfigException$UnableToRetrieve$WrongType: Key 'jicofo.bridge.health-checks.enabled' in source 'typesafe config (reloaded 1 times)': /config/jicofo.conf: 22: jicofo.bridge.health-checks.enabled has type STRING rather than BOOLEAN
```

