### PR TITLE
Adapting Jibri configuration for new Jitsi web behaviour

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,7 @@ services:
             - ENABLE_P2P
             - ENABLE_WELCOME_PAGE
             - ENABLE_CLOSE_PAGE
+            - ENABLE_LIVESTREAMING
             - ENABLE_LOCAL_RECORDING_NOTIFY_ALL_PARTICIPANT
             - ENABLE_LOCAL_RECORDING_SELF_START
             - ENABLE_RECORDING

--- a/web/rootfs/defaults/settings-config.js
+++ b/web/rootfs/defaults/settings-config.js
@@ -11,6 +11,7 @@
 {{ $ENABLE_WELCOME_PAGE := .Env.ENABLE_WELCOME_PAGE | default "true" | toBool -}}
 {{ $ENABLE_CLOSE_PAGE := .Env.ENABLE_CLOSE_PAGE | default "false" | toBool -}}
 {{ $ENABLE_RECORDING := .Env.ENABLE_RECORDING | default "false" | toBool -}}
+{{ $ENABLE_LIVESTREAMING := .Env.ENABLE_LIVESTREAMING | default "false" | toBool -}}
 {{ $ENABLE_REMB := .Env.ENABLE_REMB | default "true" | toBool -}}
 {{ $ENABLE_REQUIRE_DISPLAY_NAME := .Env.ENABLE_REQUIRE_DISPLAY_NAME | default "false" | toBool -}}
 {{ $ENABLE_SIMULCAST := .Env.ENABLE_SIMULCAST | default "true" | toBool -}}
@@ -135,17 +136,17 @@ config.etherpad_base = '{{ $PUBLIC_URL }}/etherpad/p/';
 // Recording.
 //
 
-{{ if $ENABLE_RECORDING -}}
+{{ if or $ENABLE_RECORDING .Env.DROPBOX_APPKEY $ENABLE_LIVESTREAMING  -}}
 
 config.hiddenDomain = '{{ $XMPP_RECORDER_DOMAIN }}';
 
 if (!config.hasOwnProperty('recordingService')) config.recordingService = {};
 
 // Whether to enable file recording or not
-config.recordingService.enabled = true;
+config.recordingService.enabled = {{ $ENABLE_RECORDING }};
 
 // Whether to enable live streaming or not.
-config.liveStreamingEnabled = true;
+config.liveStreamingEnabled = {{ $ENABLE_LIVESTREAMING }};
 
 {{ if .Env.DROPBOX_APPKEY -}}
 // Enable the dropbox integration.


### PR DESCRIPTION
In the latest version of Jitsi web, the behaviour of the "recording" settings has slightly changed.

Now, when you "enable" recording with `config.recordingService.enabled = true`, this enables the "custom recording service" provided by the server. And you can enable dropbox independently.

If you want to enable only Dropbox recording, you need to set `config.recordingService.enabled = false`.

In the previous versions, you had to set the flag to true, and only Dropbox was available.

In the new version, both recording strategies can be enabled independently:

![Capture d’écran du 2022-08-17 20-48-35](https://user-images.githubusercontent.com/1290952/185240263-acaf395c-5c63-4a6f-bf03-e53df4f71ed4.png)

Most users having Dropbox configured will want to disable the "custom recording service", which is currently not possible.

This PR modifies the generation of `settings-config.js`.

Now, the `ENABLE_RECORDING` variable only enables or disables the custom recording service.
Setting `ENABLE_RECORDING=false` + `DROPBOX_APPKEY=[value]` will enable dropbox recording.

In order to be complete, since everything can be configured independently, I took the liberty to add a new `ENABLE_LIVESTREAMING` variable to allow the live streaming (it was previously tied to ENABLE_RECORDING)

The `ENABLE_LIVESTREAMING` will need to be properly documented (I'm not sure if this doc is available somewhere, if it is in another repo, I can provide a PR)