### PR TITLE
Set web charset

### DIFF
--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -7,6 +7,8 @@
 
 server_name _;
 
+charset utf8;
+
 client_max_body_size 0;
 
 root /usr/share/jitsi-meet;


### PR DESCRIPTION
With the following `custom-interface_config.js`:
```js
interfaceConfig.APP_NAME = "Test ö test ä Test";
```

Without this change when visiting e.g. `/static/close2.html`:
![image](https://user-images.githubusercontent.com/1325121/196162346-3accfac5-6ee7-460d-8366-5acab463f641.png)

With this change:
![image](https://user-images.githubusercontent.com/1325121/196162367-3a42d153-41fd-44cd-b0ef-a38f0c8ced92.png)

The change seems reasonably safe, though could make it configurable if desired