### PR TITLE
Update etherpad image to etherpad/etherpad:1.9

### DIFF
--- a/etherpad.yml
+++ b/etherpad.yml
@@ -3,7 +3,7 @@ version: '3.5'
 services:
     # Etherpad: real-time collaborative document editing
     etherpad:
-        image: etherpad/etherpad:1.8.6
+        image: etherpad/etherpad:1.9.6
         restart: ${RESTART_POLICY:-unless-stopped}
         environment:
             - TITLE=${ETHERPAD_TITLE}


### PR DESCRIPTION
Etherpad images starting with tag 1.9.0 are supporting ARCH amd64 and arm64

Closes: #1665 