### PR TITLE
Bugfix

### DIFF
--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -244,7 +244,7 @@ Component "{{ $XMPP_MUC_DOMAIN }}" "muc"
     muc_room_locking = false
     muc_room_default_public_jids = true
     {{ if .Env.XMPP_MUC_CONFIGURATION -}}
-    "{{ join "\"\n\"" (splitList "," .Env.XMPP_MUC_CONFIGURATION) }}";
+    {{ join "\n\t" (splitList "," .Env.XMPP_MUC_CONFIGURATION) }}
     {{ end -}}
 
 Component "focus.{{ $XMPP_DOMAIN }}" "client_proxy"

--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -244,7 +244,7 @@ Component "{{ $XMPP_MUC_DOMAIN }}" "muc"
     muc_room_locking = false
     muc_room_default_public_jids = true
     {{ if .Env.XMPP_MUC_CONFIGURATION -}}
-    {{ join "\n\t" (splitList "," .Env.XMPP_MUC_CONFIGURATION) }}
+    {{ join "\n" (splitList "," .Env.XMPP_MUC_CONFIGURATION) }}
     {{ end -}}
 
 Component "focus.{{ $XMPP_DOMAIN }}" "client_proxy"


### PR DESCRIPTION
I clearly don't understand the synthax here. Can someone confirm that this is correct?

I got a config that had my data but was poorly formatted and had one too many strings and an ending semi-colon.

   muc_room_default_public_jids = true
    "muc_max_occupants="2""
"muc_other="30";