### PR TITLE
Remove "ping" in ViarualHosts

### DIFF
--- a/prosody/rootfs/defaults/conf.d/brewery.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/brewery.cfg.lua
@@ -13,9 +13,6 @@ admins = {
 plugin_paths = { "/prosody-plugins/", "/prosody-plugins-custom" }
 
 VirtualHost "{{ $JVB_XMPP_AUTH_DOMAIN }}"
-    modules_enabled = {
-      "ping";
-    }
     authentication = "internal_hashed"
     ssl = {
         key = "/config/certs/{{ $JVB_XMPP_AUTH_DOMAIN }}.key";
@@ -24,7 +21,6 @@ VirtualHost "{{ $JVB_XMPP_AUTH_DOMAIN }}"
 
 Component "{{ $JVB_XMPP_INTERNAL_MUC_DOMAIN }}" "muc"
     modules_enabled = {
-      "ping",
       "muc_hide_all";
       "muc_filter_access";
     }

--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -130,7 +130,6 @@ smacks_max_old_sessions = 1;
 {{ if $ENABLE_JAAS_COMPONENTS }}
 VirtualHost "jigasi.meet.jitsi"
     modules_enabled = {
-      "ping";
       "bosh";
       "muc_password_check";
     }
@@ -196,7 +195,6 @@ VirtualHost "{{ $XMPP_DOMAIN }}"
         "websocket";
         "smacks"; -- XEP-0198: Stream Management
         {{ end }}
-        "ping";
         "speakerstats";
         "conference_duration";
         "room_metadata";
@@ -271,7 +269,6 @@ VirtualHost "{{ $XMPP_DOMAIN }}"
 VirtualHost "{{ $XMPP_GUEST_DOMAIN }}"
     authentication = "{{ $GUEST_AUTH_TYPE }}"
     modules_enabled = {
-        "ping";
         {{ if $ENABLE_XMPP_WEBSOCKET }}
         "smacks"; -- XEP-0198: Stream Management
         {{ end }}
@@ -291,14 +288,12 @@ VirtualHost "{{ $XMPP_AUTH_DOMAIN }}"
     }
     modules_enabled = {
         "limits_exception";
-        "ping";
     }
     authentication = "internal_hashed"
 
 {{ if $ENABLE_RECORDING }}
 VirtualHost "{{ $XMPP_RECORDER_DOMAIN }}"
     modules_enabled = {
-      "ping";
       "smacks";
     }
     authentication = "internal_hashed"
@@ -307,7 +302,6 @@ VirtualHost "{{ $XMPP_RECORDER_DOMAIN }}"
 Component "{{ $XMPP_INTERNAL_MUC_DOMAIN }}" "muc"
     storage = "memory"
     modules_enabled = {
-        "ping";
         {{ if .Env.XMPP_INTERNAL_MUC_MODULES -}}
         "{{ join "\";\n\"" (splitList "," .Env.XMPP_INTERNAL_MUC_MODULES) }}";
         {{ end -}}

--- a/prosody/rootfs/defaults/conf.d/visitors.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/visitors.cfg.lua
@@ -112,7 +112,6 @@ VirtualHost 'v{{ $VISITOR_INDEX }}.{{ $VISITORS_XMPP_DOMAIN }}'
     }
     modules_enabled = {
       'bosh';
-      'ping';
       "external_services";
       {{ if $ENABLE_XMPP_WEBSOCKET -}}
       "websocket";
@@ -134,7 +133,6 @@ VirtualHost 'v{{ $VISITOR_INDEX }}.{{ $VISITORS_XMPP_DOMAIN }}'
 VirtualHost '{{ $XMPP_AUTH_DOMAIN}}'
     modules_enabled = {
       'limits_exception';
-      'ping';
     }
     authentication = 'internal_hashed'
 


### PR DESCRIPTION
It's already present in the global modules_enabled and thus loaded for
each VirtualHost.
