### PR TITLE
jvb: remove TCP support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -263,7 +263,6 @@ services:
         restart: ${RESTART_POLICY}
         ports:
             - '${JVB_PORT}:${JVB_PORT}/udp'
-            - '${JVB_TCP_PORT}:${JVB_TCP_PORT}'
         volumes:
             - ${CONFIG}/jvb:/config:Z
         environment:
@@ -275,9 +274,6 @@ services:
             - JVB_BREWERY_MUC
             - JVB_PORT
             - JVB_MUC_NICKNAME
-            - JVB_TCP_HARVESTER_DISABLED
-            - JVB_TCP_PORT
-            - JVB_TCP_MAPPED_PORT
             - JVB_STUN_SERVERS
             - JVB_OCTO_BIND_ADDRESS
             - JVB_OCTO_PUBLIC_ADDRESS

--- a/env.example
+++ b/env.example
@@ -257,11 +257,6 @@ JVB_STUN_SERVERS=meet-jit-si-turnrelay.jitsi.net:443
 # Media port for the Jitsi Videobridge
 JVB_PORT=10000
 
-# TCP Fallback for Jitsi Videobridge for when UDP isn't available
-JVB_TCP_HARVESTER_DISABLED=true
-JVB_TCP_PORT=4443
-JVB_TCP_MAPPED_PORT=4443
-
 # XMPP user for Jicofo client connections.
 # NOTE: this option doesn't currently work due to a bug
 JICOFO_AUTH_USER=focus

--- a/jvb/rootfs/defaults/jvb.conf
+++ b/jvb/rootfs/defaults/jvb.conf
@@ -2,8 +2,6 @@
 {{ $ENABLE_COLIBRI_WEBSOCKET := .Env.ENABLE_COLIBRI_WEBSOCKET | default "1" | toBool }}
 {{ $ENABLE_OCTO := .Env.ENABLE_OCTO | default "0" | toBool }}
 {{ $JVB_MUC_NICKNAME := .Env.JVB_MUC_NICKNAME | default .Env.HOSTNAME -}}
-{{ $JVB_TCP_PORT := .Env.JVB_TCP_PORT | default "4443" }}
-{{ $JVB_TCP_MAPPED_PORT := .Env.JVB_TCP_MAPPED_PORT | default $JVB_TCP_PORT }}
 {{ $PUBLIC_URL_DOMAIN := .Env.PUBLIC_URL | default "https://localhost:8443" | trimPrefix "https://" | trimSuffix "/" -}}
 {{ $SHUTDOWN_REST_ENABLED := .Env.SHUTDOWN_REST_ENABLED | default "false" | toBool }}
 {{ $WS_DOMAIN := .Env.JVB_WS_DOMAIN | default $PUBLIC_URL_DOMAIN -}}
@@ -13,13 +11,6 @@ videobridge {
     ice {
         udp {
             port = {{ .Env.JVB_PORT }}
-        }
-        tcp {
-            enabled = {{ not (.Env.JVB_TCP_HARVESTER_DISABLED | default "true" | toBool) }}
-            port = {{ .Env.JVB_TCP_PORT }}
-            {{ if not (eq $JVB_TCP_PORT $JVB_TCP_MAPPED_PORT) }}
-            mapped-port = {{ $JVB_TCP_MAPPED_PORT }}
-            {{ end }}
         }
     }
     apis {


### PR DESCRIPTION
It's not tested at all and has problems. The recommendation is to use a
TURN server for TCP.