### PR TITLE
fix: properly use default SIP config

### DIFF
--- a/jigasi/rootfs/defaults/sip-communicator.properties
+++ b/jigasi/rootfs/defaults/sip-communicator.properties
@@ -21,7 +21,7 @@ net.java.sip.communicator.packetlogging.PACKET_LOGGING_ENABLED=false
 
 # SIP account
 net.java.sip.communicator.impl.protocol.sip.acc1=acc1
-{{ if and .Env.JIGASI_SIP_PORT .Env.JIGASI_SIP_TRANSPORT }}
+{{ if .Env.JIGASI_SIP_SERVER }}
 net.java.sip.communicator.impl.protocol.sip.acc1.PROXY_ADDRESS={{ .Env.JIGASI_SIP_SERVER }}
 net.java.sip.communicator.impl.protocol.sip.acc1.PROXY_AUTO_CONFIG=false
 net.java.sip.communicator.impl.protocol.sip.acc1.PROXY_PORT={{ .Env.JIGASI_SIP_PORT | default "5060" }}


### PR DESCRIPTION
The default values for JIGASI_SIP_PORT and JIGASI_SIP_TRANSPORT were never used