### PR TITLE
✨(prosody) enable libevent

### DIFF
--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-dpkg-wrap apt-get update && \
       libsasl2-dev \
       libssl-dev \
       libreadline-dev \
+      lua-event \
       git \
       unzip \
       wget && \

--- a/prosody/rootfs/defaults/prosody.cfg.lua
+++ b/prosody/rootfs/defaults/prosody.cfg.lua
@@ -26,7 +26,7 @@ admins = { }
 
 -- Enable use of libevent for better performance under high load
 -- For more information see: http://prosody.im/doc/libevent
---use_libevent = true;
+use_libevent = true;
 
 -- This is the list of modules Prosody will load on startup.
 -- It looks for mod_modulename.lua in the plugins folder, so make sure that exists too.


### PR DESCRIPTION
In the prosody [documentation] it is recommanded to enable libevent in
order to have better performance. For this, the lua-event debian package
should be installed and then we have to enable it in the configuration,
uncommenting the use_libevent instruction.

[documentation]: https://prosody.im/doc/libevent