### PR TITLE
prosody: update version of prosody-plugings package

### DIFF
--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -27,7 +27,7 @@ LABEL org.opencontainers.image.url="https://prosody.im/"
 LABEL org.opencontainers.image.source="https://github.com/jitsi/docker-jitsi-meet"
 LABEL org.opencontainers.image.documentation="https://jitsi.github.io/handbook/"
 
-ARG VERSION_JITSI_CONTRIB_PROSODY_PLUGINS="20230803"
+ARG VERSION_JITSI_CONTRIB_PROSODY_PLUGINS="20230929"
 ARG VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN="1.8.0"
 
 RUN wget -qO /etc/apt/trusted.gpg.d/prosody.gpg https://prosody.im/files/prosody-debian-packages.key && \


### PR DESCRIPTION
[The new release](https://github.com/jitsi-contrib/prosody-plugins/releases/tag/v20230929) contains a fix for [Hybrid Matrix Token](https://github.com/jitsi-contrib/prosody-plugins/tree/main/auth_hybrid_matrix_token)