### PR TITLE
Migrating configuration to use secure octo configuration by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
             - ENABLE_LIPSYNC
             - ENABLE_NO_AUDIO_DETECTION
             - ENABLE_NOISY_MIC_DETECTION
+            - ENABLE_OCTO
             - ENABLE_OPUS_RED
             - ENABLE_PREJOIN_PAGE
             - ENABLE_P2P
@@ -306,9 +307,8 @@ services:
             - JVB_MUC_NICKNAME
             - JVB_STUN_SERVERS
             - JVB_OCTO_BIND_ADDRESS
-            - JVB_OCTO_PUBLIC_ADDRESS
-            - JVB_OCTO_BIND_PORT
             - JVB_OCTO_REGION
+            - JVB_OCTO_RELAY_ID
             - JVB_WS_DOMAIN
             - JVB_WS_SERVER_ID
             - PUBLIC_URL

--- a/jvb/rootfs/defaults/jvb.conf
+++ b/jvb/rootfs/defaults/jvb.conf
@@ -75,12 +75,10 @@ videobridge {
     }
 
     {{ if $ENABLE_OCTO -}}
-    octo {
+    relay {
         enabled = true
-        bind-address = "{{ .Env.JVB_OCTO_BIND_ADDRESS | default "0.0.0.0" }}"
-        public-address = "{{ .Env.JVB_OCTO_PUBLIC_ADDRESS }}"
-        bind-port = "{{ .Env.JVB_OCTO_BIND_PORT | default "4096" }}"
         region = "{{ .Env.JVB_OCTO_REGION | default "europe" }}"
+        relay-id = "{{ .Env.JVB_OCTO_RELAY_ID | default .Env.JVB_OCTO_BIND_ADDRESS }}"
     }
     {{ end -}}
 }

--- a/jvb/rootfs/etc/cont-init.d/10-config
+++ b/jvb/rootfs/etc/cont-init.d/10-config
@@ -31,3 +31,9 @@ tpl /defaults/logging.properties > /config/logging.properties
 tpl /defaults/jvb.conf > /config/jvb.conf
 
 chown -R jvb:jitsi /config
+
+# Configuration checks
+if [[ (-z $ENABLE_COLIBRI_WEBSOCKET || $ENABLE_COLIBRI_WEBSOCKET == "0") && $ENABLE_OCTO == "1"  ]]; then
+  echo "ERROR: In order to enable Octo relays (with ENABLE_OCTO=1), you MUST enable Colibri websockets (with ENABLE_COLIBRI_WEBSOCKET=1)";
+  exit 1;
+fi

--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -1,5 +1,6 @@
 {{ $ENABLE_COLIBRI_WEBSOCKET := .Env.ENABLE_COLIBRI_WEBSOCKET | default "1" | toBool }}
 {{ $ENABLE_JAAS_COMPONENTS := .Env.ENABLE_JAAS_COMPONENTS | default "0" | toBool }}
+{{ $ENABLE_OCTO := .Env.ENABLE_OCTO | default "0" | toBool -}}
 {{ $ENABLE_XMPP_WEBSOCKET := .Env.ENABLE_XMPP_WEBSOCKET | default "1" | toBool }}
 {{ $ENABLE_SUBDOMAINS := .Env.ENABLE_SUBDOMAINS | default "true" | toBool -}}
 {{ $XMPP_DOMAIN := .Env.XMPP_DOMAIN | default "meet.jitsi" -}}
@@ -72,6 +73,19 @@ location ~ ^/colibri-ws/([a-zA-Z0-9-\._]+)/(.*) {
 
     proxy_pass http://$1:9090/colibri-ws/$1/$2$is_args$args;
 }
+
+{{ if $ENABLE_OCTO }}
+# colibri (JVB) Relay to Relay websockets
+location ~ ^/colibri-relay-ws/([a-zA-Z0-9-\._]+)/(.*) {
+    tcp_nodelay on;
+
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+
+    proxy_pass http://$1:9090/colibri-relay-ws/$1/$2$is_args$args;
+}
+{{ end }}
 {{ end }}
 
 # BOSH


### PR DESCRIPTION
I'm using Octo and with the latest version, I started noticing errors in the JVB logs:

```
JVB 2022-08-17 13:04:31.625 SEVERE: [19] [confId=911e1687f8f3fad0 conf_name=kz1zbo-chillzone@muc.prosody.myserver.net relayId=34.242.225.XXX] Relay.scheduleRelayMessageTransportTimeout$lambda-50#696: RelayMessageTransport still not connected.
```

According to [this post](https://community.jitsi.org/t/new-client-joins-conference-wtih-octo-causes-existing-one-to-lose-video/113860/41?page=3) and [this PR](https://github.com/jitsi/jitsi-videobridge/pull/1873), it seems that with secure octo, we now need to proxy the endpoint that allows communication between relay servers.

But this proxy of `colibri-relay-ws` is not currently possible in docker-jitsi-meet.

This PR adds the `colibri-relay-ws` proxying to Nginx (behind a `$ENABLE_OCTO` flag).

Also, I took the liberty to migrate the old "octo" configuration to the new format.
The new format requires a "relay-id" parameter so I added the new JVB_OCTO_RELAY_ID environment variable.

In order to keep a compatibility with the old images, I'm falling back to JVB_OCTO_BIND_ADDRESS if JVB_OCTO_RELAY_ID is not found.
