### PR TITLE
Framerate, bosh path and bwe configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,8 @@ services:
             - ENABLE_XMPP_WEBSOCKET
             - ETHERPAD_PUBLIC_URL
             - ETHERPAD_URL_BASE
+            - FRAMERATE
+            - FRAMERATE_MIN
             - GOOGLE_ANALYTICS_ID
             - GOOGLE_API_APP_CLIENT_ID
             - INVITE_SERVICE_URL
@@ -117,6 +119,7 @@ services:
             - VIDEOQUALITY_ENFORCE_PREFERRED_CODEC
             - VIDEOQUALITY_PREFERRED_CODEC
             - XMPP_AUTH_DOMAIN
+            - XMPP_BOSH_PATH
             - XMPP_BOSH_URL_BASE
             - XMPP_DOMAIN
             - XMPP_GUEST_DOMAIN
@@ -285,6 +288,7 @@ services:
             - SENTRY_RELEASE
             - COLIBRI_REST_ENABLED
             - SHUTDOWN_REST_ENABLED
+            - TRUST_BWE
             - TZ
             - XMPP_AUTH_DOMAIN
             - XMPP_INTERNAL_MUC_DOMAIN

--- a/env.example
+++ b/env.example
@@ -71,6 +71,20 @@ TZ=UTC
 #ENABLE_NOISY_MIC_DETECTION=1
 
 #
+# Video configuration
+#
+
+# Resolution
+#RESOLUTION=720
+#RESOLUTION_MIN=180
+#RESOLUTION_WIDTH=1280
+#RESOLUTION_WIDTH_MIN=320
+
+# Frame rate
+#FRAMERATE=30
+#FRAMERATE_MIN=15
+
+#
 # Let's Encrypt configuration
 #
 
@@ -217,8 +231,14 @@ XMPP_SERVER=xmpp.meet.jitsi
 # Internal XMPP server URL
 XMPP_BOSH_URL_BASE=http://xmpp.meet.jitsi:5280
 
+# Connect to XMPP using websocket
+#ENABLE_XMPP_WEBSOCKET=1
+
 # Internal XMPP domain for authenticated services
 XMPP_AUTH_DOMAIN=auth.meet.jitsi
+
+# Bosh path
+#XMPP_BOSH_PATH=/http-bind
 
 # XMPP domain for the MUC
 XMPP_MUC_DOMAIN=muc.meet.jitsi

--- a/jvb/rootfs/defaults/jvb.conf
+++ b/jvb/rootfs/defaults/jvb.conf
@@ -5,6 +5,7 @@
 {{ $JVB_TCP_MAPPED_PORT := .Env.JVB_TCP_MAPPED_PORT | default $JVB_TCP_PORT }}
 {{ $PUBLIC_URL_DOMAIN := .Env.PUBLIC_URL | default "https://localhost:8443" | trimPrefix "https://" | trimSuffix "/" -}}
 {{ $SHUTDOWN_REST_ENABLED := .Env.SHUTDOWN_REST_ENABLED | default "false" | toBool }}
+{{ $TRUST_BWE := .Env.TRUST_BWE | default "true" | toBool }}
 {{ $WS_DOMAIN := .Env.JVB_WS_DOMAIN | default $PUBLIC_URL_DOMAIN -}}
 {{ $WS_SERVER_ID := .Env.JVB_WS_SERVER_ID | default .Env.JVB_WS_SERVER_ID_FALLBACK -}}
 
@@ -38,6 +39,9 @@ videobridge {
         rest {
             enabled = {{ $COLIBRI_REST_ENABLED }}
         }
+    }
+    cc {
+        trust-bwe = {{ $TRUST_BWE }}
     }
     rest {
         shutdown {

--- a/web/rootfs/defaults/settings-config.js
+++ b/web/rootfs/defaults/settings-config.js
@@ -24,6 +24,8 @@
 {{ $RESOLUTION_MIN := .Env.RESOLUTION_MIN | default "180" -}}
 {{ $RESOLUTION_WIDTH := .Env.RESOLUTION_WIDTH | default "1280" -}}
 {{ $RESOLUTION_WIDTH_MIN := .Env.RESOLUTION_WIDTH_MIN | default "320" -}}
+{{ $FRAMERATE := .Env.FRAMERATE | default "30" -}}
+{{ $FRAMERATE_MIN := .Env.FRAMERATE_MIN | default "15" -}}
 {{ $START_AUDIO_ONLY := .Env.START_AUDIO_ONLY | default "false" | toBool -}}
 {{ $START_AUDIO_MUTED := .Env.START_AUDIO_MUTED | default 10 -}}
 {{ $START_WITH_AUDIO_MUTED := .Env.START_WITH_AUDIO_MUTED | default "false" | toBool -}}
@@ -53,6 +55,7 @@ if (!config.constraints.hasOwnProperty('video')) config.constraints.video = {};
 config.resolution = {{ $RESOLUTION }};
 config.constraints.video.height = { ideal: {{ $RESOLUTION }}, max: {{ $RESOLUTION }}, min: {{ $RESOLUTION_MIN }} };
 config.constraints.video.width = { ideal: {{ $RESOLUTION_WIDTH }}, max: {{ $RESOLUTION_WIDTH }}, min: {{ $RESOLUTION_WIDTH_MIN }}};
+config.constraints.video.frameRate = { ideal: {{ $FRAMERATE }}, max: {{ $FRAMERATE }}, min: {{ $FRAMERATE_MIN }}};
 config.disableSimulcast = {{ not $ENABLE_SIMULCAST }};
 config.startVideoMuted = {{ $START_VIDEO_MUTED }};
 config.startWithVideoMuted = {{ $START_WITH_VIDEO_MUTED }};

--- a/web/rootfs/defaults/system-config.js
+++ b/web/rootfs/defaults/system-config.js
@@ -6,6 +6,7 @@
 {{ $JICOFO_AUTH_USER := .Env.JICOFO_AUTH_USER | default "focus" }}
 {{ $PUBLIC_URL_DOMAIN := .Env.PUBLIC_URL | default "https://localhost:8443" | trimPrefix "https://" | trimSuffix "/" -}}
 {{ $XMPP_AUTH_DOMAIN := .Env.XMPP_AUTH_DOMAIN -}}
+{{ $XMPP_BOSH_PATH := .Env.XMPP_BOSH_PATH | default "/http-bind" -}}
 {{ $XMPP_DOMAIN := .Env.XMPP_DOMAIN -}}
 {{ $XMPP_MUC_DOMAIN := .Env.XMPP_MUC_DOMAIN -}}
 {{ $XMPP_MUC_DOMAIN_PREFIX := (split "." .Env.XMPP_MUC_DOMAIN)._0  -}}
@@ -36,7 +37,7 @@ config.hosts.anonymousdomain = '{{ .Env.XMPP_GUEST_DOMAIN }}';
 config.hosts.authdomain = '{{ $XMPP_DOMAIN }}';
 {{ end -}}
 
-config.bosh = '/http-bind';
+config.bosh = '{{ $XMPP_BOSH_PATH }}';
 {{ if $ENABLE_XMPP_WEBSOCKET -}}
 config.websocket = 'wss://{{ $PUBLIC_URL_DOMAIN }}/xmpp-websocket';
 {{ end -}}


### PR DESCRIPTION
Added environment configuration flag to control:
- Video frame rate
- XMPP bosh path
- Trusting bandwidth estimation

Added environment definition inside example for:
- Video resolution
- Using websocket to communication with XMPP server