### PR TITLE
jicofo: add JICOFO_AUTH_LIFETIME as environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -285,6 +285,7 @@ services:
             - ENABLE_RECORDING
             - ENABLE_SCTP
             - ENABLE_AUTO_LOGIN
+            - JICOFO_AUTH_LIFETIME
             - JICOFO_AUTH_PASSWORD
             - JICOFO_AUTH_TYPE
             - JICOFO_BRIDGE_REGION_GROUPS

--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -2,6 +2,7 @@
 {{ $JICOFO_ENABLE_AUTH := .Env.JICOFO_ENABLE_AUTH | default $ENABLE_AUTH | toBool -}}
 {{ $AUTH_TYPE := .Env.AUTH_TYPE | default "internal" -}}
 {{ $JICOFO_AUTH_TYPE := .Env.JICOFO_AUTH_TYPE | default $AUTH_TYPE -}}
+{{ $JICOFO_AUTH_LIFETIME := .Env.JICOFO_AUTH_LIFETIME | default "24 hours" -}}
 {{ $ENABLE_SCTP := .Env.ENABLE_SCTP | default "0" | toBool -}}
 {{ $ENABLE_RECORDING := .Env.ENABLE_RECORDING | default "0" | toBool -}}
 {{ $ENABLE_OCTO := .Env.ENABLE_OCTO | default "0" | toBool -}}
@@ -36,7 +37,8 @@ jicofo {
       type = XMPP
       {{ end }}
       login-url = "{{ $XMPP_DOMAIN }}"
-      enable-auto-login={{ $ENABLE_AUTO_LOGIN }}
+      enable-auto-login = {{ $ENABLE_AUTO_LOGIN }}
+      authentication-lifetime = {{ $JICOFO_AUTH_LIFETIME }}
     }
     {{ end }}
 


### PR DESCRIPTION
This PR adds `JICOFO_AUTH_LIFETIME` as environment variable to control the value of `authentication-lifetime` in `jicofo.conf`