### PR TITLE
JVB: allow configuration of videobridge.ice.advertise-private-candidates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -298,6 +298,7 @@ services:
             - ENABLE_COLIBRI_WEBSOCKET
             - ENABLE_OCTO
             - ENABLE_MULTI_STREAM
+            - JVB_ADVERTISE_PRIVATE_CANDIDATES
             - JVB_AUTH_USER
             - JVB_AUTH_PASSWORD
             - JVB_BREWERY_MUC

--- a/jvb/rootfs/defaults/jvb.conf
+++ b/jvb/rootfs/defaults/jvb.conf
@@ -7,6 +7,7 @@
 {{ $JVB_AUTH_USER := .Env.JVB_AUTH_USER | default "jvb" -}}
 {{ $JVB_BREWERY_MUC := .Env.JVB_BREWERY_MUC | default "jvbbrewery" -}}
 {{ $JVB_MUC_NICKNAME := .Env.JVB_MUC_NICKNAME | default .Env.HOSTNAME -}}
+{{ $JVB_ADVERTISE_PRIVATE_CANDIDATES := .Env.JVB_ADVERTISE_PRIVATE_CANDIDATES | default "true" | toBool -}}
 {{ $PUBLIC_URL_DOMAIN := .Env.PUBLIC_URL | default "https://localhost:8443" | trimPrefix "https://" | trimSuffix "/" -}}
 {{ $SHUTDOWN_REST_ENABLED := .Env.SHUTDOWN_REST_ENABLED | default "false" | toBool -}}
 {{ $WS_DOMAIN := .Env.JVB_WS_DOMAIN | default $PUBLIC_URL_DOMAIN -}}
@@ -24,6 +25,7 @@ videobridge {
         udp {
             port = {{ .Env.JVB_PORT | default 10000 }}
         }
+        advertise-private-candidates = {{ $JVB_ADVERTISE_PRIVATE_CANDIDATES }}
     }
     apis {
         xmpp-client {


### PR DESCRIPTION
Similar to https://github.com/jitsi/docker-jitsi-meet/pull/1306 but keeps the current default and is configurable via an ENV var