### PR TITLE
add missing package libldap-common to prosody

### DIFF
--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -26,6 +26,7 @@ RUN wget -qO /etc/apt/trusted.gpg.d/prosody.gpg https://prosody.im/files/prosody
     apt-dpkg-wrap apt-get install -y \
       prosody \
       libssl1.1 \
+      libldap-common \
       sasl2-bin \
       libsasl2-modules-ldap \
       lua-basexx \


### PR DESCRIPTION
Fixes: https://github.com/jitsi/docker-jitsi-meet/issues/1158