### PR TITLE
add jvb dependency to web container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,6 +174,8 @@ services:
             - WHITEBOARD_COLLAB_SERVER_PUBLIC_URL
         networks:
             meet.jitsi:
+        depends_on:
+            - jvb
 
     # XMPP server
     prosody:


### PR DESCRIPTION
since web runs dig jvb on startup, if jvb isn't up yet, this can fail or point to a wrong ip, leading the colibri websocket connection to fail

this might be the cause for #1531 and #1599, at least I fixed the same symptoms like this for me