### PR TITLE
jibri: expose the call-status-check settings to configuration via env vars

### DIFF
--- a/jibri.yml
+++ b/jibri.yml
@@ -10,9 +10,12 @@ services:
         cap_add:
             - SYS_ADMIN
         environment:
+            - ALL_MUTED_TIMEOUT
             - CHROMIUM_FLAGS
+            - DEFAULT_CALL_EMPTY_TIMEOUT
             - DISPLAY=:0
             - ENABLE_STATS_D
+            - ICE_CONNECTION_TIMEOUT
             - JIBRI_HTTP_API_EXTERNAL_PORT
             - JIBRI_HTTP_API_INTERNAL_PORT
             - JIBRI_RECORDING_RESOLUTION
@@ -25,6 +28,7 @@ services:
             - JIBRI_RECORDING_DIR
             - JIBRI_FINALIZE_RECORDING_SCRIPT_PATH
             - JIBRI_STRIP_DOMAIN_JID
+            - NO_MEDIA_TIMEOUT
             - PUBLIC_URL
             - TZ
             - XMPP_AUTH_DOMAIN

--- a/jibri/rootfs/defaults/jibri.conf
+++ b/jibri/rootfs/defaults/jibri.conf
@@ -123,4 +123,31 @@ jibri {
       enable-stats-d = {{ .Env.ENABLE_STATS_D }}
     }
     {{ end -}}
+
+    call-status-checks {
+      {{ if .Env.NO_MEDIA_TIMEOUT -}}
+      // If all clients have their audio and video muted and if Jibri does not
+      // detect any data stream (audio or video) comming in, it will stop
+      // recording after NO_MEDIA_TIMEOUT expires.
+      no-media-timeout = {{ .Env.NO_MEDIA_TIMEOUT }}
+      {{ end -}}
+
+      {{ if .Env.ALL_MUTED_TIMEOUT -}}
+      // If all clients have their audio and video muted, Jibri consideres this
+      // as an empty call and stops the recording after ALL_MUTED_TIMEOUT expires.
+      all-muted-timeout = {{ .Env.ALL_MUTED_TIMEOUT }}
+      {{ end -}}
+
+      {{ if .Env.DEFAULT_CALL_EMPTY_TIMEOUT -}}
+      // When detecting if a call is empty, Jibri takes into consideration for how
+      // long the call has been empty already. If it has been empty for more than
+      // DEFAULT_CALL_EMPTY_TIMEOUT, it will consider it empty and stop the recording.
+      default-call-empty-timeout = {{ .Env.DEFAULT_CALL_EMPTY_TIMEOUT }}
+      {{ end -}}
+
+      {{ if .Env.ICE_CONNECTION_TIMEOUT -}}
+      // If ICE hasn't completed, or stays in a state other than "connected" for this amount of time, Jibri will stop.
+      ice-connection-timeout = {{ .Env.ICE_CONNECTION_TIMEOUT }}
+      {{ end -}}
+    }
 }


### PR DESCRIPTION
Comments from https://github.com/jitsi/jibri/blob/master/src/main/resources/reference.conf#L79-L93 preserved, though happy to remove.

Env var names taken from what's in the comments, happy to change as desired. Haven't added them to `env.example` as only a small subset of Jibri env vars seem to be present there.