### PR TITLE
add enable-auto-login option to jicofo config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,6 +202,7 @@ services:
             - ENABLE_OCTO
             - ENABLE_RECORDING
             - ENABLE_SCTP
+            - ENABLE_AUTO_LOGIN
             - JICOFO_AUTH_USER
             - JICOFO_AUTH_PASSWORD
             - JICOFO_ENABLE_BRIDGE_HEALTH_CHECKS

--- a/env.example
+++ b/env.example
@@ -142,9 +142,6 @@ ETHERPAD_SKIN_VARIANTS=super-light-toolbar super-light-editor light-background f
 # Select authentication type: internal, jwt or ldap
 #AUTH_TYPE=internal
 
-# Enable auto login 
-#ENABLE_AUTO_LOGIN=1
-
 # JWT authentication
 #
 

--- a/env.example
+++ b/env.example
@@ -142,6 +142,9 @@ ETHERPAD_SKIN_VARIANTS=super-light-toolbar super-light-editor light-background f
 # Select authentication type: internal, jwt or ldap
 #AUTH_TYPE=internal
 
+# Enable auto login 
+#ENABLE_AUTO_LOGIN=1
+
 # JWT authentication
 #
 

--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -3,7 +3,7 @@
 {{ $AUTH_TYPE := .Env.AUTH_TYPE | default "internal" }}
 {{ $ENABLE_RECORDING := .Env.ENABLE_RECORDING | default "0" | toBool }}
 {{ $ENABLE_OCTO := .Env.ENABLE_OCTO | default "0" | toBool }}
-{{ $ENABLE_AUTO_LOGIN := .Env.ENABLE_AUTO_LOGIN | default "0" | toBool }}
+{{ $ENABLE_AUTO_LOGIN := .Env.ENABLE_AUTO_LOGIN | default "1" | toBool }}
 
 jicofo {
     {{ if $ENABLE_AUTH }}

--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -23,11 +23,7 @@ jicofo {
       {{ else }}
       login-url = "{{ .Env.XMPP_DOMAIN }}"
       {{ end }}
-      {{ if $ENABLE_AUTO_LOGIN }}
-      enable-auto-login=true
-      {{ else }}
-      enable-auto-login=false
-      {{ end }}
+      enable-auto-login={{ $ENABLE_AUTO_LOGIN }}
     }
     {{ end }}
 

--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -3,6 +3,7 @@
 {{ $AUTH_TYPE := .Env.AUTH_TYPE | default "internal" }}
 {{ $ENABLE_RECORDING := .Env.ENABLE_RECORDING | default "0" | toBool }}
 {{ $ENABLE_OCTO := .Env.ENABLE_OCTO | default "0" | toBool }}
+{{ $ENABLE_AUTO_LOGIN := .Env.ENABLE_AUTO_LOGIN | default "0" | toBool }}
 
 jicofo {
     {{ if $ENABLE_AUTH }}
@@ -21,6 +22,11 @@ jicofo {
       logout-url = "shibboleth:default"
       {{ else }}
       login-url = "{{ .Env.XMPP_DOMAIN }}"
+      {{ end }}
+      {{ if $ENABLE_AUTO_LOGIN }}
+      enable-auto-login=true
+      {{ else }}
+      enable-auto-login=false
       {{ end }}
     }
     {{ end }}


### PR DESCRIPTION
Once an authenticated user login, he is always logged in before the session timeout.  There should be an _enable-auto-login_ option in jicofo to control the auto login.  But you can not configure this option in _.env_ file when you self deploy with docker.

This pull request add an variable in _.env_ file, and modify the _docker-compose.xml_ and _jicofo.conf_ files to add this option.

_env.example_ file:
```javascript
# Enable auto login 
#ENABLE_AUTO_LOGIN=1
```
_docker-compose.xml_ file:
```javascript
            - ENABLE_AUTO_LOGIN
```

_jicofo.conf_ file:
```javascript
...
{{ $ENABLE_AUTO_LOGIN := .Env.ENABLE_AUTO_LOGIN | default "1" | toBool }}
...
      {{ if $ENABLE_AUTO_LOGIN }}
      enable-auto-login=true
      {{ else }}
      enable-auto-login=false
      {{ end }}
```

related discussion:
[Unable do disable autologin using Docker Installation](https://community.jitsi.org/t/unable-do-disable-autologin-using-docker-installation/98505)

[Default timeout for authenticated users](https://community.jitsi.org/t/default-timeout-for-authenticated-users/17664)


