### PR TITLE
Upgrade acme.sh to use zerossl server as well as option to use Cloudflare DNS validation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
             - CONFCODE_URL
             - CONFIG_EXTERNAL_CONNECT
             - CF_Token
+            - CF_Zone_ID
             - DEFAULT_LANGUAGE
             - DEPLOYMENTINFO_ENVIRONMENT
             - DEPLOYMENTINFO_ENVIRONMENT_TYPE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.5'
 services:
     # Frontend
     web:
-        image: kvaggelakos/jitsi-web:${JITSI_IMAGE_VERSION:-unstable}
+        image: jitsi/web:${JITSI_IMAGE_VERSION:-unstable}
         restart: ${RESTART_POLICY:-unless-stopped}
         ports:
             - '${HTTP_PORT}:80'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
             - COLIBRI_WEBSOCKET_PORT
             - CONFCODE_URL
             - CONFIG_EXTERNAL_CONNECT
+            - CF_Token
             - DEFAULT_LANGUAGE
             - DEPLOYMENTINFO_ENVIRONMENT
             - DEPLOYMENTINFO_ENVIRONMENT_TYPE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.5'
 services:
     # Frontend
     web:
-        image: jitsi/web:${JITSI_IMAGE_VERSION:-unstable}
+        image: kvaggelakos/jitsi-web:${JITSI_IMAGE_VERSION:-unstable}
         restart: ${RESTART_POLICY:-unless-stopped}
         ports:
             - '${HTTP_PORT}:80'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,7 @@ services:
             - LETSENCRYPT_DOMAIN
             - LETSENCRYPT_EMAIL
             - LETSENCRYPT_USE_STAGING
+            - LETSENCRYPT_VALIDATION
             - MATOMO_ENDPOINT
             - MATOMO_SITE_ID
             - MICROSOFT_API_APP_CLIENT_ID

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.url="https://jitsi.org/jitsi-meet/"
 LABEL org.opencontainers.image.source="https://github.com/jitsi/docker-jitsi-meet"
 LABEL org.opencontainers.image.documentation="https://jitsi.github.io/handbook/"
 
-ADD https://raw.githubusercontent.com/acmesh-official/acme.sh/2.8.8/acme.sh /opt
+ADD https://raw.githubusercontent.com/acmesh-official/acme.sh/3.0.6/acme.sh /opt
 COPY rootfs/ /
 
 RUN apt-dpkg-wrap apt-get update && \

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -8,7 +8,6 @@ LABEL org.opencontainers.image.url="https://jitsi.org/jitsi-meet/"
 LABEL org.opencontainers.image.source="https://github.com/jitsi/docker-jitsi-meet"
 LABEL org.opencontainers.image.documentation="https://jitsi.github.io/handbook/"
 
-ADD https://raw.githubusercontent.com/acmesh-official/acme.sh/3.0.6/acme.sh /opt
 COPY rootfs/ /
 
 RUN apt-dpkg-wrap apt-get update && \

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.documentation="https://jitsi.github.io/handbook/"
 COPY rootfs/ /
 
 RUN apt-dpkg-wrap apt-get update && \
-    apt-dpkg-wrap apt-get install -y cron nginx-extras jitsi-meet-web socat curl jq git && \
+    apt-dpkg-wrap apt-get install -y cron nginx-extras jitsi-meet-web socat curl jq && \
     mv /usr/share/jitsi-meet/interface_config.js /defaults && \
     rm -f /etc/nginx/conf.d/default.conf && \
     apt-cleanup

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -8,11 +8,10 @@ LABEL org.opencontainers.image.url="https://jitsi.org/jitsi-meet/"
 LABEL org.opencontainers.image.source="https://github.com/jitsi/docker-jitsi-meet"
 LABEL org.opencontainers.image.documentation="https://jitsi.github.io/handbook/"
 
-ADD https://raw.githubusercontent.com/acmesh-official/acme.sh/3.0.6/acme.sh /opt
 COPY rootfs/ /
 
 RUN apt-dpkg-wrap apt-get update && \
-    apt-dpkg-wrap apt-get install -y cron nginx-extras jitsi-meet-web socat curl jq && \
+    apt-dpkg-wrap apt-get install -y cron nginx-extras jitsi-meet-web socat curl jq git && \
     mv /usr/share/jitsi-meet/interface_config.js /defaults && \
     rm -f /etc/nginx/conf.d/default.conf && \
     apt-cleanup

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -8,6 +8,7 @@ LABEL org.opencontainers.image.url="https://jitsi.org/jitsi-meet/"
 LABEL org.opencontainers.image.source="https://github.com/jitsi/docker-jitsi-meet"
 LABEL org.opencontainers.image.documentation="https://jitsi.github.io/handbook/"
 
+ADD https://raw.githubusercontent.com/acmesh-official/acme.sh/3.0.6/acme.sh /opt
 COPY rootfs/ /
 
 RUN apt-dpkg-wrap apt-get update && \

--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -27,6 +27,7 @@ if [[ $DISABLE_HTTPS -ne 1 ]]; then
                 --dns dns_cf \
                 -d $LETSENCRYPT_DOMAIN
         else
