### PR TITLE
jibri: correct chromedriver mismatch

### DIFF
--- a/jibri/Dockerfile
+++ b/jibri/Dockerfile
@@ -13,16 +13,19 @@ RUN apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y jibri libgl1-mesa-dri procps && \
     apt-cleanup && \
     [ "${CHROME_RELEASE}" = "latest" ] && \
-    wget -qO - https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmour /etc/apt/trusted.gpg.d/google.gpg && \
-    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list && \
-    apt-dpkg-wrap apt-get update && \
-    apt-dpkg-wrap apt-get install -y google-chrome-stable && \
-    apt-cleanup || \
-    [ "${CHROME_RELEASE}" != "latest" ] && \
-    curl -4so "/tmp/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb" "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb" && \
-    apt-dpkg-wrap apt-get update && \
-    apt-dpkg-wrap apt-get install -y "/tmp/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb" && \
-    apt-cleanup || \
+    ( \
+        wget -qO - https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmour /etc/apt/trusted.gpg.d/google.gpg && \
+        echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list && \
+        apt-dpkg-wrap apt-get update && \
+        apt-dpkg-wrap apt-get install -y google-chrome-stable && \
+        apt-cleanup \
+    ) || \
+    ( \
+        curl -4so "/tmp/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb" "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb" && \
+        apt-dpkg-wrap apt-get update && \
+        apt-dpkg-wrap apt-get install -y "/tmp/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb" && \
+        apt-cleanup \
+    ) && \
     [ "${CHROMEDRIVER_MAJOR_RELEASE}" = "latest" ] && \
     CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE)" || \
     CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROMEDRIVER_MAJOR_RELEASE})" && \

--- a/jibri/Dockerfile
+++ b/jibri/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-dpkg-wrap apt-get update && \
     [ "${CHROMEDRIVER_MAJOR_RELEASE}" = "latest" ] && \
     CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE)" || \
     CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROMEDRIVER_MAJOR_RELEASE})" && \
+    [[ "${CHROMEDRIVER_RELEASE}" =~ ^${CHROMEDRIVER_MAJOR_RELEASE}.* ]] || exit 1 && \
     curl -4Ls "https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_RELEASE}/chromedriver_linux64.zip" \
     | zcat >> /usr/bin/chromedriver && \
     chmod +x /usr/bin/chromedriver && \

--- a/jibri/Dockerfile
+++ b/jibri/Dockerfile
@@ -7,7 +7,7 @@ FROM ${JITSI_REPO}/base-java:${BASE_TAG}
 ARG CHROME_RELEASE=96.0.4664.45
 ARG CHROMEDRIVER_MAJOR_RELEASE=96
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+SHELL ["/bin/bash", "-o", "pipefail", "-cx"]
 
 RUN apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y jibri libgl1-mesa-dri procps && \

--- a/jibri/Dockerfile
+++ b/jibri/Dockerfile
@@ -2,41 +2,17 @@ ARG JITSI_REPO=jitsi
 ARG BASE_TAG=latest
 FROM ${JITSI_REPO}/base-java:${BASE_TAG}
 
+RUN apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y jibri libgl1-mesa-dri procps jitsi-upload-integrations jq && \
+    apt-cleanup
+
 #ARG CHROME_RELEASE=latest
 #ARG CHROMEDRIVER_MAJOR_RELEASE=latest
 ARG CHROME_RELEASE=96.0.4664.45
 ARG CHROMEDRIVER_MAJOR_RELEASE=96
