### PR TITLE
added lua-event to Prosody Dockerfile

### DIFF
--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -32,6 +32,7 @@ RUN wget -qO /etc/apt/trusted.gpg.d/prosody.gpg https://prosody.im/files/prosody
       lua-basexx \
       lua-ldap \
       lua-sec \
+      lua-event \
       patch && \
     apt-cleanup && \
     rm -rf /etc/prosody && \


### PR DESCRIPTION
added lua-event (libevent) to Prosody Build to enable the use of the epoll backend