### PR TITLE
fix: Do not load domain_mapper under breakout component

### DIFF
--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -436,9 +436,6 @@ Component "breakout.{{ $XMPP_DOMAIN }}" "muc"
     muc_room_allow_persistent = false
     modules_enabled = {
         "muc_meeting_id";
-        {{ if $ENABLE_SUBDOMAINS -}}
-        "muc_domain_mapper";
-        {{ end -}}
         {{ if not $DISABLE_POLLS -}}
         "polls";
         {{ end -}}


### PR DESCRIPTION
It gets loaded twice and registers for each host twice:
2024-01-19 21:09:33 conference.beta.meet.jit.si:muc_domain_mapper          info	Loading mod_muc_domain_mapper for host jigasi.beta.meet.jit.si!
2024-01-19 21:09:33 breakout.beta.meet.jit.si:muc_domain_mapper            info	Loading mod_muc_domain_mapper for host jigasi.beta.meet.jit.si!
