### PR TITLE
ci: split unstable build and test workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./base
+          load: true
           tags: |
             jitsi/base:latest
           build-args: |
@@ -39,6 +40,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./base-java
+          load: true
           tags: |
             jitsi/base-java:latest
 
@@ -56,6 +58,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./jibri
+          load: true
           tags: |
             jitsi/jibri:latest
 
@@ -73,6 +76,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./jicofo
+          load: true
           tags: |
             jitsi/jicofo:latest
 
@@ -90,6 +94,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./jigasi
+          load: true
           tags: |
             jitsi/jigasi:latest
 
@@ -107,6 +112,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./jvb
+          load: true
           tags: |
             jitsi/jvb:latest
 
@@ -124,6 +130,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./prosody
+          load: true
           tags: |
             jitsi/prosody:latest
 
@@ -141,5 +148,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./web
+          load: true
           tags: |
             jitsi/web:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
             jitsi/base:latest
           build-args: |
             JITSI_RELEASE=unstable
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   base-java:
     runs-on: ubuntu-latest
@@ -43,8 +41,6 @@ jobs:
           context: ./base-java
           tags: |
             jitsi/base-java:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   jibri:
     runs-on: ubuntu-latest
@@ -62,8 +58,6 @@ jobs:
           context: ./jibri
           tags: |
             jitsi/jibri:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   jicofo:
     runs-on: ubuntu-latest
@@ -81,8 +75,6 @@ jobs:
           context: ./jicofo
           tags: |
             jitsi/jicofo:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   jigasi:
     runs-on: ubuntu-latest
@@ -100,8 +92,6 @@ jobs:
           context: ./jigasi
           tags: |
             jitsi/jigasi:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   jvb:
     runs-on: ubuntu-latest
@@ -119,8 +109,6 @@ jobs:
           context: ./jvb
           tags: |
             jitsi/jvb:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   prosody:
     runs-on: ubuntu-latest
@@ -138,8 +126,6 @@ jobs:
           context: ./prosody
           tags: |
             jitsi/prosody:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   web:
     runs-on: ubuntu-latest
@@ -157,5 +143,3 @@ jobs:
           context: ./web
           tags: |
             jitsi/web:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,161 @@
+name: CI Test Build
+
+on:
+  pull_request:
+  push:
+    branches:
+    - master
+
+jobs:
+  base:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./base
+          tags: |
+            jitsi/base:latest
+          build-args: |
+            JITSI_RELEASE=unstable
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  base-java:
+    runs-on: ubuntu-latest
+    needs: base
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./base-java
+          tags: |
+            jitsi/base-java:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  jibri:
+    runs-on: ubuntu-latest
+    needs: base-java
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./jibri
+          tags: |
+            jitsi/jibri:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  jicofo:
+    runs-on: ubuntu-latest
+    needs: base-java
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./jicofo
+          tags: |
+            jitsi/jicofo:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  jigasi:
+    runs-on: ubuntu-latest
+    needs: base-java
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./jigasi
+          tags: |
+            jitsi/jigasi:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  jvb:
+    runs-on: ubuntu-latest
+    needs: base-java
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./jvb
+          tags: |
+            jitsi/jvb:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  prosody:
+    runs-on: ubuntu-latest
+    needs: base
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./prosody
+          tags: |
+            jitsi/prosody:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  web:
+    runs-on: ubuntu-latest
+    needs: base
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./web
+          tags: |
+            jitsi/web:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     - master
 
 jobs:
-  base:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -16,7 +16,8 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver: docker
-      - name: Build
+
+      - name: Build base
         uses: docker/build-push-action@v2
         with:
           context: ./base
@@ -26,17 +27,7 @@ jobs:
           build-args: |
             JITSI_RELEASE=unstable
 
-  base-java:
-    runs-on: ubuntu-latest
-    needs: base
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          driver: docker
-      - name: Build
+      - name: Build base-java
         uses: docker/build-push-action@v2
         with:
           context: ./base-java
@@ -44,17 +35,7 @@ jobs:
           tags: |
             jitsi/base-java:latest
 
-  jibri:
-    runs-on: ubuntu-latest
-    needs: base-java
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          driver: docker
-      - name: Build
+      - name: Build jibri
         uses: docker/build-push-action@v2
         with:
           context: ./jibri
@@ -62,17 +43,7 @@ jobs:
           tags: |
             jitsi/jibri:latest
 
-  jicofo:
-    runs-on: ubuntu-latest
-    needs: base-java
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          driver: docker
-      - name: Build
+      - name: Build jicofo
         uses: docker/build-push-action@v2
         with:
           context: ./jicofo
@@ -80,17 +51,7 @@ jobs:
           tags: |
             jitsi/jicofo:latest
 
