### PR TITLE
Remove unnecessary modules and properties

### DIFF
--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -117,6 +117,13 @@ asap_accepted_audiences = { "{{ join "\",\"" (splitList "," .Env.JWT_ACCEPTED_AU
 consider_bosh_secure = true;
 consider_websocket_secure = true;
 
+{{ if $ENABLE_XMPP_WEBSOCKET }}
+smacks_max_unacked_stanzas = 5;
+smacks_hibernation_time = 60;
+smacks_max_hibernated_sessions = 1;
+smacks_max_old_sessions = 1;
+{{ end }}
+
 {{ if $ENABLE_JAAS_COMPONENTS }}
 VirtualHost "jigasi.meet.jitsi"
     modules_enabled = {

--- a/prosody/rootfs/defaults/prosody.cfg.lua
+++ b/prosody/rootfs/defaults/prosody.cfg.lua
@@ -67,7 +67,6 @@ modules_enabled = {
 
 	-- Not essential, but recommended
 		"private"; -- Private XML storage (for room bookmarks, etc.)
-		"vcard"; -- Allow users to set vCards
 		"limits"; -- Enable bandwidth limiting for XMPP connections
 
 	-- These are commented by default as they have a performance impact
@@ -79,8 +78,6 @@ modules_enabled = {
 		"uptime"; -- Report how long server has been running
 		"time"; -- Let others know the time here on this server
 		"ping"; -- Replies to XMPP pings with pongs
-		"pep"; -- Enables users to publish their mood, activity, playing music and more
-		"register"; -- Allow users to register on this server using a client and change passwords
 
 	-- Admin interfaces
 		"admin_adhoc"; -- Allows administration via an XMPP client that supports ad-hoc commands

--- a/prosody/rootfs/defaults/prosody.cfg.lua
+++ b/prosody/rootfs/defaults/prosody.cfg.lua
@@ -63,7 +63,6 @@ modules_enabled = {
 		"roster"; -- Allow users to have a roster. Recommended ;)
 		"saslauth"; -- Authentication for clients and servers. Recommended if you want to log in.
 		"tls"; -- Add support for secure TLS on c2s/s2s connections
-		"dialback"; -- s2s dialback support
 		"disco"; -- Service discovery
 
 	-- Not essential, but recommended
@@ -104,6 +103,7 @@ modules_enabled = {
 		"secure_interfaces";
 		{{ end -}}
 		{{ if $ENABLE_S2S -}}
+		"dialback"; -- s2s dialback support
 		"s2s_bidi";
 		"certs_s2soutinjection";
 		"s2sout_override";

--- a/prosody/rootfs/defaults/prosody.cfg.lua
+++ b/prosody/rootfs/defaults/prosody.cfg.lua
@@ -1,7 +1,6 @@
 {{ $C2S_REQUIRE_ENCRYPTION := .Env.PROSODY_C2S_REQUIRE_ENCRYPTION | default "0" | toBool -}}
 {{ $ENABLE_AUTH := .Env.ENABLE_AUTH | default "0" | toBool -}}
 {{ $ENABLE_GUEST_DOMAIN := and $ENABLE_AUTH (.Env.ENABLE_GUESTS | default "0" | toBool) -}}
-{{ $ENABLE_HTTP := ne .Env.PROSODY_MODE "brewery" -}}
 {{ $ENABLE_VISITORS := .Env.ENABLE_VISITORS | default "0" | toBool -}}
 {{ $ENABLE_S2S := or $ENABLE_VISITORS ( .Env.PROSODY_ENABLE_S2S | default "0" | toBool ) }}
 {{ $ENABLE_IPV6 := .Env.ENABLE_IPV6 | default "true" | toBool -}}
@@ -294,13 +293,11 @@ unbound = {
     resolvconf = true
 }
 
-{{ if $ENABLE_HTTP }}
 http_ports = { {{ $PROSODY_HTTP_PORT }} }
 {{ if $ENABLE_IPV6 }}
 http_interfaces = { "*", "::" }
 {{ else }}
 http_interfaces = { "*" }
-{{ end }}
 {{ end }}
 
 data_path = "/config/data"

--- a/prosody/rootfs/defaults/prosody.cfg.lua
+++ b/prosody/rootfs/defaults/prosody.cfg.lua
@@ -305,9 +305,4 @@ http_interfaces = { "*" }
 
 data_path = "/config/data"
 
-smacks_max_unacked_stanzas = 5;
-smacks_hibernation_time = 60;
-smacks_max_hibernated_sessions = 1;
-smacks_max_old_sessions = 1;
-
 Include "conf.d/*.cfg.lua"

--- a/prosody/rootfs/defaults/prosody.cfg.lua
+++ b/prosody/rootfs/defaults/prosody.cfg.lua
@@ -1,6 +1,7 @@
 {{ $C2S_REQUIRE_ENCRYPTION := .Env.PROSODY_C2S_REQUIRE_ENCRYPTION | default "0" | toBool -}}
 {{ $ENABLE_AUTH := .Env.ENABLE_AUTH | default "0" | toBool -}}
 {{ $ENABLE_GUEST_DOMAIN := and $ENABLE_AUTH (.Env.ENABLE_GUESTS | default "0" | toBool) -}}
+{{ $ENABLE_HTTP := ne .Env.PROSODY_MODE "brewery" -}}
 {{ $ENABLE_VISITORS := .Env.ENABLE_VISITORS | default "0" | toBool -}}
 {{ $ENABLE_S2S := or $ENABLE_VISITORS ( .Env.PROSODY_ENABLE_S2S | default "0" | toBool ) }}
 {{ $ENABLE_IPV6 := .Env.ENABLE_IPV6 | default "true" | toBool -}}
@@ -293,11 +294,13 @@ unbound = {
     resolvconf = true
 }
 
+{{ if $ENABLE_HTTP }}
 http_ports = { {{ $PROSODY_HTTP_PORT }} }
 {{ if $ENABLE_IPV6 }}
 http_interfaces = { "*", "::" }
 {{ else }}
 http_interfaces = { "*" }
+{{ end }}
 {{ end }}
 
 data_path = "/config/data"


### PR DESCRIPTION
- Only enable dialback when s2s is enabled.
- Remove vcard, pep, register modules.
- Only set HTTP properties when BOSH enabled.
- Only set smacks properties when xmpp ws is enabled.
