### PR TITLE
fix: update TAG as stable instead of latest

### DIFF
--- a/base-java/Dockerfile
+++ b/base-java/Dockerfile
@@ -1,5 +1,5 @@
 ARG JITSI_REPO=jitsi
-ARG BASE_TAG=latest
+ARG BASE_TAG=stable
 FROM ${JITSI_REPO}/base:${BASE_TAG}
 
 RUN mkdir -p /usr/share/man/man1 && \

--- a/jibri/Dockerfile
+++ b/jibri/Dockerfile
@@ -1,5 +1,5 @@
 ARG JITSI_REPO=jitsi
-ARG BASE_TAG=latest
+ARG BASE_TAG=stable
 FROM ${JITSI_REPO}/base-java:${BASE_TAG}
 
 LABEL org.opencontainers.image.title="Jitsi Broadcasting Infrastructure (jibri)"

--- a/jicofo/Dockerfile
+++ b/jicofo/Dockerfile
@@ -1,5 +1,5 @@
 ARG JITSI_REPO=jitsi
-ARG BASE_TAG=latest
+ARG BASE_TAG=stable
 FROM ${JITSI_REPO}/base-java:${BASE_TAG}
 
 LABEL org.opencontainers.image.title="Jitsi Conference Focus (jicofo)"

--- a/jigasi/Dockerfile
+++ b/jigasi/Dockerfile
@@ -1,5 +1,5 @@
 ARG JITSI_REPO=jitsi
-ARG BASE_TAG=latest
+ARG BASE_TAG=stable
 FROM ${JITSI_REPO}/base-java:${BASE_TAG}
 
 LABEL org.opencontainers.image.title="Jitsi Gateway to SIP (jigasi)"

--- a/jvb/Dockerfile
+++ b/jvb/Dockerfile
@@ -1,5 +1,5 @@
 ARG JITSI_REPO=jitsi
-ARG BASE_TAG=latest
+ARG BASE_TAG=stable
 FROM ${JITSI_REPO}/base-java:${BASE_TAG}
 
 LABEL org.opencontainers.image.title="Jitsi Videobridge (jvb)"

--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -1,5 +1,5 @@
 ARG JITSI_REPO=jitsi
-ARG BASE_TAG=latest
+ARG BASE_TAG=stable
 
 FROM ${JITSI_REPO}/base:${BASE_TAG} as builder
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,5 @@
 ARG JITSI_REPO=jitsi
-ARG BASE_TAG=latest
+ARG BASE_TAG=stable
 FROM ${JITSI_REPO}/base:${BASE_TAG}
 
 LABEL org.opencontainers.image.title="Jitsi Meet"


### PR DESCRIPTION
This commit sets the tag as `stable` because `latest` is not available as a tag anymore.