+            # TODO: move away from standalone mode to webroot mode.
             echo "Using standalone validation"
             /config/acme.sh/acme.sh \
                 $STAGING \

--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -1,5 +1,7 @@
 #!/usr/bin/with-contenv bash
 
+set -x
+
 # make our folders
 mkdir -p \
     /config/{nginx/site-confs,keys} \
@@ -21,7 +23,8 @@ if [[ $DISABLE_HTTPS -ne 1 ]]; then
         fi
         export LE_WORKING_DIR="/config/acme.sh"
         # TODO: move away from standalone mode to webroot mode.
-        if [[ -z "$CF_Token" ]]; then
+        if [ ! -z "$CF_Token" ]; then
+            echo "Using dns validation"
             /config/acme.sh/acme.sh \
                 $STAGING \
                 --issue \
@@ -30,6 +33,7 @@ if [[ $DISABLE_HTTPS -ne 1 ]]; then
                 --dns dns_cf \
                 -d $LETSENCRYPT_DOMAIN
         else
+            echo "Using standalone validation"
             /config/acme.sh/acme.sh \
                 $STAGING \
                 --issue \

--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -11,10 +11,10 @@ mkdir -p \
 if [[ $DISABLE_HTTPS -ne 1 ]]; then
     if [[ $ENABLE_LETSENCRYPT -eq 1 ]]; then
         mkdir -p /config/acme.sh
-        curl https://get.acme.sh | sh -s email=$LETSENCRYPT_EMAIL
-        /config/acme.sh/acme.sh \
+        sh /opt/acme.sh --install \
+            --home /config/acme.sh \
+            --accountemail $LETSENCRYPT_EMAIL \
             --register-account \
-            -m $LETSENCRYPT_EMAIL \
             --server zerossl
 
         if [ ! -z "$CF_Token" ]; then

--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -10,37 +10,30 @@ mkdir -p \
 # generate keys (maybe)
 if [[ $DISABLE_HTTPS -ne 1 ]]; then
     if [[ $ENABLE_LETSENCRYPT -eq 1 ]]; then
-        mkdir -p /config
-        cd /config/
-        git clone git@github.com:acmesh-official/acme.sh.git
-        git checkout 3.0.6
+        ACME_VERSION=3.0.6
+        validation=${LETSENCRYPT_VALIDATION:-"--standalone"}
+        echo "Using validation method: $validation"
+        mkdir -p /config/acme.sh
+        cd /tmp/
+        wget https://github.com/acmesh-official/acme.sh/archive/refs/tags/$ACME_VERSION.tar.gz
+        tar xzvf acme.sh-$ACME_VERSION.tar.gz
+        rm acme.sh-$ACME_VERSION.tar.gz
+        mv acme.sh-$ACME_VERSION acme.sh
         cd acme.sh
         sh ./acme.sh --install \
             --home /config/acme.sh \
-            --accountemail $LETSENCRYPT_EMAIL \
-            --register-account \
-            --server zerossl
+            --accountemail $LETSENCRYPT_EMAIL
 
-        if [ ! -z "$CF_Token" ]; then
-            echo "Using dns validation"
-            /config/acme.sh/acme.sh \
-                $STAGING \
-                --issue \
-                --pre-hook "if [[ -d /var/run/s6/services/nginx ]]; then s6-svc -d /var/run/s6/services/nginx; fi" \
-                --post-hook "if [[ -d /var/run/s6/services/nginx ]]; then s6-svc -u /var/run/s6/services/nginx; fi" \
-                --dns dns_cf \
-                -d $LETSENCRYPT_DOMAIN
-        else
-            # TODO: move away from standalone mode to webroot mode.
-            echo "Using standalone validation"
-            /config/acme.sh/acme.sh \
-                $STAGING \
-                --issue \
-    -           --standalone \
-                --pre-hook "if [[ -d /var/run/s6/services/nginx ]]; then s6-svc -d /var/run/s6/services/nginx; fi" \
-                --post-hook "if [[ -d /var/run/s6/services/nginx ]]; then s6-svc -u /var/run/s6/services/nginx; fi" \
-                -d $LETSENCRYPT_DOMAIN
-        fi
+        export LE_WORKING_DIR="/config/acme.sh"
+        # TODO: move away from standalone mode to webroot mode.
+        /config/acme.sh/acme.sh \
+            $STAGING \
+            --issue \
+            --pre-hook "if [[ -d /var/run/s6/services/nginx ]]; then s6-svc -d /var/run/s6/services/nginx; fi" \
+            --post-hook "if [[ -d /var/run/s6/services/nginx ]]; then s6-svc -u /var/run/s6/services/nginx; fi" \
+            $validation \
+            -d $LETSENCRYPT_DOMAIN
+
         rc=$?
         if [[ $rc -eq 1 ]]; then
             echo "Failed to obtain a certificate from the Let's Encrypt CA."

--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -10,8 +10,12 @@ mkdir -p \
 # generate keys (maybe)
 if [[ $DISABLE_HTTPS -ne 1 ]]; then
     if [[ $ENABLE_LETSENCRYPT -eq 1 ]]; then
