### PR TITLE
Add missing ENABLE_BREAKOUT_ROOMS to env.example

### DIFF
--- a/env.example
+++ b/env.example
@@ -70,6 +70,9 @@ TZ=UTC
 # Enable noisy mic detection
 #ENABLE_NOISY_MIC_DETECTION=1
 
+# Enable breakout rooms
+#ENABLE_BREAKOUT_ROOMS=1
+
 #
 # Let's Encrypt configuration
 #


### PR DESCRIPTION
This one was missing in 6f56e5b7a203deec9124a4dcf0390af3bf01fdfe