### PR TITLE
jicofo: remove shibboleth authentication options

### DIFF
--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -28,20 +28,13 @@ jicofo {
     {{ if $JICOFO_ENABLE_AUTH }}
     authentication {
       enabled = true
-      // The type of authentication. Supported values are XMPP, JWT or SHIBBOLETH (default).
+      // The type of authentication. Supported values are XMPP or JWT.
       {{ if eq $AUTH_TYPE "jwt" }}
       type = JWT
-      {{ else if eq $AUTH_TYPE "shibboleth" }}
-      type = SHIBBOLETH
       {{ else }}
       type = XMPP
       {{ end }}
-      {{ if eq $AUTH_TYPE "shibboleth" }}
-      login-url = "shibboleth:default"
-      logout-url = "shibboleth:default"
-      {{ else }}
       login-url = "{{ $XMPP_DOMAIN }}"
-      {{ end }}
       enable-auto-login={{ $ENABLE_AUTO_LOGIN }}
     }
     {{ end }}


### PR DESCRIPTION
It got removed from Jicofo.