### PR TITLE
Fix for prosody reservation API prefix issue on docker

### DIFF
--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -167,7 +167,7 @@ VirtualHost "{{ $XMPP_DOMAIN }}"
     {{ end }}
 
     {{ if $PROSODY_RESERVATION_ENABLED }}
-    reservations_api_prefix = { "{{ $PROSODY_RESERVATION_REST_BASE_URL }}" }  
+    reservations_api_prefix = "{{ $PROSODY_RESERVATION_REST_BASE_URL }}" 
     {{ end }}
 
     {{ if $ENABLE_BREAKOUT_ROOMS }}


### PR DESCRIPTION
Fix for https://github.com/jitsi/jitsi-meet/issues/11623