### PR TITLE
jicofo: configure trusted-domains for Jibri if ENABLE_RECORDING is set

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -246,6 +246,7 @@ services:
             - XMPP_AUTH_DOMAIN
             - XMPP_INTERNAL_MUC_DOMAIN
             - XMPP_MUC_DOMAIN
+            - XMPP_RECORDER_DOMAIN
             - XMPP_SERVER
         depends_on:
             - prosody

--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -122,7 +122,7 @@ jicofo {
       // two MUST be in sync (otherwise bridges will crash because they won't know how to
       // deal with octo channels).
       enabled = {{ $ENABLE_OCTO }}
-      
+
       id = "{{ .Env.JICOFO_SHORT_ID | default "1" }}"
     }
 
@@ -136,11 +136,14 @@ jicofo {
         hostname = "{{ .Env.XMPP_SERVER }}"
         domain = "{{ .Env.XMPP_AUTH_DOMAIN }}"
         username = "{{ .Env.JICOFO_AUTH_USER }}"
-        password = "{{ .Env.JICOFO_AUTH_PASSWORD }}"  
+        password = "{{ .Env.JICOFO_AUTH_PASSWORD }}"
         conference-muc-jid = "{{ .Env.XMPP_MUC_DOMAIN }}"
         client-proxy = "focus.{{ .Env.XMPP_DOMAIN }}"
         disable-certificate-verification = true
       }
+      {{ if $ENABLE_RECORDING }}
+      trusted-domains = [ "{{ .Env.XMPP_RECORDER_DOMAIN }}" ]
+      {{ end }}
     }
 
     {{ if .Env.JICOFO_RESERVATION_ENABLED | default "false" | toBool }}


### PR DESCRIPTION
Setting as per https://github.com/jitsi/jicofo/blob/master/src/main/resources/reference.conf#L336-L338

* `ENABLE_RECORDING` is setup in `jicofo.conf`, `docker-compose.yml` & `env.example` already but was unused for Jicofo.
* `XMPP_RECORDER_DOMAIN` is the variable used for Jibri, web & Prosody

