### PR TITLE
allow to configure buttons in toolbar and pre-join screen

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,7 @@ services:
             - ETHERPAD_URL_BASE
             - GOOGLE_ANALYTICS_ID
             - GOOGLE_API_APP_CLIENT_ID
+            - HIDE_PREMEETING_BUTTONS
             - INVITE_SERVICE_URL
             - JICOFO_AUTH_USER
             - LETSENCRYPT_DOMAIN
@@ -104,6 +105,7 @@ services:
             - TESTING_CAP_SCREENSHARE_BITRATE
             - TESTING_OCTO_PROBABILITY
             - TOKEN_AUTH_URL
+            - TOOLBAR_BUTTONS
             - TZ
             - VIDEOQUALITY_BITRATE_H264_LOW
             - VIDEOQUALITY_BITRATE_H264_STANDARD

--- a/env.example
+++ b/env.example
@@ -406,3 +406,9 @@ RESTART_POLICY=unless-stopped
 # Optional properties for shutdown api
 #COLIBRI_REST_ENABLED=true
 #SHUTDOWN_REST_ENABLED=true
+
+# Configure toolbar buttons. Add the buttons name separated with comma(no spaces between comma)
+#TOOLBAR_BUTTONS=
+
+# Hide the buttons at pre-join screen. Add the buttons name separated with comma
+#HIDE_PREMEETING_BUTTONS=

--- a/web/rootfs/defaults/settings-config.js
+++ b/web/rootfs/defaults/settings-config.js
@@ -364,3 +364,13 @@ config.disableReactions = {{ $DISABLE_REACTIONS }};
 
 // Polls
 config.disablePolls = {{ $DISABLE_POLLS }};
+
+// configure toolbar buttons
+{{ if .Env.TOOLBAR_BUTTONS -}}
+config.toolbarButtons = [ '{{ join "','" (splitList "," .Env.TOOLBAR_BUTTONS) }}' ];
+{{ end -}}
+
+// Hides the buttons at pre-join screen
+{{ if .Env.HIDE_PREMEETING_BUTTONS -}}
+config.hiddenPremeetingButtons = [ '{{ join "','" (splitList "," .Env.HIDE_PREMEETING_BUTTONS) }}' ];
+{{ end -}}

--- a/web/rootfs/defaults/settings-config.js
+++ b/web/rootfs/defaults/settings-config.js
@@ -365,7 +365,7 @@ config.disableReactions = {{ $DISABLE_REACTIONS }};
 // Polls
 config.disablePolls = {{ $DISABLE_POLLS }};
 
-// configure toolbar buttons
+// Configure toolbar buttons
 {{ if .Env.TOOLBAR_BUTTONS -}}
 config.toolbarButtons = [ '{{ join "','" (splitList "," .Env.TOOLBAR_BUTTONS) }}' ];
 {{ end -}}


### PR DESCRIPTION
This PR will allow configuring the buttons in the toolbar and at the pre-join screen. For example, If we want to hide the `invite` button at the pre-join screen then we can set  `HIDE_PREMEETING_BUTTONS=invite`. Similarly setting `TOOLBAR_BUTTONS=camera,chat,fullscreen` will only show these buttons.