### PR TITLE
bug: escape/encapsulate string in env.example

### DIFF
--- a/env.example
+++ b/env.example
@@ -74,7 +74,7 @@ TZ=UTC
 #ETHERPAD_PUBLIC_URL=https://etherpad.my.domain/p/
 
 # Name your etherpad instance!
-ETHERPAD_TITLE=Video Chat
+ETHERPAD_TITLE="Video Chat"
 
 # The default text of a pad
 ETHERPAD_DEFAULT_PAD_TEXT="Welcome to Web Chat!\n\n"


### PR DESCRIPTION
Currently if you use the default `source` command in linux and the default `.env` file as declared in the `env.example`, it will fail because of the space in the string.

Using double-quotes around the string will solve this issue.