### PR TITLE
feat(jvb): allow underscore in JVB_WS_SERVER_ID

### DIFF
--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -53,7 +53,7 @@ location ~ ^/(libs|css|static|images|fonts|lang|sounds|connection_optimization|.
 
 {{ if $ENABLE_COLIBRI_WEBSOCKET }}
 # colibri (JVB) websockets
-location ~ ^/colibri-ws/([a-zA-Z0-9-\.]+)/(.*) {
+location ~ ^/colibri-ws/([a-zA-Z0-9-\._]+)/(.*) {
     tcp_nodelay on;
 
     proxy_http_version 1.1;


### PR DESCRIPTION
Swarm adds `_<service>` to build the service / container name. Adding the underscore to the regex will allow setting `JVB_WS_SERVER_ID` to the docker service name.