### PR TITLE
Prosody: upgrade UVS module to be compatible with Prosody 0.12 and luajwtjitsi 3.0

### DIFF
--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -27,7 +27,7 @@ LABEL org.opencontainers.image.url="https://prosody.im/"
 LABEL org.opencontainers.image.source="https://github.com/jitsi/docker-jitsi-meet"
 LABEL org.opencontainers.image.documentation="https://jitsi.github.io/handbook/"
 
-ARG VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN="1.7.0"
+ARG VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN="1.8.0"
 
 RUN wget -qO /etc/apt/trusted.gpg.d/prosody.gpg https://prosody.im/files/prosody-debian-packages.key && \
     echo "deb http://packages.prosody.im/debian bullseye main" > /etc/apt/sources.list.d/prosody.list && \


### PR DESCRIPTION
RE #1394

Includes https://github.com/matrix-org/prosody-mod-auth-matrix-user-verification/pull/17 & https://github.com/matrix-org/prosody-mod-auth-matrix-user-verification/pull/18