### PR TITLE
prosody: add mod_auth_cyrus from community libraries

### DIFF
--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -50,8 +50,8 @@ RUN wget -qO /etc/apt/trusted.gpg.d/prosody.gpg https://prosody.im/files/prosody
     mv /tmp/pkg/usr/share/jitsi-meet/prosody-plugins /prosody-plugins && \
     rm -f /prosody-plugins/token/util.lib.lua && \
     wget -qO /prosody-plugins/token/util.lib.lua https://raw.githubusercontent.com/jitsi/jitsi-meet/46dd88c91b63988f516114daee65ff8995c74c56/resources/prosody-plugins/token/util.lib.lua && \
-    wget -qO /prosody-plugins/mod_auth_cyrus.lua https://hg.prosody.im/prosody-modules/raw-file/tip/mod_auth_cyrus/mod_auth_cyrus.lua && \
-    wget -qO /prosody-plugins/sasl_cyrus.lua https://hg.prosody.im/prosody-modules/raw-file/tip/mod_auth_cyrus/sasl_cyrus.lua && \
+    wget -qO /prosody-plugins/mod_auth_cyrus.lua https://hg.prosody.im/prosody-modules/raw-file/65438e4ba563/mod_auth_cyrus/mod_auth_cyrus.lua && \
+    wget -qO /prosody-plugins/sasl_cyrus.lua https://hg.prosody.im/prosody-modules/raw-file/65438e4ba563/mod_auth_cyrus/sasl_cyrus.lua  && \
     apt-cleanup && \
     rm -rf /tmp/pkg /var/cache/apt && \
     rm -rf /etc/prosody && \

--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -50,6 +50,8 @@ RUN wget -qO /etc/apt/trusted.gpg.d/prosody.gpg https://prosody.im/files/prosody
     mv /tmp/pkg/usr/share/jitsi-meet/prosody-plugins /prosody-plugins && \
     rm -f /prosody-plugins/token/util.lib.lua && \
     wget -qO /prosody-plugins/token/util.lib.lua https://raw.githubusercontent.com/jitsi/jitsi-meet/46dd88c91b63988f516114daee65ff8995c74c56/resources/prosody-plugins/token/util.lib.lua && \
+    wget -qO /prosody-plugins/mod_auth_cyrus.lua https://hg.prosody.im/prosody-modules/raw-file/tip/mod_auth_cyrus/mod_auth_cyrus.lua && \
+    wget -qO /prosody-plugins/sasl_cyrus.lua https://hg.prosody.im/prosody-modules/raw-file/tip/mod_auth_cyrus/sasl_cyrus.lua && \
     apt-cleanup && \
     rm -rf /tmp/pkg /var/cache/apt && \
     rm -rf /etc/prosody && \


### PR DESCRIPTION
- with prosody 0.12 mod_auth_cyrus moved to community repos see: https://prosody.im/doc/release/0.12.0
- manually adding mod_auth_cyrus and sasl_cyrus to bring back LDAP auth
- should fix #1264 