### PR TITLE
configure remote participant video menu

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,9 @@ services:
             - DIALOUT_CODES_URL
             - DISABLE_AUDIO_LEVELS
             - DISABLE_DEEP_LINKING
+            - DISABLE_GRANT_MODERATOR
             - DISABLE_HTTPS
+            - DISABLE_KICKOUT
             - DISABLE_POLLS
             - DISABLE_REACTIONS
             - DROPBOX_APPKEY

--- a/web/rootfs/defaults/settings-config.js
+++ b/web/rootfs/defaults/settings-config.js
@@ -374,3 +374,12 @@ config.toolbarButtons = [ '{{ join "','" (splitList "," .Env.TOOLBAR_BUTTONS) }}
 {{ if .Env.HIDE_PREMEETING_BUTTONS -}}
 config.hiddenPremeetingButtons = [ '{{ join "','" (splitList "," .Env.HIDE_PREMEETING_BUTTONS) }}' ];
 {{ end -}}
+
+// Configure remote participant video menu
+if (!config.hasOwnProperty('remoteVideoMenu')) config.remoteVideoMenu = {};
+{{ if .Env.DISABLE_KICKOUT -}}
+config.remoteVideoMenu.disableKick = {{ .Env.DISABLE_KICKOUT }};
+{{ end -}}
+{{ if .Env.DISABLE_GRANT_MODERATOR -}}
+config.remoteVideoMenu.disableGrantModerator = {{ .Env.DISABLE_GRANT_MODERATOR }};
+{{ end -}}


### PR DESCRIPTION
This will help in hiding the `KickOut` and `GrantModeratorRights` buttons from the participant menu.