### PR TITLE
Change TURN transport from TCP to UDP

### DIFF
--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -67,7 +67,7 @@ external_service_secret = "{{.Env.TURN_CREDENTIALS}}";
 {{ if or .Env.TURN_HOST .Env.TURNS_HOST }}
 external_services = {
   {{ if .Env.TURN_HOST }}
-     { type = "turn", host = "{{ .Env.TURN_HOST }}", port = {{ $TURN_PORT }}, transport = "tcp", secret = true, ttl = 86400, algorithm = "turn" }
+     { type = "turn", host = "{{ .Env.TURN_HOST }}", port = {{ $TURN_PORT }}, transport = "udp", secret = true, ttl = 86400, algorithm = "turn" }
   {{ end }}
   {{ if and .Env.TURN_HOST .Env.TURNS_HOST }}
   ,


### PR DESCRIPTION
This pull request changes the transport mode for "turn" server from TCP to UDP.

This change allows peer to peer connections trough the TURN server to use UDP transport for the client->TURN server communication.

Using UDP for turn transport is also what meet.jit.si uses in its ICE server candidates.

Community thread about this: https://community.jitsi.org/t/jitis-docker-turn-transport-tcp-should-be-udp/119374