### PR TITLE
build: simplify detection of the target platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,19 +2,8 @@ FORCE_REBUILD ?= 0
 JITSI_RELEASE ?= stable
 JITSI_BUILD ?= unstable
 JITSI_REPO ?= jitsi
-NATIVE_ARCH ?= $(shell uname -m)
 
 JITSI_SERVICES := base base-java web prosody jicofo jvb jigasi jibri
-
-ifeq ($(NATIVE_ARCH),x86_64)
-	TARGETPLATFORM := linux/amd64
-else ifeq ($(NATIVE_ARCH),aarch64)
-	TARGETPLATFORM := linux/arm64
-else ifeq ($(NATIVE_ARCH),arm64)
-	TARGETPLATFORM := linux/arm64
-else
-	TARGETPLATFORM := unsupported
-endif
 
 BUILD_ARGS := \
 	--build-arg JITSI_REPO=$(JITSI_REPO) \
@@ -43,19 +32,12 @@ buildx:
 $(addprefix buildx_,$(JITSI_SERVICES)):
 	$(MAKE) --no-print-directory JITSI_SERVICE=$(patsubst buildx_%,%,$@) buildx
 
-ifeq ($(TARGETPLATFORM), unsupported)
 build:
-	@echo "Unsupported native architecture"
-	@exit 1
-else
-build:
-	@echo "Building for $(TARGETPLATFORM)"
 	docker build \
-		$(BUILD_ARGS) --build-arg TARGETPLATFORM=$(TARGETPLATFORM) \
+		$(BUILD_ARGS) \
 		--progress plain \
 		--tag $(JITSI_REPO)/$(JITSI_SERVICE) \
 		$(JITSI_SERVICE)
-endif
 
 $(addprefix build_,$(JITSI_SERVICES)):
 	$(MAKE) --no-print-directory JITSI_SERVICE=$(patsubst build_%,%,$@) build

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,18 +1,16 @@
 FROM docker.io/library/debian:bullseye-slim
 
 ARG JITSI_RELEASE=stable
-ARG TARGETPLATFORM
 ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2
 
 COPY rootfs /
 
-RUN case ${TARGETPLATFORM} in \
-         "linux/amd64")  TPL_ARCH=amd64  ;; \
-         "linux/arm64")  TPL_ARCH=arm64  ;; \
-    esac && \
-    case ${TARGETPLATFORM} in \
-         "linux/amd64")  S6_ARCH=amd64  ;; \
-         "linux/arm64")  S6_ARCH=aarch64  ;; \
+RUN \
+    dpkgArch="$(dpkg --print-architecture)" && \
+    case "${dpkgArch##*-}" in \
+        "amd64") TPL_ARCH=amd64; S6_ARCH=amd64 ;; \
+        "arm64") TPL_ARCH=arm64; S6_ARCH=aarch64 ;; \
+        *) echo "unsupported architecture"; exit 1 ;; \
     esac && \
     apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y apt-transport-https apt-utils ca-certificates gnupg wget && \

--- a/jibri/Dockerfile
+++ b/jibri/Dockerfile
@@ -8,7 +8,6 @@ LABEL org.opencontainers.image.url="https://github.com/jitsi/jibri"
 LABEL org.opencontainers.image.source="https://github.com/jitsi/docker-jitsi-meet"
 LABEL org.opencontainers.image.documentation="https://jitsi.github.io/handbook/"
 
-ARG TARGETPLATFORM
 ARG USE_CHROMIUM=0
 #ARG CHROME_RELEASE=latest
 # https://googlechromelabs.github.io/chrome-for-testing/
@@ -21,9 +20,11 @@ RUN apt-dpkg-wrap apt-get update && \
     /usr/bin/install-chrome.sh && \
     apt-cleanup && \
     adduser jibri rtkit && \
-    case ${TARGETPLATFORM} in \
-        "linux/amd64")  SC_ARCH=x86_64  ;; \
-        "linux/arm64")  SC_ARCH=aarch64  ;; \
+    dpkgArch="$(dpkg --print-architecture)" && \
+    case "${dpkgArch##*-}" in \
+        "amd64") SC_ARCH=x86_64 ;; \
+        "arm64") SC_ARCH=aarch64 ;; \
+        *) echo "unsupported architecture"; exit 1 ;; \
     esac && \
     wget -qO /usr/bin/shm-check https://github.com/saghul/shm-check/releases/download/v1.0.0/shm-check-${SC_ARCH} && \
     chmod +x /usr/bin/shm-check

--- a/jibri/rootfs/usr/bin/install-chrome.sh
+++ b/jibri/rootfs/usr/bin/install-chrome.sh
@@ -2,7 +2,9 @@
 
 set -o pipefail -xeu
 
-if [ "${USE_CHROMIUM}" = 1 -o "${TARGETPLATFORM}" = "linux/arm64" ]; then
+dpkgArch="$(dpkg --print-architecture)"
+
+if [ "${USE_CHROMIUM}" = 1 -o "${dpkgArch##*-}" = "arm64" ]; then
     echo "Using Debian's Chromium"
     apt-dpkg-wrap apt-get install -y chromium chromium-driver chromium-sandbox
     chromium --version


### PR DESCRIPTION
It can be done within the container, rather than having to compute it in the Makefile and then pass it as an argument.