### PR TITLE
fix(jigasi): participants joining conference without going through lobby

### DIFF
--- a/jigasi.yml
+++ b/jigasi.yml
@@ -12,7 +12,9 @@ services:
             - ${CONFIG}/transcripts:/tmp/transcripts:Z
         environment:
             - ENABLE_AUTH
+            - ENABLE_GUESTS
             - XMPP_AUTH_DOMAIN
+            - XMPP_GUEST_DOMAIN
             - XMPP_MUC_DOMAIN
             - XMPP_INTERNAL_MUC_DOMAIN
             - XMPP_SERVER

--- a/jigasi/rootfs/defaults/sip-communicator.properties
+++ b/jigasi/rootfs/defaults/sip-communicator.properties
@@ -116,9 +116,14 @@ org.jitsi.jigasi.xmpp.acc.IM_DISABLED=true
 org.jitsi.jigasi.xmpp.acc.SERVER_STORED_INFO_DISABLED=true
 org.jitsi.jigasi.xmpp.acc.IS_FILE_TRANSFER_DISABLED=true
 {{ if .Env.ENABLE_AUTH | default "0" | toBool }}
+{{ if .Env.ENABLE_GUESTS | default "0" | toBool }}
+org.jitsi.jigasi.xmpp.acc.USER_ID={{ .Env.JIGASI_XMPP_USER }}@{{ .Env.XMPP_GUEST_DOMAIN }}
+org.jitsi.jigasi.xmpp.acc.ANONYMOUS_AUTH=true
+{{ else }}
 org.jitsi.jigasi.xmpp.acc.USER_ID={{ .Env.JIGASI_XMPP_USER }}@{{ .Env.XMPP_AUTH_DOMAIN }}
-org.jitsi.jigasi.xmpp.acc.PASS={{ .Env.JIGASI_XMPP_PASSWORD }}
 org.jitsi.jigasi.xmpp.acc.ANONYMOUS_AUTH=false
+{{ end }}
+org.jitsi.jigasi.xmpp.acc.PASS={{ .Env.JIGASI_XMPP_PASSWORD }}
 org.jitsi.jigasi.xmpp.acc.ALLOW_NON_SECURE=true
 {{ end }}
 


### PR DESCRIPTION
This patch will make Jigasi using the guest domain for sip participants, if enabled. This fixes Jigasi users joining a conference without approval when lobby is enabled, due to the whitelisting of the auth domain in the Prosody lobby module.