### PR TITLE
Fix "<no value>" issue in prosody config

### DIFF
--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -203,7 +203,7 @@ VirtualHost "{{ $XMPP_DOMAIN }}"
     conference_duration_component = "conferenceduration.{{ $XMPP_DOMAIN }}"
 
     {{ if $ENABLE_END_CONFERENCE }}
-    end_conference_component = "endconference.{{ XMPP_DOMAIN }}"
+    end_conference_component = "endconference.{{ $XMPP_DOMAIN }}"
     {{ end }}
 
     {{ if $ENABLE_AV_MODERATION }}
@@ -293,8 +293,8 @@ Component "conferenceduration.{{ $XMPP_DOMAIN }}" "conference_duration_component
     muc_component = "{{ $XMPP_MUC_DOMAIN }}"
 
 {{ if $ENABLE_END_CONFERENCE }}
-Component "endconference.{{ XMPP_DOMAIN }}" "end_conference"
-    muc_component = "{{ XMPP_MUC_DOMAIN }}"
+Component "endconference.{{ $XMPP_DOMAIN }}" "end_conference"
+    muc_component = "{{ $XMPP_MUC_DOMAIN }}"
 {{ end }}
 
 {{ if $ENABLE_AV_MODERATION }}

--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -203,7 +203,7 @@ VirtualHost "{{ $XMPP_DOMAIN }}"
     conference_duration_component = "conferenceduration.{{ $XMPP_DOMAIN }}"
 
     {{ if $ENABLE_END_CONFERENCE }}
-    end_conference_component = "endconference.{{ .Env.XMPP_DOMAIN }}"
+    end_conference_component = "endconference.{{ XMPP_DOMAIN }}"
     {{ end }}
 
     {{ if $ENABLE_AV_MODERATION }}
@@ -293,8 +293,8 @@ Component "conferenceduration.{{ $XMPP_DOMAIN }}" "conference_duration_component
     muc_component = "{{ $XMPP_MUC_DOMAIN }}"
 
 {{ if $ENABLE_END_CONFERENCE }}
-Component "endconference.{{ .Env.XMPP_DOMAIN }}" "end_conference"
-    muc_component = "{{ .Env.XMPP_MUC_DOMAIN }}"
+Component "endconference.{{ XMPP_DOMAIN }}" "end_conference"
+    muc_component = "{{ XMPP_MUC_DOMAIN }}"
 {{ end }}
 
 {{ if $ENABLE_AV_MODERATION }}


### PR DESCRIPTION
If XMPP_DOMAIN and XMPP_MUC_DOMAIN are not configured in the .env file (which is the default situation), we get the following lines in jitsi-meet.cfg.lua:

`    end_conference_component = "endconference.<no value>"`

```
Component "endconference.<no value>" "end_conference"
    muc_component = "<no value>"
```