### PR TITLE
jicofo: Handle special characters in password

### DIFF
--- a/jicofo/rootfs/etc/services.d/jicofo/run
+++ b/jicofo/rootfs/etc/services.d/jicofo/run
@@ -3,6 +3,6 @@
 JAVA_SYS_PROPS="-Djava.util.logging.config.file=/config/logging.properties -Dconfig.file=/config/jicofo.conf"
 DAEMON=/usr/share/jicofo/jicofo.sh
 DAEMON_DIR=/usr/share/jicofo/
-DAEMON_OPTS="--domain=$XMPP_DOMAIN --host=$XMPP_SERVER --user_name=$JICOFO_AUTH_USER --user_domain=$XMPP_AUTH_DOMAIN --user_password=$JICOFO_AUTH_PASSWORD"
+DAEMON_OPTS="--domain=\"$XMPP_DOMAIN\" --host=\"$XMPP_SERVER\" --user_name=\"$JICOFO_AUTH_USER\" --user_domain=\"$XMPP_AUTH_DOMAIN\" --user_password=\"$JICOFO_AUTH_PASSWORD\""
 
 exec s6-setuidgid jicofo /bin/bash -c "cd $DAEMON_DIR; JAVA_SYS_PROPS=\"$JAVA_SYS_PROPS\" exec $DAEMON $DAEMON_OPTS"


### PR DESCRIPTION
Add quotations to jicofo run script.

This fixes #488 where jicofo fails to start due to special characters. For
example, if the JICOFO_AUTH_PASSWORD variable value contains `&` or `#` then the
run script fails because the characters are interpreted by bash rather than as a
string.

Note that the `gen-passwords.sh` script does _not_ trigger this issue because it
does not generate characters outside the ASCII alpha-numeric range. This only
shows up when using other tools to generate the password values that do include
special characters in the output or when setting the password values by hand.