### PR TITLE
Fixing ENABLE_RECORDING issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ services:
             - ENABLE_RECORDING
             - ENABLE_REMB
             - ENABLE_REQUIRE_DISPLAY_NAME
+            - ENABLE_SERVICE_RECORDING
             - ENABLE_SIMULCAST
             - ENABLE_STATS_ID
             - ENABLE_STEREO

--- a/web/rootfs/defaults/settings-config.js
+++ b/web/rootfs/defaults/settings-config.js
@@ -11,7 +11,7 @@
 {{ $ENABLE_WELCOME_PAGE := .Env.ENABLE_WELCOME_PAGE | default "true" | toBool -}}
 {{ $ENABLE_CLOSE_PAGE := .Env.ENABLE_CLOSE_PAGE | default "false" | toBool -}}
 {{ $ENABLE_RECORDING := .Env.ENABLE_RECORDING | default "false" | toBool -}}
-{{ $ENABLE_SERVICE_RECORDING := .Env.ENABLE_SERVICE_RECORDING | default "true" | toBool -}}
+{{ $ENABLE_SERVICE_RECORDING := .Env.ENABLE_SERVICE_RECORDING | default ($ENABLE_RECORDING | printf "%t") | toBool -}}
 {{ $ENABLE_LIVESTREAMING := .Env.ENABLE_LIVESTREAMING | default "false" | toBool -}}
 {{ $ENABLE_REMB := .Env.ENABLE_REMB | default "true" | toBool -}}
 {{ $ENABLE_REQUIRE_DISPLAY_NAME := .Env.ENABLE_REQUIRE_DISPLAY_NAME | default "false" | toBool -}}

--- a/web/rootfs/defaults/settings-config.js
+++ b/web/rootfs/defaults/settings-config.js
@@ -11,6 +11,7 @@
 {{ $ENABLE_WELCOME_PAGE := .Env.ENABLE_WELCOME_PAGE | default "true" | toBool -}}
 {{ $ENABLE_CLOSE_PAGE := .Env.ENABLE_CLOSE_PAGE | default "false" | toBool -}}
 {{ $ENABLE_RECORDING := .Env.ENABLE_RECORDING | default "false" | toBool -}}
+{{ $ENABLE_SERVICE_RECORDING := .Env.ENABLE_SERVICE_RECORDING | default "true" | toBool -}}
 {{ $ENABLE_LIVESTREAMING := .Env.ENABLE_LIVESTREAMING | default "false" | toBool -}}
 {{ $ENABLE_REMB := .Env.ENABLE_REMB | default "true" | toBool -}}
 {{ $ENABLE_REQUIRE_DISPLAY_NAME := .Env.ENABLE_REQUIRE_DISPLAY_NAME | default "false" | toBool -}}
@@ -136,14 +137,14 @@ config.etherpad_base = '{{ $PUBLIC_URL }}/etherpad/p/';
 // Recording.
 //
 
-{{ if or $ENABLE_RECORDING .Env.DROPBOX_APPKEY $ENABLE_LIVESTREAMING  -}}
+{{ if $ENABLE_RECORDING  -}}
 
 config.hiddenDomain = '{{ $XMPP_RECORDER_DOMAIN }}';
 
 if (!config.hasOwnProperty('recordingService')) config.recordingService = {};
 
-// Whether to enable file recording or not
-config.recordingService.enabled = {{ $ENABLE_RECORDING }};
+// Whether to enable file recording or not using the "service" defined by the finalizer in Jibri
+config.recordingService.enabled = {{ $ENABLE_SERVICE_RECORDING }};
 
 // Whether to enable live streaming or not.
 config.liveStreamingEnabled = {{ $ENABLE_LIVESTREAMING }};


### PR DESCRIPTION
In https://github.com/jitsi/docker-jitsi-meet/pull/1372, I made a change to allow the web component to set ENABLE_RECORDING and still enable recording (in order to have "service recording" disabled but Dropbox recording enabled.

I failed to notice that the ENABLE_RECORDING environment variable is also used in Prosody as a global switch ([here](https://github.com/jitsi/docker-jitsi-meet/blob/475be2af18a14ea5bc00882152904fa473267190/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua#L166)). @saghul  I'm sorry I overlooked this.

With the new variable semantic (as proposed in #1372), in order to know if Jibri must be enabled or not, we need 3 variables (ENABLE_RECORDING, DROPBOX_APPKEY and ENABLE_LIVESTREAMING).
This means we should also propagate those variables to Prosody.

To be honest, having the "DROPBOX_APPKEY" forwarded to Prosody just to know if we should enable or disable recording is a bit weird.

So I feel it is a better idea to revert back the meaning of "ENABLE_RECORDING" to be a global switch.

I'm therefore reverting back to old behaviour and adding a new environment variable (ENABLE_SERVICE_RECORDING) that allows turning on or off the "service recording".

(alternatively, we can keep the keep #1372 as is and I can forward DROPBOX_APPKEY and ENABLE_LIVESTREAMING to Prosody to do the check. @saghul tell me what you prefer)