-  jigasi:
-    runs-on: ubuntu-latest
-    needs: base-java
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          driver: docker
-      - name: Build
+      - name: Build jigasi
         uses: docker/build-push-action@v2
         with:
           context: ./jigasi
@@ -98,17 +59,7 @@ jobs:
           tags: |
             jitsi/jigasi:latest
 
-  jvb:
-    runs-on: ubuntu-latest
-    needs: base-java
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          driver: docker
-      - name: Build
+      - name: Build jvb
         uses: docker/build-push-action@v2
         with:
           context: ./jvb
@@ -116,17 +67,7 @@ jobs:
           tags: |
             jitsi/jvb:latest
 
-  prosody:
-    runs-on: ubuntu-latest
-    needs: base
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          driver: docker
-      - name: Build
+      - name: Build prosody
         uses: docker/build-push-action@v2
         with:
           context: ./prosody
@@ -134,17 +75,7 @@ jobs:
           tags: |
             jitsi/prosody:latest
 
-  web:
-    runs-on: ubuntu-latest
-    needs: base
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          driver: docker
-      - name: Build
+      - name: Build web
         uses: docker/build-push-action@v2
         with:
           context: ./web

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -1,7 +1,6 @@
 name: Unstable Build
 
 on:
-  pull_request:
   schedule:
     - cron: "0 6 * * *"
   workflow_dispatch:
@@ -70,32 +69,17 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
         uses: docker/login-action@v1
