### PR TITLE
Added functionality for docker container to set max occupants allowed in a single room

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -207,6 +207,7 @@ services:
             - LDAP_START_TLS
             - LDAP_URL
             - LDAP_USE_TLS
+            - MAX_PARTICIPANTS
             - PROSODY_RESERVATION_ENABLED
             - PROSODY_RESERVATION_REST_BASE_URL
             - PUBLIC_URL

--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -239,6 +239,9 @@ Component "{{ $XMPP_MUC_DOMAIN }}" "muc"
         {{ if $ENABLE_SUBDOMAINS -}}
         "muc_domain_mapper";
         {{ end -}}
+        {{ if .Env.MAX_PARTICIPANTS }}
+        "muc_max_occupants";
+        {{ end }
     }
     muc_room_cache_size = 1000
     muc_room_locking = false
@@ -246,6 +249,10 @@ Component "{{ $XMPP_MUC_DOMAIN }}" "muc"
     {{ if .Env.XMPP_MUC_CONFIGURATION -}}
     {{ join "\n" (splitList "," .Env.XMPP_MUC_CONFIGURATION) }}
     {{ end -}}
+    {{ if .Env.MAX_PARTICIPANTS }}
+    muc_access_whitelist = { "{{ .Env.JICOFO_AUTH_USER }}@{{ .Env.XMPP_AUTH_DOMAIN }}" }
+    muc_max_occupants = "{{ .Env.MAX_PARTICIPANTS }}"
+    {{ end }}
 
 Component "focus.{{ $XMPP_DOMAIN }}" "client_proxy"
     target_address = "{{ $JICOFO_AUTH_USER }}@{{ $XMPP_AUTH_DOMAIN }}"


### PR DESCRIPTION
I have added the option to be able to set a max number of occupants into a room via the docker jitsi-meet.cfg.lua template file.

It keys off if a user has set the ENVIRONMENT variable MAX_PARTICIPANTS in there env file or docker run command. Ie to specify 25 occupants max in a room set an env variable MAX_PARTICIPANTS=25

Please let me know what you think or if you have any comments