### PR TITLE
jicofo: support jicofo log file for tailing

### DIFF
--- a/jicofo/rootfs/etc/services.d/jicofo/run
+++ b/jicofo/rootfs/etc/services.d/jicofo/run
@@ -4,4 +4,8 @@ JAVA_SYS_PROPS="-Djava.util.logging.config.file=/config/logging.properties -Dcon
 DAEMON=/usr/share/jicofo/jicofo.sh
 DAEMON_DIR=/usr/share/jicofo/
 
-exec s6-setuidgid jicofo /bin/bash -c "cd $DAEMON_DIR; JAVA_SYS_PROPS=\"$JAVA_SYS_PROPS\" exec $DAEMON"
+JICOFO_CMD="exec $DAEMON"
+
+[ -n "$JICOFO_LOG_FILE" ] && JICOFO_CMD="$JICOFO_CMD 2>&1 | tee $JICOFO_LOG_FILE"
+
+exec s6-setuidgid jicofo /bin/bash -c "cd $DAEMON_DIR; JAVA_SYS_PROPS=\"$JAVA_SYS_PROPS\" $JICOFO_CMD"


### PR DESCRIPTION
This is intended to be used alongside a tool like the jicofo-rtcstats-push service to gather jicofo logs.  In addition it is recommended one use a regular truncation of this file to avoid overrunning disk allocation.