-        mkdir -p /config/acme.sh
-        sh /opt/acme.sh --install \
+        mkdir -p /config
+        cd /config/
+        git clone git@github.com:acmesh-official/acme.sh.git
+        git checkout 3.0.6
+        cd acme.sh
+        sh ./acme.sh --install \
             --home /config/acme.sh \
             --accountemail $LETSENCRYPT_EMAIL \
             --register-account \

--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -1,7 +1,5 @@
 #!/usr/bin/with-contenv bash
 
-set -x
-
 # make our folders
 mkdir -p \
     /config/{nginx/site-confs,keys} \

--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -13,16 +13,12 @@ mkdir -p \
 if [[ $DISABLE_HTTPS -ne 1 ]]; then
     if [[ $ENABLE_LETSENCRYPT -eq 1 ]]; then
         mkdir -p /config/acme.sh
-        pushd /opt
-        sh ./acme.sh --install --home /config/acme.sh --accountemail $LETSENCRYPT_EMAIL
-        popd
+        curl https://get.acme.sh | sh -s email=$LETSENCRYPT_EMAIL
+        /config/acme.sh/acme.sh \
+            --register-account \
+            -m $LETSENCRYPT_EMAIL \
+            --server zerossl
 
-        STAGING=""
-        if [[ $LETSENCRYPT_USE_STAGING -eq 1 ]]; then
-            STAGING="--staging"
-        fi
-        export LE_WORKING_DIR="/config/acme.sh"
-        # TODO: move away from standalone mode to webroot mode.
         if [ ! -z "$CF_Token" ]; then
             echo "Using dns validation"
             /config/acme.sh/acme.sh \

--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -21,13 +21,23 @@ if [[ $DISABLE_HTTPS -ne 1 ]]; then
         fi
         export LE_WORKING_DIR="/config/acme.sh"
         # TODO: move away from standalone mode to webroot mode.
-        /config/acme.sh/acme.sh \
-            $STAGING \
-            --issue \
-            --standalone \
-            --pre-hook "if [[ -d /var/run/s6/services/nginx ]]; then s6-svc -d /var/run/s6/services/nginx; fi" \
-            --post-hook "if [[ -d /var/run/s6/services/nginx ]]; then s6-svc -u /var/run/s6/services/nginx; fi" \
-            -d $LETSENCRYPT_DOMAIN
+        if [[ -z "$CF_Token" ]]; then
+            /config/acme.sh/acme.sh \
+                $STAGING \
+                --issue \
+                --pre-hook "if [[ -d /var/run/s6/services/nginx ]]; then s6-svc -d /var/run/s6/services/nginx; fi" \
+                --post-hook "if [[ -d /var/run/s6/services/nginx ]]; then s6-svc -u /var/run/s6/services/nginx; fi" \
+                --dns dns_cf \
+                -d $LETSENCRYPT_DOMAIN
+        else
+            /config/acme.sh/acme.sh \
+                $STAGING \
+                --issue \
+    -           --standalone \
+                --pre-hook "if [[ -d /var/run/s6/services/nginx ]]; then s6-svc -d /var/run/s6/services/nginx; fi" \
+                --post-hook "if [[ -d /var/run/s6/services/nginx ]]; then s6-svc -u /var/run/s6/services/nginx; fi" \
+                -d $LETSENCRYPT_DOMAIN
+        fi
         rc=$?
         if [[ $rc -eq 1 ]]; then
             echo "Failed to obtain a certificate from the Let's Encrypt CA."

--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -14,16 +14,16 @@ if [[ $DISABLE_HTTPS -ne 1 ]]; then
         validation=${LETSENCRYPT_VALIDATION:-"--standalone"}
         echo "Using validation method: $validation"
         mkdir -p /config/acme.sh
-        cd /tmp/
-        wget https://github.com/acmesh-official/acme.sh/archive/refs/tags/$ACME_VERSION.tar.gz
-        tar xzvf acme.sh-$ACME_VERSION.tar.gz
-        rm acme.sh-$ACME_VERSION.tar.gz
-        mv acme.sh-$ACME_VERSION acme.sh
-        cd acme.sh
-        sh ./acme.sh --install \
+        wget -o /tmp/acme.sh.tar.gz https://github.com/acmesh-official/acme.sh/archive/refs/tags/$ACME_VERSION.tar.gz
+        tar xvf /tmp/acme.sh.tar.gz -C /tmp && rm /tmp/acme.sh.tar.gz
+        sh /tmp/acme.sh-$ACME_VERSION/acme.sh --install \
             --home /config/acme.sh \
             --accountemail $LETSENCRYPT_EMAIL
 
+        STAGING=""
+        if [[ $LETSENCRYPT_USE_STAGING -eq 1 ]]; then
+            STAGING="--staging"
+        fi
         export LE_WORKING_DIR="/config/acme.sh"
         # TODO: move away from standalone mode to webroot mode.
         /config/acme.sh/acme.sh \


### PR DESCRIPTION
In this MR I've:

1. Moved acme.sh install from manual to online installation
2. Registering account with zerossl (no rate limiting)
3. Added the option to validate using DNS (cloudflare)