### PR TITLE
prosody: fix not finding the basexx module

### DIFF
--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -1,6 +1,23 @@
 ARG JITSI_REPO=jitsi
 ARG BASE_TAG=latest
 
+FROM ${JITSI_REPO}/base:${BASE_TAG} as builder
+
+RUN apt-dpkg-wrap apt-get update && \
+    apt-dpkg-wrap apt-get install -y \
+      build-essential \
+      lua5.4 \
+      liblua5.4-dev \
+      libreadline-dev \
+      git \
+      unzip \
+      wget && \
+    mkdir /tmp/luarocks && \
+    wget -qO - https://luarocks.github.io/luarocks/releases/luarocks-3.8.0.tar.gz | tar xfz - --strip-components 1 -C /tmp/luarocks && \
+    cd /tmp/luarocks && ./configure && make && make install && cd - && \
+    luarocks install basexx 0.4.1-1 && \
+    luarocks install lua-cjson 2.1.0-1
+
 FROM ${JITSI_REPO}/base:${BASE_TAG}
 
 LABEL org.opencontainers.image.title="Prosody IM"
@@ -21,8 +38,6 @@ RUN wget -qO /etc/apt/trusted.gpg.d/prosody.gpg https://prosody.im/files/prosody
       libldap-common \
       sasl2-bin \
       libsasl2-modules-ldap \
-      lua-basexx \
-      lua-cjson \
       lua-cyrussasl \
       lua-ldap \
       lua-luaossl \
@@ -43,6 +58,10 @@ RUN wget -qO /etc/apt/trusted.gpg.d/prosody.gpg https://prosody.im/files/prosody
     rm -rf prosody-mod-auth-matrix-user-verification-$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN v$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN.tar.gz
 
 COPY rootfs/ /
+
+COPY --from=builder /usr/local/lib/lua/5.4/cjson.so /usr/local/lib/lua/5.4/
+COPY --from=builder /usr/local/share/lua/5.4/basexx.lua /usr/local/share/lua/5.4/
+COPY --from=builder /usr/local/share/lua/5.4/cjson /usr/local/share/lua/5.4/
 
 EXPOSE 5222 5280
 

--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -42,15 +42,15 @@ RUN wget -qO /etc/apt/trusted.gpg.d/prosody.gpg https://prosody.im/files/prosody
       lua-ldap \
       lua-luaossl \
       lua-sec \
-      lua-unbound && \
-    apt-dpkg-wrap apt-get -d install -y jitsi-meet-prosody && \
-    dpkg -x /var/cache/apt/archives/jitsi-meet-prosody*.deb /tmp/pkg && \
-    mv /tmp/pkg/usr/share/jitsi-meet/prosody-plugins /prosody-plugins && \
+      lua-unbound \
+      jitsi-meet-prosody && \
+    apt-cleanup && \
+    rm -rf /etc/prosody && \
+    mv /usr/share/jitsi-meet/prosody-plugins /prosody-plugins && \
+    rm -rf /usr/lib/lua/{5.1,5.2,5.3} && \
+    rm -rf /usr/share/lua/{5.1,5.2,5.3} && \
     wget -qO /prosody-plugins/mod_auth_cyrus.lua https://hg.prosody.im/prosody-modules/raw-file/65438e4ba563/mod_auth_cyrus/mod_auth_cyrus.lua && \
     wget -qO /prosody-plugins/sasl_cyrus.lua https://hg.prosody.im/prosody-modules/raw-file/65438e4ba563/mod_auth_cyrus/sasl_cyrus.lua  && \
-    apt-cleanup && \
-    rm -rf /tmp/pkg /var/cache/apt && \
-    rm -rf /etc/prosody && \
     wget https://github.com/matrix-org/prosody-mod-auth-matrix-user-verification/archive/refs/tags/v$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN.tar.gz && \
     tar -xf v$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN.tar.gz && \
     mv prosody-mod-auth-matrix-user-verification-$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN/mod_auth_matrix_user_verification.lua /prosody-plugins && \


### PR DESCRIPTION
Debian doesn't provide a Lua > 5.2 packaged version.

Fixes: https://github.com/jitsi/docker-jitsi-meet/issues/1359