### PR TITLE
jibri: add ability to ignore certificate errors

### DIFF
--- a/jibri.yml
+++ b/jibri.yml
@@ -23,6 +23,7 @@ services:
             - CHROMIUM_FLAGS
             - DISPLAY=:0
             - ENABLE_STATS_D
+            - IGNORE_CERTIFICATE_ERRORS
             - JIBRI_WEBHOOK_SUBSCRIBERS
             - JIBRI_INSTANCE_ID
             - JIBRI_HTTP_API_EXTERNAL_PORT

--- a/jibri/rootfs/defaults/jibri.conf
+++ b/jibri/rootfs/defaults/jibri.conf
@@ -141,6 +141,17 @@ jibri {
         "{{ join "\",\"" (splitList "," .Env.CHROMIUM_FLAGS) }}"
       ]
     }
+    {{ else if .Env.IGNORE_CERTIFICATE_ERRORS -}}
+    chrome {
+      flags = [
+        "--use-fake-ui-for-media-stream",
+        "--start-maximized",
+        "--kiosk",
+        "--enabled",
+        "--autoplay-policy=no-user-gesture-required",
+        "--ignore-certificate-errors"
+      ]
+    }
     {{ end -}}
 
     {{ if .Env.ENABLE_STATS_D -}}


### PR DESCRIPTION
This is useful for testing without a valid TLS certificate.