### PR TITLE
Adding configurable module options in prosody

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -233,6 +233,8 @@ services:
             - XMPP_GUEST_DOMAIN
             - XMPP_MUC_DOMAIN
             - XMPP_INTERNAL_MUC_DOMAIN
+            - XMPP_OPTIONS
+            - XMPP_MUC_OPTIONS
             - XMPP_MODULES
             - XMPP_MUC_MODULES
             - XMPP_MUC_CONFIGURATION

--- a/env.example
+++ b/env.example
@@ -212,3 +212,9 @@ JIBRI_XMPP_PASSWORD=
 
 # Jitsi image version (useful for local development)
 #JITSI_IMAGE_VERSION=latest
+
+# Prosody Module Options
+#XMPP_OPTIONS='op1 = "value1",op2 = "value2"'
+
+# Prosody MUC Module Options
+#XMPP_MUC_OPTIONS='op1 = "value1",op2 = "value2"'

--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -202,6 +202,10 @@ VirtualHost "{{ $XMPP_DOMAIN }}"
     av_moderation_component = "avmoderation.{{ $XMPP_DOMAIN }}"
     {{ end }}
 
+    {{ if .Env.XMPP_OPTIONS }}
+    {{ join "\n" (splitList "," .Env.XMPP_OPTIONS) }}
+    {{ end }}
+
     c2s_require_encryption = false
 
 {{ if $ENABLE_GUEST_DOMAIN }}
@@ -273,6 +277,9 @@ Component "{{ $XMPP_MUC_DOMAIN }}" "muc"
     {{ if .Env.MAX_PARTICIPANTS }}
     muc_access_whitelist = { "{{ .Env.JICOFO_AUTH_USER }}@{{ .Env.XMPP_AUTH_DOMAIN }}" }
     muc_max_occupants = "{{ .Env.MAX_PARTICIPANTS }}"
+    {{ end }}
+    {{ if .Env.XMPP_MUC_OPTIONS }}
+    {{ join "\n" (splitList "," .Env.XMPP_MUC_OPTIONS) }}
     {{ end }}
 
 Component "focus.{{ $XMPP_DOMAIN }}" "client_proxy"


### PR DESCRIPTION
This is useful when used in conjuction with custom modules, especially when added from XMPP_MODULES and XMPP_MUC_MODULES, where you want to read specific custom options