-
-SHELL ["/bin/bash", "-o", "pipefail", "-cx"]
-
-RUN apt-dpkg-wrap apt-get update && \
-    apt-dpkg-wrap apt-get install -y jibri libgl1-mesa-dri procps && \
-    apt-cleanup && \
-    [ "${CHROME_RELEASE}" = "latest" ] && \
-    ( \
-        wget -qO - https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmour /etc/apt/trusted.gpg.d/google.gpg && \
-        echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list && \
-        apt-dpkg-wrap apt-get update && \
-        apt-dpkg-wrap apt-get install -y google-chrome-stable && \
-        apt-cleanup \
-    ) || \
-    ( \
-        curl -4so "/tmp/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb" "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb" && \
-        apt-dpkg-wrap apt-get update && \
-        apt-dpkg-wrap apt-get install -y "/tmp/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb" && \
-        apt-cleanup \
-    ) && \
-    [ "${CHROMEDRIVER_MAJOR_RELEASE}" = "latest" ] && \
-    CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE)" || \
-    CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROMEDRIVER_MAJOR_RELEASE})" && \
-    [[ "${CHROMEDRIVER_RELEASE}" =~ ^${CHROMEDRIVER_MAJOR_RELEASE}.* ]] || exit 1 && \
-    curl -4Ls "https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_RELEASE}/chromedriver_linux64.zip" \
-    | zcat >> /usr/bin/chromedriver && \
-    chmod +x /usr/bin/chromedriver && \
-    chromedriver --version && \
-    apt-dpkg-wrap apt-get update && \
-    apt-dpkg-wrap apt-get install -y jitsi-upload-integrations jq && \
-    apt-cleanup
+COPY build/install-chrome.sh /install-chrome.sh
+RUN /install-chrome.sh && \
+    rm /install-chrome.sh
 
 COPY rootfs/ /
 

--- a/jibri/build/install-chrome.sh
+++ b/jibri/build/install-chrome.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -o pipefail -xeu
+
+if  [ "${CHROME_RELEASE}" = "latest" ]; then
+    wget -qO - https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmour > /etc/apt/trusted.gpg.d/google.gpg
+    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
+    apt-dpkg-wrap apt-get update
+    apt-dpkg-wrap apt-get install -y google-chrome-stable
+    apt-cleanup
+else
+    curl -4so "/tmp/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb" "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb"
+    apt-dpkg-wrap apt-get update
+    apt-dpkg-wrap apt-get install -y "/tmp/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb"
+    apt-cleanup
+fi
+
+if [ "${CHROMEDRIVER_MAJOR_RELEASE}" = "latest" ]; then
+    CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE)"
+else
+    CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROMEDRIVER_MAJOR_RELEASE})"
+fi
+
+curl -4Ls "https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_RELEASE}/chromedriver_linux64.zip"  | zcat >> /usr/bin/chromedriver
+chmod +x /usr/bin/chromedriver
+chromedriver --version


### PR DESCRIPTION
Previously when `CHROME_RELEASE` is set to something specific (not `latest`), the `[ "${CHROMEDRIVER_MAJOR_RELEASE}" = "latest" ]` check is skipped due to the `||` before it. i.e. the original code is structured like:

```sh
CHROME_RELEASE=95.0.4638.69 CHROMEDRIVER_MAJOR_RELEASE=95 echo "Do initial things" && \
  [ "${CHROME_RELEASE}" = "latest" ] && \
  echo "Do latest chrome release things 1" && \
  echo "Do latest chrome release things 2"  || \
  [ "${CHROME_RELEASE}" != "latest" ] && \
  echo "Do specific chrome release 1" && \
  echo "Do specific chrome release 2" || \
  [ "${CHROMEDRIVER_MAJOR_RELEASE}" = "latest" ] && \
  CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE)" || \
  CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROMEDRIVER_MAJOR_RELEASE})" && \
  echo "${CHROMEDRIVER_MAJOR_RELEASE} vs ${CHROMEDRIVER_RELEASE}"

Do initial things
Do specific chrome release 1
Do specific chrome release 2
95 vs 96.0.4664.45
```

The new code on the other hand:
```sh
CHROME_RELEASE=95.0.4638.69 CHROMEDRIVER_MAJOR_RELEASE=95 echo "Do initial things" && \
  [ "${CHROME_RELEASE}" = "latest" ] && \
  ( \
    echo "Do latest chrome release things 1" && \
    echo "Do latest chrome release things 2" \
  ) || \
  ( \
    echo "Do specific chrome release 1" && \
    echo "Do specific chrome release 2" \
  ) && \
  [ "${CHROMEDRIVER_MAJOR_RELEASE}" = "latest" ] && \
  CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE)" || \
  CHROMEDRIVER_RELEASE="$(curl -4Ls https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROMEDRIVER_MAJOR_RELEASE})" && \
  echo "${CHROMEDRIVER_MAJOR_RELEASE} vs ${CHROMEDRIVER_RELEASE}"

Do initial things
Do specific chrome release 1
Do specific chrome release 2
95 vs 95.0.4638.69
```

This PR fixes this, makes things easier to debug in future and adds a fail-safe incase there's another issue