### PR TITLE
fix(jvb): jvb.conf parsing error

### DIFF
--- a/jvb/rootfs/defaults/jvb.conf
+++ b/jvb/rootfs/defaults/jvb.conf
@@ -1,14 +1,14 @@
-{{ $COLIBRI_REST_ENABLED := .Env.COLIBRI_REST_ENABLED | default "false" | toBool }}
-{{ $ENABLE_COLIBRI_WEBSOCKET := .Env.ENABLE_COLIBRI_WEBSOCKET | default "1" | toBool }}
-{{ $ENABLE_OCTO := .Env.ENABLE_OCTO | default "0" | toBool }}
-{{ $ENABLE_MULTI_STREAM := .Env.ENABLE_MULTI_STREAM | default "0" | toBool }}
-{{ $JVB_DISABLE_STUN := .Env.JVB_DISABLE_STUN- | default "0" | toBool }}
+{{ $COLIBRI_REST_ENABLED := .Env.COLIBRI_REST_ENABLED | default "false" | toBool -}}
+{{ $ENABLE_COLIBRI_WEBSOCKET := .Env.ENABLE_COLIBRI_WEBSOCKET | default "1" | toBool -}}
+{{ $ENABLE_OCTO := .Env.ENABLE_OCTO | default "0" | toBool -}}
+{{ $ENABLE_MULTI_STREAM := .Env.ENABLE_MULTI_STREAM | default "0" | toBool -}}
+{{ $JVB_DISABLE_STUN := .Env.JVB_DISABLE_STUN | default "0" | toBool -}}
 {{ $JVB_STUN_SERVERS := .Env.JVB_STUN_SERVERS | default "meet-jit-si-turnrelay.jitsi.net:443" -}}
 {{ $JVB_AUTH_USER := .Env.JVB_AUTH_USER | default "jvb" -}}
 {{ $JVB_BREWERY_MUC := .Env.JVB_BREWERY_MUC | default "jvbbrewery" -}}
 {{ $JVB_MUC_NICKNAME := .Env.JVB_MUC_NICKNAME | default .Env.HOSTNAME -}}
 {{ $PUBLIC_URL_DOMAIN := .Env.PUBLIC_URL | default "https://localhost:8443" | trimPrefix "https://" | trimSuffix "/" -}}
-{{ $SHUTDOWN_REST_ENABLED := .Env.SHUTDOWN_REST_ENABLED | default "false" | toBool }}
+{{ $SHUTDOWN_REST_ENABLED := .Env.SHUTDOWN_REST_ENABLED | default "false" | toBool -}}
 {{ $WS_DOMAIN := .Env.JVB_WS_DOMAIN | default $PUBLIC_URL_DOMAIN -}}
 {{ $WS_SERVER_ID := .Env.JVB_WS_SERVER_ID | default .Env.JVB_WS_SERVER_ID_FALLBACK -}}
 {{ $XMPP_AUTH_DOMAIN := .Env.XMPP_AUTH_DOMAIN | default "auth.meet.jitsi" -}}
@@ -40,7 +40,7 @@ videobridge {
                     MUC_NICKNAME = "{{ $JVB_MUC_NICKNAME }}"
                     DISABLE_CERTIFICATE_VERIFICATION = true
                 }
-{{ end }}
+{{ end -}}
             }
         }
         rest {
@@ -65,7 +65,7 @@ videobridge {
         enabled = {{ $ENABLE_MULTI_STREAM }}
     }
     http-servers {
-        private { 
+        private {
           host = 0.0.0.0
         }
         public {


### PR DESCRIPTION
Fixes `panic: unable to parse template file: template: /defaults/jvb.conf:5: bad character U+002D '-' error` in jvb and some minor cosmetics.