### PR TITLE
Allow configuration of MUC Modules through ENV variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -218,6 +218,7 @@ services:
             - XMPP_INTERNAL_MUC_DOMAIN
             - XMPP_MODULES
             - XMPP_MUC_MODULES
+            - XMPP_MUC_CONFIGURATION
             - XMPP_INTERNAL_MUC_MODULES
             - XMPP_RECORDER_DOMAIN
             - XMPP_PORT

--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -243,6 +243,9 @@ Component "{{ $XMPP_MUC_DOMAIN }}" "muc"
     muc_room_cache_size = 1000
     muc_room_locking = false
     muc_room_default_public_jids = true
+    {{ if .Env.XMPP_MUC_CONFIGURATION -}}
+    "{{ join "\"\n\"" (splitList "," .Env.XMPP_MUC_CONFIGURATION) }}";
+    {{ end -}}
 
 Component "focus.{{ $XMPP_DOMAIN }}" "client_proxy"
     target_address = "{{ $JICOFO_AUTH_USER }}@{{ $XMPP_AUTH_DOMAIN }}"


### PR DESCRIPTION
This one is allowing configuration of added XMPP_MUC_MODULES for issue #1310