### PR TITLE
feat: add ENABLE_LOAD_TEST option

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
             - ENABLE_IPV6
             - ENABLE_LETSENCRYPT
             - ENABLE_LIPSYNC
+            - ENABLE_LOAD_TEST
             - ENABLE_NO_AUDIO_DETECTION
             - ENABLE_NOISY_MIC_DETECTION
             - ENABLE_PREJOIN_PAGE

--- a/env.example
+++ b/env.example
@@ -423,3 +423,6 @@ RESTART_POLICY=unless-stopped
 
 # Hide the buttons at pre-join screen. Add the buttons name separated with comma
 #HIDE_PREMEETING_BUTTONS=
+
+# Enable the load test minimal ui used for jitsi-meet-torture's malleus.sh script.
+#ENABLE_LOAD_TEST=1

--- a/env.example
+++ b/env.example
@@ -423,6 +423,3 @@ RESTART_POLICY=unless-stopped
 
 # Hide the buttons at pre-join screen. Add the buttons name separated with comma
 #HIDE_PREMEETING_BUTTONS=
-
-# Enable the load test minimal ui used for jitsi-meet-torture's malleus.sh script.
-#ENABLE_LOAD_TEST=1

--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -1,5 +1,6 @@
 {{ $ENABLE_COLIBRI_WEBSOCKET := .Env.ENABLE_COLIBRI_WEBSOCKET | default "1" | toBool }}
 {{ $ENABLE_XMPP_WEBSOCKET := .Env.ENABLE_XMPP_WEBSOCKET | default "1" | toBool }}
+{{ $ENABLE_LOAD_TEST := .Env.ENABLE_LOAD_TEST | default "0" | toBool }}
 {{ $ENABLE_SUBDOMAINS := .Env.ENABLE_SUBDOMAINS | default "true" | toBool -}}
 
 server_name _;

--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -84,6 +84,17 @@ location = /xmpp-websocket {
 }
 {{ end }}
 
+{{ if $ENABLE_LOAD_TEST }}
+location ~ ^/_load-test/([^/?&:'"]+)$ {
+    rewrite ^/_load-test/(.*)$ /load-test/index.html break;
+}
+
+location ~ ^/_load-test/libs/(.*)$ {
+    add_header 'Access-Control-Allow-Origin' '*';
+    alias /usr/share/jitsi-meet/load-test/libs/$1;
+}
+{{ end }}
+
 location ~ ^/([^/?&:'"]+)$ {
     try_files $uri @root_path;
 }


### PR DESCRIPTION
This is useful for load testing with [jitsi-meet-torture's malleus script](https://github.com/jitsi/jitsi-meet-torture/blob/master/scripts/malleus.sh) using the `--use-load-test` flag.

Maybe the var name needs to be more explicit.