### PR TITLE
Add support for wav files to nginx default.

### DIFF
--- a/web/rootfs/defaults/nginx.conf
+++ b/web/rootfs/defaults/nginx.conf
@@ -32,6 +32,8 @@ http {
 	types {
 		# add support for wasm MIME type, that is required by specification and it is not part of default mime.types file
 		application/wasm wasm;
+		# add support for the wav MIME type that is requried to playback wav files in Firefox.
+		audio/wav        wav;
 	}
 	default_type application/octet-stream;
 


### PR DESCRIPTION
Nginx does not define a MIME type for wav files by default.  This causes Firefox to refuse to load these files.
By adding this MIME type, we can ensure that Firefox plays back all interface sounds by default.
Issue is further described in: https://github.com/jitsi/jitsi-meet/issues/11860