### PR TITLE
Use storage.googleapis.com location for chromedriver.

### DIFF
--- a/jibri/rootfs/usr/bin/install-chrome.sh
+++ b/jibri/rootfs/usr/bin/install-chrome.sh
@@ -33,7 +33,7 @@ else
     fi
 
     CHROMEDRIVER_ZIP="/tmp/chromedriver_linux64.zip"
-    curl -4Lso ${CHROMEDRIVER_ZIP} "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${CHROMEDRIVER_RELEASE}/linux64/chromedriver-linux64.zip"
+    curl -4Lso ${CHROMEDRIVER_ZIP} "https://storage.googleapis.com/chrome-for-testing-public/${CHROMEDRIVER_RELEASE}/linux64/chromedriver-linux64.zip"
     unzip ${CHROMEDRIVER_ZIP} -d /tmp/
     mv /tmp/chromedriver-linux64/chromedriver /usr/bin/
     chmod +x /usr/bin/chromedriver


### PR DESCRIPTION
This is the place listed on
https://googlechromelabs.github.io/chrome-for-testing/ which would seem to be the least likely to silently break. Currently, the edgedl.me.gvt1.com location is broken.