### PR TITLE
web: fix bosh for subdomains

### DIFF
--- a/web/rootfs/defaults/system-config.js
+++ b/web/rootfs/defaults/system-config.js
@@ -41,11 +41,7 @@ config.hosts.anonymousdomain = '{{ $XMPP_GUEST_DOMAIN }}';
 config.hosts.authdomain = '{{ $XMPP_DOMAIN }}';
 {{ end -}}
 
-{{ if $ENABLE_SUBDOMAINS -}}
-config.bosh = '/' + subdir + 'http-bind';
-{{ else -}}
 config.bosh = '/http-bind';
-{{ end -}}
 
 {{ if $ENABLE_XMPP_WEBSOCKET -}}
 {{ if $ENABLE_SUBDOMAINS -}}


### PR DESCRIPTION
The subdomain is already appended for bosh when the relative URL is used, so removing it from config.

https://github.com/jitsi/jitsi-meet/blob/e405595a11a265f8da565f3e94d62c5ef9f7ff09/react/features/base/config/actions.ts#L129