-        if: ${{ github.event_name != 'pull_request' }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v2
-        if: ${{ github.event_name != 'pull_request' }}
         with:
           push: true
           context: ./base
           tags: |
             ${{ secrets.JITSI_REPO }}/base:${{ needs.version.outputs.base }}
             ${{ secrets.JITSI_REPO }}/base:${{ needs.version.outputs.date }}
-          build-args: |
-            JITSI_RELEASE=unstable
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-      - name: Dryrun
-        uses: docker/build-push-action@v2
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          context: ./base
-          tags: |
-            jitsi/base:${{ needs.version.outputs.base }}
-            jitsi/base:${{ needs.version.outputs.date }}
           build-args: |
             JITSI_RELEASE=unstable
           platforms: linux/amd64,linux/arm64
@@ -116,13 +100,11 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
         uses: docker/login-action@v1
-        if: ${{ github.event_name != 'pull_request' }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v2
-        if: ${{ github.event_name != 'pull_request' }}
         with:
           push: true
           context: ./base-java
@@ -131,20 +113,6 @@ jobs:
             ${{ secrets.JITSI_REPO }}/base-java:${{ needs.version.outputs.date }}
           build-args: |
             JITSI_REPO=${{ secrets.JITSI_REPO }}
-            BASE_TAG=${{ needs.version.outputs.base }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-      - name: Dryrun
-        uses: docker/build-push-action@v2
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          context: ./base-java
-          tags: |
-            jitsi/base-java:${{ needs.version.outputs.base }}
-            jitsi/base-java:${{ needs.version.outputs.date }}
-          build-args: |
-            JITSI_REPO=jitsi
             BASE_TAG=${{ needs.version.outputs.base }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
@@ -164,13 +132,11 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
         uses: docker/login-action@v1
-        if: ${{ github.event_name != 'pull_request' }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v2
-        if: ${{ github.event_name != 'pull_request' }}
         with:
           push: true
           context: ./jibri
@@ -180,21 +146,6 @@ jobs:
             ${{ secrets.JITSI_REPO }}/jibri:${{ needs.version.outputs.jibri_version }}
           build-args: |
             JITSI_REPO=${{ secrets.JITSI_REPO }}
-            BASE_TAG=${{ needs.version.outputs.base }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-      - name: Dryrun
-        uses: docker/build-push-action@v2
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          context: ./jibri
-          tags: |
-            jitsi/jibri:${{ needs.version.outputs.base }}
-            jitsi/jibri:${{ needs.version.outputs.date }}
-            jitsi/jibri:${{ needs.version.outputs.jibri_version }}
-          build-args: |
-            JITSI_REPO=jitsi
             BASE_TAG=${{ needs.version.outputs.base }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
@@ -214,13 +165,11 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
         uses: docker/login-action@v1
-        if: ${{ github.event_name != 'pull_request' }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v2
-        if: ${{ github.event_name != 'pull_request' }}
         with:
           push: true
           context: ./jicofo
@@ -230,21 +179,6 @@ jobs:
             ${{ secrets.JITSI_REPO }}/jicofo:${{ needs.version.outputs.jicofo_version }}
           build-args: |
             JITSI_REPO=${{ secrets.JITSI_REPO }}
-            BASE_TAG=${{ needs.version.outputs.base }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-      - name: Dryrun
-        uses: docker/build-push-action@v2
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          context: ./jicofo
-          tags: |
-            jitsi/jicofo:${{ needs.version.outputs.base }}
-            jitsi/jicofo:${{ needs.version.outputs.date }}
-            jitsi/jicofo:${{ needs.version.outputs.jicofo_version }}
-          build-args: |
-            JITSI_REPO=jitsi
             BASE_TAG=${{ needs.version.outputs.base }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
@@ -264,13 +198,11 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
         uses: docker/login-action@v1
-        if: ${{ github.event_name != 'pull_request' }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v2
-        if: ${{ github.event_name != 'pull_request' }}
         with:
           push: true
           context: ./jigasi
@@ -280,21 +212,6 @@ jobs:
             ${{ secrets.JITSI_REPO }}/jigasi:${{ needs.version.outputs.jigasi_version }}
           build-args: |
             JITSI_REPO=${{ secrets.JITSI_REPO }}
-            BASE_TAG=${{ needs.version.outputs.base }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-      - name: Dryrun
-        uses: docker/build-push-action@v2
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          context: ./jigasi
-          tags: |
-            jitsi/jigasi:${{ needs.version.outputs.base }}
-            jitsi/jigasi:${{ needs.version.outputs.date }}
-            jitsi/jigasi:${{ needs.version.outputs.jigasi_version }}
-          build-args: |
-            JITSI_REPO=jitsi
             BASE_TAG=${{ needs.version.outputs.base }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
@@ -314,13 +231,11 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
         uses: docker/login-action@v1
-        if: ${{ github.event_name != 'pull_request' }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v2
-        if: ${{ github.event_name != 'pull_request' }}
         with:
           push: true
           context: ./jvb
@@ -330,21 +245,6 @@ jobs:
             ${{ secrets.JITSI_REPO }}/jvb:${{ needs.version.outputs.jvb_version }}
           build-args: |
             JITSI_REPO=${{ secrets.JITSI_REPO }}
-            BASE_TAG=${{ needs.version.outputs.base }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-      - name: Dryrun
-        uses: docker/build-push-action@v2
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          context: ./jvb
-          tags: |
-            jitsi/jvb:${{ needs.version.outputs.base }}
-            jitsi/jvb:${{ needs.version.outputs.date }}
-            jitsi/jvb:${{ needs.version.outputs.jvb_version }}
-          build-args: |
-            JITSI_REPO=jitsi
             BASE_TAG=${{ needs.version.outputs.base }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
@@ -364,13 +264,11 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
         uses: docker/login-action@v1
-        if: ${{ github.event_name != 'pull_request' }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v2
-        if: ${{ github.event_name != 'pull_request' }}
         with:
           push: true
           context: ./prosody
@@ -380,21 +278,6 @@ jobs:
             ${{ secrets.JITSI_REPO }}/prosody:${{ needs.version.outputs.prosody_version }}
           build-args: |
             JITSI_REPO=${{ secrets.JITSI_REPO }}
-            BASE_TAG=${{ needs.version.outputs.base }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-      - name: Dryrun
-        uses: docker/build-push-action@v2
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          context: ./prosody
-          tags: |
-            jitsi/prosody:${{ needs.version.outputs.base }}
-            jitsi/prosody:${{ needs.version.outputs.date }}
-            jitsi/prosody:${{ needs.version.outputs.prosody_version }}
-          build-args: |
-            JITSI_REPO=jitsi
             BASE_TAG=${{ needs.version.outputs.base }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
@@ -414,13 +297,11 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
         uses: docker/login-action@v1
-        if: ${{ github.event_name != 'pull_request' }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v2
-        if: ${{ github.event_name != 'pull_request' }}
         with:
           push: true
           context: ./web
@@ -430,21 +311,6 @@ jobs:
             ${{ secrets.JITSI_REPO }}/web:${{ needs.version.outputs.web_version }}
           build-args: |
             JITSI_REPO=${{ secrets.JITSI_REPO }}
-            BASE_TAG=${{ needs.version.outputs.base }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-      - name: Dryrun
-        uses: docker/build-push-action@v2
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          context: ./web
-          tags: |
-            jitsi/web:${{ needs.version.outputs.base }}
-            jitsi/web:${{ needs.version.outputs.date }}
-            jitsi/web:${{ needs.version.outputs.web_version }}
-          build-args: |
-            JITSI_REPO=jitsi
             BASE_TAG=${{ needs.version.outputs.base }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha


### PR DESCRIPTION
In order to make multi-arch builds the buildx action will use the docker-container driver, which does not support loading images, and thus the jvb image won't be built based on the "base-java" image, in turn based on the "base" image. That works only when pushing.

If we setup buildx to use the "docker" driver it will just build for the current architecture, but it will properly load images and the base images will be used correctly.