### PR TITLE
nginx: jvb websocket proxy avoid arbitrary redirect

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,7 @@ services:
             - XMPP_GUEST_DOMAIN
             - XMPP_MUC_DOMAIN
             - XMPP_RECORDER_DOMAIN
+            - XMPP_SERVER
         networks:
             meet.jitsi:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,7 @@ version: '3'
 services:
     # Frontend
     web:
-#        image: jitsi/web:latest
-        build: ./web
+        image: jitsi/web:latest
         restart: ${RESTART_POLICY}
         ports:
             - '${HTTP_PORT}:80'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@ version: '3'
 services:
     # Frontend
     web:
-        image: jitsi/web:latest
+#        image: jitsi/web:latest
+        build: ./web
         restart: ${RESTART_POLICY}
         ports:
             - '${HTTP_PORT}:80'
@@ -122,7 +123,8 @@ services:
             - XMPP_GUEST_DOMAIN
             - XMPP_MUC_DOMAIN
             - XMPP_RECORDER_DOMAIN
-            - XMPP_SERVER
+        depends_on:
+            - jvb
         networks:
             meet.jitsi:
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -6,7 +6,7 @@ ADD https://raw.githubusercontent.com/acmesh-official/acme.sh/2.8.8/acme.sh /opt
 COPY rootfs/ /
 
 RUN apt-dpkg-wrap apt-get update && \
-    apt-dpkg-wrap apt-get install -y cron nginx-extras jitsi-meet-web socat && \
+    apt-dpkg-wrap apt-get install -y cron nginx-extras jitsi-meet-web socat iproute2 dnsutils && \
     apt-dpkg-wrap apt-get -d install -y jitsi-meet-web-config && \
     dpkg -x /var/cache/apt/archives/jitsi-meet-web-config*.deb /tmp/pkg && \
     mv /tmp/pkg/usr/share/jitsi-meet-web-config/config.js /defaults && \

--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -1,5 +1,6 @@
 {{ $ENABLE_COLIBRI_WEBSOCKET := .Env.ENABLE_COLIBRI_WEBSOCKET | default "1" | toBool }}
 {{ $ENABLE_XMPP_WEBSOCKET := .Env.ENABLE_XMPP_WEBSOCKET | default "1" | toBool }}
+{{ $WS_SERVER_ID := .Env.JVB_WS_SERVER_ID | default .Env.JVB_WS_SERVER_ID_FALLBACK -}}
 
 server_name _;
 
@@ -48,7 +49,7 @@ location ~ ^/(libs|css|static|images|fonts|lang|sounds|connection_optimization|.
 {{ if $ENABLE_COLIBRI_WEBSOCKET }}
 # colibri (JVB) websockets
 location ~ ^/colibri-ws/([a-zA-Z0-9-\.]+)/(.*) {
-    proxy_pass http://$1:9090/colibri-ws/$1/$2$is_args$args;
+    proxy_pass http://{{ $WS_SERVER_ID }}:9090/colibri-ws/$1/$2$is_args$args;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";

--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -48,8 +48,8 @@ location ~ ^/(libs|css|static|images|fonts|lang|sounds|connection_optimization|.
 
 {{ if $ENABLE_COLIBRI_WEBSOCKET }}
 # colibri (JVB) websockets
-location ~ ^/colibri-ws/([a-zA-Z0-9-\.]+)/(.*) {
-    proxy_pass http://{{ $WS_SERVER_ID }}:9090/colibri-ws/$1/$2$is_args$args;
+location ~ ^/colibri-ws/{{ $WS_SERVER_ID }}/(.*) {
+    proxy_pass http://{{ $WS_SERVER_ID }}:9090/colibri-ws/{{ $WS_SERVER_ID }}/$1$is_args$args;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";

--- a/web/rootfs/defaults/system-config.js
+++ b/web/rootfs/defaults/system-config.js
@@ -8,8 +8,7 @@
 {{ $XMPP_AUTH_DOMAIN := .Env.XMPP_AUTH_DOMAIN -}}
 {{ $XMPP_DOMAIN := .Env.XMPP_DOMAIN -}}
 {{ $XMPP_MUC_DOMAIN := .Env.XMPP_MUC_DOMAIN -}}
-{{ $XMPP_MUC_DOMAIN_PREFIX_MAP := split "." .Env.XMPP_MUC_DOMAIN  }}
-{{ $XMPP_MUC_DOMAIN_PREFIX := $XMPP_MUC_DOMAIN_PREFIX_MAP._0  }}
+{{ $XMPP_MUC_DOMAIN_PREFIX := (split "." .Env.XMPP_MUC_DOMAIN)._0  -}}
 
 // Begin default config overrides.
 

--- a/web/rootfs/defaults/system-config.js
+++ b/web/rootfs/defaults/system-config.js
@@ -8,7 +8,8 @@
 {{ $XMPP_AUTH_DOMAIN := .Env.XMPP_AUTH_DOMAIN -}}
 {{ $XMPP_DOMAIN := .Env.XMPP_DOMAIN -}}
 {{ $XMPP_MUC_DOMAIN := .Env.XMPP_MUC_DOMAIN -}}
-{{ $XMPP_MUC_DOMAIN_PREFIX := (split "." .Env.XMPP_MUC_DOMAIN)._0  -}}
+{{ $XMPP_MUC_DOMAIN_PREFIX_MAP := split "." .Env.XMPP_MUC_DOMAIN  }}
+{{ $XMPP_MUC_DOMAIN_PREFIX := $XMPP_MUC_DOMAIN_PREFIX_MAP._0  }}
 
 // Begin default config overrides.
 

--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -63,6 +63,12 @@ if [[ $DISABLE_HTTPS -ne 1 ]]; then
     fi
 fi
 
+# On environments like Swarm the IP address used by the default gateway need not be
+# the one used for inter-container traffic. Use that one for our fallback ID.
+XMPP_SERVER_IP=$(dig +short ${XMPP_SERVER})
+# export this here to ensure JVB and nginx are in sync about websocket proxy host
+export JVB_WS_SERVER_ID_FALLBACK=$(ip route get ${XMPP_SERVER_IP} | grep -oP '(?<=src ).*' | awk '{ print $1 '})
+
 # copy config files
 tpl /defaults/nginx.conf > /config/nginx/nginx.conf
 

--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -64,7 +64,7 @@ if [[ $DISABLE_HTTPS -ne 1 ]]; then
 fi
 
 # export this here to ensure JVB and nginx are in sync about websocket proxy host
-JVB_WS_SERVER_ID_FALLBACK=$(dig +short jvb)
+export JVB_WS_SERVER_ID_FALLBACK=$(dig +short jvb)
 
 # copy config files
 tpl /defaults/nginx.conf > /config/nginx/nginx.conf

--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -63,11 +63,8 @@ if [[ $DISABLE_HTTPS -ne 1 ]]; then
     fi
 fi
 
-# On environments like Swarm the IP address used by the default gateway need not be
-# the one used for inter-container traffic. Use that one for our fallback ID.
-XMPP_SERVER_IP=$(dig +short ${XMPP_SERVER})
 # export this here to ensure JVB and nginx are in sync about websocket proxy host
-export JVB_WS_SERVER_ID_FALLBACK=$(ip route get ${XMPP_SERVER_IP} | grep -oP '(?<=src ).*' | awk '{ print $1 '})
+JVB_WS_SERVER_ID_FALLBACK=$(dig +short jvb)
 
 # copy config files
 tpl /defaults/nginx.conf > /config/nginx/nginx.conf


### PR DESCRIPTION
This is intended to ensure the colibri-ws passthrough for the JVB websocket only goes to the proper location