### PR TITLE
web: Add modifier for etherpad location.

### DIFF
--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -86,7 +86,7 @@ location = /xmpp-websocket {
 
 {{ if .Env.ETHERPAD_URL_BASE }}
 # Etherpad-lite
-location /etherpad/ {
+location ^~ /etherpad/ {
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
To avoid /etherpad/ matched by fallback:
location ~ ^/([^/?&:'"]+)/(.*)$