### PR TITLE
Make MUC_NICKNAME configurable via .env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -272,6 +272,7 @@ services:
             - JVB_AUTH_PASSWORD
             - JVB_BREWERY_MUC
             - JVB_PORT
+            - JVB_MUC_NICKNAME
             - JVB_TCP_HARVESTER_DISABLED
             - JVB_TCP_PORT
             - JVB_TCP_MAPPED_PORT

--- a/jvb/rootfs/defaults/jvb.conf
+++ b/jvb/rootfs/defaults/jvb.conf
@@ -1,6 +1,7 @@
 {{ $COLIBRI_REST_ENABLED := .Env.COLIBRI_REST_ENABLED | default "false" | toBool }}
 {{ $ENABLE_COLIBRI_WEBSOCKET := .Env.ENABLE_COLIBRI_WEBSOCKET | default "1" | toBool }}
 {{ $ENABLE_OCTO := .Env.ENABLE_OCTO | default "0" | toBool }}
+{{ $JVB_MUC_NICKNAME := .Env.JVB_MUC_NICKNAME | default .Env.HOSTNAME -}}
 {{ $JVB_TCP_PORT := .Env.JVB_TCP_PORT | default "4443" }}
 {{ $JVB_TCP_MAPPED_PORT := .Env.JVB_TCP_MAPPED_PORT | default $JVB_TCP_PORT }}
 {{ $PUBLIC_URL_DOMAIN := .Env.PUBLIC_URL | default "https://localhost:8443" | trimPrefix "https://" | trimSuffix "/" -}}
@@ -30,7 +31,7 @@ videobridge {
                     USERNAME = "{{ .Env.JVB_AUTH_USER }}"
                     PASSWORD = "{{ .Env.JVB_AUTH_PASSWORD }}"
                     MUC_JIDS = "{{ .Env.JVB_BREWERY_MUC }}@{{ .Env.XMPP_INTERNAL_MUC_DOMAIN }}"
-                    MUC_NICKNAME = "{{ .Env.HOSTNAME }}"
+                    MUC_NICKNAME = "{{ $JVB_MUC_NICKNAME }}"
                     DISABLE_CERTIFICATE_VERIFICATION = true
                 }
             }


### PR DESCRIPTION
This PR gives the opportunity to have MUC_NICKNAME configured via JVB container name (container hostname) or manually via .env.

Useful if you are processing statistics via Grafana, etc.