### PR TITLE
allow jvb and jicofo max_mem env vars to be altered through docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -338,6 +338,7 @@ services:
             - JICOFO_ENABLE_HEALTH_CHECKS
             - JICOFO_ENABLE_REST
             - JICOFO_HEALTH_CHECKS_USE_PRESENCE
+            - JICOFO_MAX_MEMORY
             - JICOFO_MULTI_STREAM_BACKWARD_COMPAT
             - JICOFO_OCTO_REGION
             - JIBRI_BREWERY_MUC
@@ -422,6 +423,7 @@ services:
             - COLIBRI_REST_ENABLED
             - SHUTDOWN_REST_ENABLED
             - TZ
+            - VIDEOBRIDGE_MAX_MEMORY
             - XMPP_AUTH_DOMAIN
             - XMPP_INTERNAL_MUC_DOMAIN
             - XMPP_SERVER

--- a/env.example
+++ b/env.example
@@ -36,6 +36,12 @@ TZ=UTC
 # https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-docker#running-behind-nat-or-on-a-lan-environment
 #JVB_ADVERTISE_IPS=192.168.1.1,1.2.3.4
 
+#
+# Memory limits for Java components
+#
+
+#JICOFO_MAX_MEMORY=3072m
+#VIDEOBRIDGE_MAX_MEMORY=3072m
 
 #
 # JaaS Components (beta)


### PR DESCRIPTION
as described in https://github.com/jitsi/docker-jitsi-meet/issues/1647, for non containerized setups of jitsi, users can alter the maximum memory limit for java to be set in the respective jvb and jicofo configuration files, but these files are not exposed in `/config` for dockerized installations.

while that is the case, the run-scripts for both jvb and jicofo read `JICOFO_MAX_MEMORY` and `VIDEOBRIDGE_MAX_MEMORY` from the environment.

these patches allow for the same functionality to be restored without the config files needing to be exposed to the main namespace.