### PR TITLE
Default ENABLE_OCTO_SCTP to ENABLE_SCTP not .Env.ENABLE_SCTP.

### DIFF
--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -7,7 +7,7 @@
 {{ $ENABLE_SCTP := .Env.ENABLE_SCTP | default "0" | toBool -}}
 {{ $ENABLE_RECORDING := .Env.ENABLE_RECORDING | default "0" | toBool -}}
 {{ $ENABLE_OCTO := .Env.ENABLE_OCTO | default "0" | toBool -}}
-{{ $ENABLE_OCTO_SCTP := .Env.ENABLE_OCTO_SCTP | default .Env.ENABLE_SCTP | toBool -}}
+{{ $ENABLE_OCTO_SCTP := .Env.ENABLE_OCTO_SCTP | default $ENABLE_SCTP | toBool -}}
 {{ $ENABLE_AUTO_LOGIN := .Env.ENABLE_AUTO_LOGIN | default "1" | toBool -}}
 {{ $ENABLE_REST := .Env.JICOFO_ENABLE_REST | default "0" | toBool -}}
 {{ $ENABLE_JVB_XMPP_SERVER := .Env.ENABLE_JVB_XMPP_SERVER | default "0" | toBool -}}

--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -4,10 +4,11 @@
 {{ $AUTH_TYPE := .Env.AUTH_TYPE | default "internal" -}}
 {{ $JICOFO_AUTH_TYPE := .Env.JICOFO_AUTH_TYPE | default $AUTH_TYPE -}}
 {{ $JICOFO_AUTH_LIFETIME := .Env.JICOFO_AUTH_LIFETIME | default "24 hours" -}}
-{{ $ENABLE_SCTP := .Env.ENABLE_SCTP | default "0" | toBool -}}
+{{ $ENABLE_SCTP_TMP := .Env.ENABLE_SCTP | default "0" -}}
+{{ $ENABLE_SCTP := $ENABLE_SCTP_TMP | toBool -}}
 {{ $ENABLE_RECORDING := .Env.ENABLE_RECORDING | default "0" | toBool -}}
 {{ $ENABLE_OCTO := .Env.ENABLE_OCTO | default "0" | toBool -}}
-{{ $ENABLE_OCTO_SCTP := .Env.ENABLE_OCTO_SCTP | default $ENABLE_SCTP | toBool -}}
+{{ $ENABLE_OCTO_SCTP := .Env.ENABLE_OCTO_SCTP | default $ENABLE_SCTP_TMP | toBool -}}
 {{ $ENABLE_AUTO_LOGIN := .Env.ENABLE_AUTO_LOGIN | default "1" | toBool -}}
 {{ $ENABLE_REST := .Env.JICOFO_ENABLE_REST | default "0" | toBool -}}
 {{ $ENABLE_JVB_XMPP_SERVER := .Env.ENABLE_JVB_XMPP_SERVER | default "0" | toBool -}}


### PR DESCRIPTION
The latter may not be passed and then the tpl initializtion for jicofo.conf fails, resulting in an empty conf file and a disfunctional setup.