### PR TITLE
fix: missing configuration options

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
             - ANALYTICS_SCRIPT_URLS
             - ANALYTICS_WHITELISTED_EVENTS
             - AUDIO_QUALITY_OPUS_BITRATE
+            - AUTO_CAPTION_ON_RECORD
             - BRANDING_DATA_URL
             - CALLSTATS_CUSTOM_SCRIPT_URL
             - CALLSTATS_ID
@@ -46,6 +47,7 @@ services:
             - DISABLE_PROFILE
             - DISABLE_REACTIONS
             - DISABLE_REMOTE_VIDEO_MENU
+            - DISABLE_START_FOR_ALL
             - DROPBOX_APPKEY
             - DROPBOX_REDIRECT_URI
             - DYNAMIC_BRANDING_URL
@@ -109,6 +111,7 @@ services:
             - NGINX_WORKER_PROCESSES
             - NGINX_WORKER_CONNECTIONS
             - PEOPLE_SEARCH_URL
+            - PREFERRED_LANGUAGE
             - PUBLIC_URL
             - P2P_PREFERRED_CODEC
             - RESOLUTION
@@ -126,7 +129,10 @@ services:
             - TESTING_OCTO_PROBABILITY
             - TOKEN_AUTH_URL
             - TOOLBAR_BUTTONS
+            - TRANSLATION_LANGUAGES
+            - TRANSLATION_LANGUAGES_HEAD
             - TZ
+            - USE_APP_LANGUAGE
             - VIDEOQUALITY_BITRATE_H264_LOW
             - VIDEOQUALITY_BITRATE_H264_STANDARD
             - VIDEOQUALITY_BITRATE_H264_HIGH

--- a/web/rootfs/defaults/settings-config.js
+++ b/web/rootfs/defaults/settings-config.js
@@ -22,6 +22,12 @@
 {{ $ENABLE_TALK_WHILE_MUTED := .Env.ENABLE_TALK_WHILE_MUTED | default "false" | toBool -}}
 {{ $ENABLE_TCC := .Env.ENABLE_TCC | default "true" | toBool -}}
 {{ $ENABLE_TRANSCRIPTIONS := .Env.ENABLE_TRANSCRIPTIONS | default "false" | toBool -}}
+{{ $TRANSLATION_LANGUAGES := .Env.TRANSLATION_LANGUAGES | default "['en', 'fr']" -}}
+{{ $TRANSLATION_LANGUAGES_HEAD := .Env.TRANSLATION_LANGUAGES_HEAD | default "['en']" -}}
+{{ $USE_APP_LANGUAGE := .Env.USE_APP_LANGUAGE | default "true" | toBool -}}
+{{ $PREFERRED_LANGUAGE := .Env.PREFERRED_LANGUAGE | default "en-US" -}}
+{{ $DISABLE_START_FOR_ALL := .Env.DISABLE_START_FOR_ALL | default "false" | toBool -}}
+{{ $AUTO_CAPTION_ON_RECORD := .Env.AUTO_CAPTION_ON_RECORD | default "false" | toBool -}}
 {{ $ENABLE_JAAS_COMPONENTS := .Env.ENABLE_JAAS_COMPONENTS | default "0" | toBool }}
 {{ $ENABLE_MULTI_STREAM := .Env.ENABLE_MULTI_STREAM | default "true" | toBool }}
 {{ $HIDE_PREJOIN_DISPLAY_NAME := .Env.HIDE_PREJOIN_DISPLAY_NAME | default "false" | toBool -}}
@@ -337,7 +343,13 @@ config.enableTcc = {{ $ENABLE_TCC }};
 config.useIPv6 = {{ $ENABLE_IPV6 }};
 
 // Transcriptions (subtitles and buttons can be configured in interface_config)
-config.transcribingEnabled = {{ $ENABLE_TRANSCRIPTIONS }};
+config.transcription = { enabled: {{ $ENABLE_TRANSCRIPTIONS }} };
+config.transcription.translationLanguages = {{ $TRANSLATION_LANGUAGES }};
+config.transcription.translationLanguagesHead = {{ $TRANSLATION_LANGUAGES_HEAD }};
+config.transcription.useAppLanguage = {{ $USE_APP_LANGUAGE }};
+config.transcription.preferredLanguage = {{ $PREFERRED_LANGUAGE }};
+config.transcription.disableStartForAll = {{ $DISABLE_START_FOR_ALL }};
+config.transcription.autoCaptionOnRecord = {{ $AUTO_CAPTION_ON_RECORD }};
 
 {{ if .Env.DYNAMIC_BRANDING_URL -}}
 // External API url used to receive branding specific information.

--- a/web/rootfs/defaults/settings-config.js
+++ b/web/rootfs/defaults/settings-config.js
@@ -22,7 +22,7 @@
 {{ $ENABLE_TALK_WHILE_MUTED := .Env.ENABLE_TALK_WHILE_MUTED | default "false" | toBool -}}
 {{ $ENABLE_TCC := .Env.ENABLE_TCC | default "true" | toBool -}}
 {{ $ENABLE_TRANSCRIPTIONS := .Env.ENABLE_TRANSCRIPTIONS | default "false" | toBool -}}
-{{ $TRANSLATION_LANGUAGES := .Env.TRANSLATION_LANGUAGES | default "['en', 'fr']" -}}
+{{ $TRANSLATION_LANGUAGES := .Env.TRANSLATION_LANGUAGES -}}
 {{ $TRANSLATION_LANGUAGES_HEAD := .Env.TRANSLATION_LANGUAGES_HEAD | default "['en']" -}}
 {{ $USE_APP_LANGUAGE := .Env.USE_APP_LANGUAGE | default "true" | toBool -}}
 {{ $PREFERRED_LANGUAGE := .Env.PREFERRED_LANGUAGE | default "en-US" -}}

--- a/web/rootfs/defaults/settings-config.js
+++ b/web/rootfs/defaults/settings-config.js
@@ -22,7 +22,7 @@
 {{ $ENABLE_TALK_WHILE_MUTED := .Env.ENABLE_TALK_WHILE_MUTED | default "false" | toBool -}}
 {{ $ENABLE_TCC := .Env.ENABLE_TCC | default "true" | toBool -}}
 {{ $ENABLE_TRANSCRIPTIONS := .Env.ENABLE_TRANSCRIPTIONS | default "false" | toBool -}}
-{{ $TRANSLATION_LANGUAGES := .Env.TRANSLATION_LANGUAGES -}}
+{{ $TRANSLATION_LANGUAGES := .Env.TRANSLATION_LANGUAGES | default "[]" -}}
 {{ $TRANSLATION_LANGUAGES_HEAD := .Env.TRANSLATION_LANGUAGES_HEAD | default "['en']" -}}
 {{ $USE_APP_LANGUAGE := .Env.USE_APP_LANGUAGE | default "true" | toBool -}}
 {{ $PREFERRED_LANGUAGE := .Env.PREFERRED_LANGUAGE | default "en-US" -}}


### PR DESCRIPTION
This PR fixes missing configurations from the latest version of Jitsi-meet (2.0.7830)

The [new configuration options for transcription](https://github.com/jitsi/jitsi-meet/blob/da9b5a91568f4d2544a93ab0def7bb67bdc9009c/config.js#L376-L407) are now implemented.

Please let me know if there is anything I can edit.

PS: I have signed the CLA.