### PR TITLE
make prosody use ENABLE_IPV6 environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,6 +159,7 @@ services:
             - ENABLE_AV_MODERATION
             - ENABLE_BREAKOUT_ROOMS
             - ENABLE_GUESTS
+            - ENABLE_IPV6
             - ENABLE_LOBBY
             - ENABLE_RECORDING
             - ENABLE_XMPP_WEBSOCKET

--- a/prosody/rootfs/defaults/prosody.cfg.lua
+++ b/prosody/rootfs/defaults/prosody.cfg.lua
@@ -188,10 +188,8 @@ unbound = {
 http_ports = { 5280 }
 {{ if $ENABLE_IPV6 }}
 http_interfaces = { "*", "::" }
-https_interfaces = { "*", "::" }
 {{ else }}
 http_interfaces = { "*" }
-https_interfaces = { "*" }
 {{ end }}
 
 data_path = "/config/data"

--- a/prosody/rootfs/defaults/prosody.cfg.lua
+++ b/prosody/rootfs/defaults/prosody.cfg.lua
@@ -1,5 +1,6 @@
 {{ $LOG_LEVEL := .Env.LOG_LEVEL | default "info" }}
 {{ $XMPP_PORT := .Env.XMPP_PORT | default "5222" -}}
+{{ $ENABLE_IPV6 := .Env.ENABLE_IPV6 | default "true" | toBool -}}
 
 -- Prosody Example Configuration File
 --
@@ -180,7 +181,13 @@ unbound = {
 }
 
 http_ports = { 5280 }
+{{ if $ENABLE_IPV6 }}
 http_interfaces = { "*", "::" }
+https_interfaces = { "*", "::" }
+{{ else }}
+http_interfaces = { "*" }
+https_interfaces = { "*" }
+{{ end }}
 
 data_path = "/config/data"
 

--- a/prosody/rootfs/defaults/prosody.cfg.lua
+++ b/prosody/rootfs/defaults/prosody.cfg.lua
@@ -114,6 +114,11 @@ c2s_require_encryption = false
 
 -- set c2s port
 c2s_ports = { {{ $XMPP_PORT }} } -- Listen on specific c2s port
+{{ if $ENABLE_IPV6 }}
+c2s_interfaces = { "*", "::" }
+{{ else }}
+c2s_interfaces = { "*" }
+{{ end }}
 
 -- Force certificate authentication for server-to-server connections?
 -- This provides ideal security, but requires servers you communicate


### PR DESCRIPTION
As discussed in #1337 changing `docker-compose.yml` and `prosody.cfg.lua` to make prosody use the `ENABLE_IPV6` environment variable.