### PR TITLE
JVB configurable Jetty sendServerVersion

### DIFF
--- a/jvb/rootfs/defaults/jvb.conf
+++ b/jvb/rootfs/defaults/jvb.conf
@@ -24,8 +24,6 @@
 {{ $XMPP_PORT := .Env.XMPP_PORT | default "5222" -}}
 {{ $XMPP_SERVER := .Env.XMPP_SERVER | default "xmpp.meet.jitsi" -}}
 {{ $XMPP_SERVERS := splitList "," $XMPP_SERVER -}}
-{{ $JETTY_SEND_SERVER_VERSION_PUBLIC := .Env.JETTY_SEND_SERVER_VERSION_PUBLIC | default "true" | toBool -}}
-{{ $JETTY_SEND_SERVER_VERSION_PRIVATE := .Env.JETTY_SEND_SERVER_VERSION_PRIVATE | default "true" | toBool -}}
 {{/* assign env from context, preserve during range when . is re-assigned */}}
 {{ $ENV := .Env -}}
 
@@ -91,12 +89,12 @@ videobridge {
     http-servers {
         private {
           host = 0.0.0.0
-          send-server-version = {{ $JETTY_SEND_SERVER_VERSION_PRIVATE }}
+          send-server-version = false
         }
         public {
             host = 0.0.0.0
             port = 9090
-            send-server-version = {{ $JETTY_SEND_SERVER_VERSION_PUBLIC }}
+            send-server-version = false
         }
     }
 

--- a/jvb/rootfs/defaults/jvb.conf
+++ b/jvb/rootfs/defaults/jvb.conf
@@ -24,6 +24,8 @@
 {{ $XMPP_PORT := .Env.XMPP_PORT | default "5222" -}}
 {{ $XMPP_SERVER := .Env.XMPP_SERVER | default "xmpp.meet.jitsi" -}}
 {{ $XMPP_SERVERS := splitList "," $XMPP_SERVER -}}
+{{ $JETTY_SEND_SERVER_VERSION_PUBLIC := .Env.JETTY_SEND_SERVER_VERSION_PUBLIC | default "true" | toBool -}}
+{{ $JETTY_SEND_SERVER_VERSION_PRIVATE := .Env.JETTY_SEND_SERVER_VERSION_PRIVATE | default "true" | toBool -}}
 {{/* assign env from context, preserve during range when . is re-assigned */}}
 {{ $ENV := .Env -}}
 
@@ -89,10 +91,12 @@ videobridge {
     http-servers {
         private {
           host = 0.0.0.0
+          send-server-version = {{ $JETTY_SEND_SERVER_VERSION_PRIVATE }}
         }
         public {
             host = 0.0.0.0
             port = 9090
+            send-server-version = {{ $JETTY_SEND_SERVER_VERSION_PUBLIC }}
         }
     }
 


### PR DESCRIPTION
Added 2 Env new variables which allow to configure, if the jetty http server should include the jetty version in its HTTP Headers and error pages.

Default behaviour is defined in jicoco "JettyBundleActivatorConfig.kt" and is also set to true.
