### PR TITLE
Adding single-use-mode flag to Jibri config

### DIFF
--- a/jibri/rootfs/defaults/jibri.conf
+++ b/jibri/rootfs/defaults/jibri.conf
@@ -3,6 +3,7 @@
 {{ $JIBRI_USAGE_TIMEOUT := .Env.JIBRI_USAGE_TIMEOUT | default "0" -}}
 {{ $JIBRI_RECORDING_RESOLUTION := .Env.JIBRI_RECORDING_RESOLUTION | default "1280x720" -}}
 {{ $JIBRI_BREWERY_MUC := .Env.JIBRI_BREWERY_MUC | default "jibribrewery" -}}
+{{ $JIBRI_SINGLE_USE_MODE := .Env.JIBRI_SINGLE_USE_MODE | default "false" -}}
 {{ $XMPP_AUTH_DOMAIN := .Env.XMPP_AUTH_DOMAIN | default "auth.meet.jitsi" -}}
 {{ $XMPP_DOMAIN := .Env.XMPP_DOMAIN | default "meet.jitsi" -}}
 {{ $XMPP_INTERNAL_MUC_DOMAIN := .Env.XMPP_INTERNAL_MUC_DOMAIN | default "internal-muc.meet.jitsi" -}}
@@ -20,6 +21,11 @@
 jibri {
     // A unique identifier for this Jibri
     id = "{{ .Env.JIBRI_INSTANCE_ID }}"
+    // Whether or not Jibri should return to idle state after handling
+    // (successfully or unsuccessfully) a request.  A value of 'true'
+    // here means that a Jibri will NOT return back to the IDLE state
+    // and will need to be restarted in order to be used again.
+    single-use-mode = {{ .Env.JIBRI_SINGLE_USE_MODE }}
 
     api {
       {{ if or .Env.JIBRI_HTTP_API_EXTERNAL_PORT .Env.JIBRI_HTTP_API_INTERNAL_PORT -}}

--- a/jibri/rootfs/defaults/jibri.conf
+++ b/jibri/rootfs/defaults/jibri.conf
@@ -25,7 +25,7 @@ jibri {
     // (successfully or unsuccessfully) a request.  A value of 'true'
     // here means that a Jibri will NOT return back to the IDLE state
     // and will need to be restarted in order to be used again.
-    single-use-mode = {{ .Env.JIBRI_SINGLE_USE_MODE }}
+    single-use-mode = {{ $JIBRI_SINGLE_USE_MODE }}
 
     api {
       {{ if or .Env.JIBRI_HTTP_API_EXTERNAL_PORT .Env.JIBRI_HTTP_API_INTERNAL_PORT -}}


### PR DESCRIPTION
Adding the missing `single-use-mode` flag to the `jibri.conf` template, defaulting to `false`. The flag is already present in the [reference file](https://github.com/jitsi/jibri/blob/master/src/main/resources/reference.conf) for Jibri.

It defines whether or not Jibri should return to idle state after handling (successfully or unsuccessfully) a request. A value of 'true' here means that a Jibri will NOT return back to the IDLE state and will need to be restarted in order to be used again.