### PR TITLE
Update generatePassword function

### DIFF
--- a/gen-passwords.sh
+++ b/gen-passwords.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 
 function generatePassword() {
-    openssl rand -hex 16
+    # there is a clean base64 conversion we can use:
+    #   where:
+    #       R = random bytes count
+    #       L = base64 string length
+    #   L = R(4/3)
+    # therefore 48 will generate a 64 character base64 string
+    head -c 48 /dev/urandom | base64 -w0
 }
 
 JICOFO_AUTH_PASSWORD=$(generatePassword)


### PR DESCRIPTION
This update helps make the `generatePassword` function a bit more portable, by removing the use of `openssl` the script can run on systems without `openssl` installed. `head`, `/dev/urandom` and `base64` are more likely to be available.

To adjust the length of the generated string, there is a comment in the function which explains the calculation for the value of the `-c` argument, however, it is best to use a multiple of 3. It prevents trailing equals signs (`=`) from being generated.

Raising the length from 16 to 64, and using base64 instead of base16, also increases the complexity. This is more of a personal preference, being overly secure by default. However, I'm not very familiar with the verification methods used yet (everything seems to work though), so this may need to be adjusted to align with any constrains, if any.