### PR TITLE
jvb: forward port 8080 to docker host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -267,6 +267,7 @@ services:
         restart: ${RESTART_POLICY}
         ports:
             - '${JVB_PORT}:${JVB_PORT}/udp'
+            - '127.0.0.1:8080:8080'
         volumes:
             - ${CONFIG}/jvb:/config:Z
         environment:


### PR DESCRIPTION
Forward port 8080 from the JVB colibri rest api to the docker hosts localhost.
Closes jitsi#1239