### PR TITLE
fix JWT_ENABLE_DOMAIN_VERIFICATION missing in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,6 +197,7 @@ services:
             - JWT_ASAP_KEYSERVER
             - JWT_ALLOW_EMPTY
             - JWT_AUTH_TYPE
+            - JWT_ENABLE_DOMAIN_VERIFICATION
             - JWT_TOKEN_AUTH_MODULE
             - MATRIX_UVS_URL
             - MATRIX_UVS_ISSUER


### PR DESCRIPTION
variable JWT_ENABLE_DOMAIN_VERIFICATION was added in stable-7648 to prosody files but enabling in .env had no effects