### PR TITLE
jicofo & jvb: Fix OCTO + SCTP behaviour

### DIFF
--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -4,7 +4,7 @@
 {{ $AUTH_TYPE := .Env.AUTH_TYPE | default "internal" -}}
 {{ $JICOFO_AUTH_TYPE := .Env.JICOFO_AUTH_TYPE | default $AUTH_TYPE -}}
 {{ $JICOFO_AUTH_LIFETIME := .Env.JICOFO_AUTH_LIFETIME | default "24 hours" -}}
-{{ $ENABLE_SCTP := .Env.ENABLE_SCTP | default "1" | toBool -}}
+{{ $ENABLE_SCTP := .Env.ENABLE_SCTP | default "0" | toBool -}}
 {{ $ENABLE_RECORDING := .Env.ENABLE_RECORDING | default "0" | toBool -}}
 {{ $ENABLE_OCTO := .Env.ENABLE_OCTO | default "0" | toBool -}}
 {{ $ENABLE_OCTO_SCTP := .Env.ENABLE_OCTO_SCTP | default $ENABLE_SCTP | toBool -}}

--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -4,10 +4,10 @@
 {{ $AUTH_TYPE := .Env.AUTH_TYPE | default "internal" -}}
 {{ $JICOFO_AUTH_TYPE := .Env.JICOFO_AUTH_TYPE | default $AUTH_TYPE -}}
 {{ $JICOFO_AUTH_LIFETIME := .Env.JICOFO_AUTH_LIFETIME | default "24 hours" -}}
-{{ $ENABLE_SCTP := .Env.ENABLE_SCTP | default "0" | toBool -}}
+{{ $ENABLE_SCTP := .Env.ENABLE_SCTP | default "1" | toBool -}}
 {{ $ENABLE_RECORDING := .Env.ENABLE_RECORDING | default "0" | toBool -}}
 {{ $ENABLE_OCTO := .Env.ENABLE_OCTO | default "0" | toBool -}}
-{{ $ENABLE_OCTO_SCTP := .Env.ENABLE_OCTO_SCTP | default (.Env.ENABLE_SCTP | default "0") | toBool -}}
+{{ $ENABLE_OCTO_SCTP := .Env.ENABLE_OCTO_SCTP | default (.Env.ENABLE_SCTP | default "1") | toBool -}}
 {{ $ENABLE_AUTO_LOGIN := .Env.ENABLE_AUTO_LOGIN | default "1" | toBool -}}
 {{ $ENABLE_REST := .Env.JICOFO_ENABLE_REST | default "0" | toBool -}}
 {{ $ENABLE_JVB_XMPP_SERVER := .Env.ENABLE_JVB_XMPP_SERVER | default "0" | toBool -}}
@@ -288,8 +288,8 @@ jicofo {
         disable-certificate-verification = true
       }
       {{ end }}
-      
+
       trusted-domains = [ {{ range $index, $element := $TRUSTED_DOMAINS }}{{ if gt $index 0 }},{{ end }}"{{ $element }}"{{ end}} ]
-      
+
     }
 }

--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -7,7 +7,7 @@
 {{ $ENABLE_SCTP := .Env.ENABLE_SCTP | default "1" | toBool -}}
 {{ $ENABLE_RECORDING := .Env.ENABLE_RECORDING | default "0" | toBool -}}
 {{ $ENABLE_OCTO := .Env.ENABLE_OCTO | default "0" | toBool -}}
-{{ $ENABLE_OCTO_SCTP := .Env.ENABLE_OCTO_SCTP | default (.Env.ENABLE_SCTP | default "1") | toBool -}}
+{{ $ENABLE_OCTO_SCTP := .Env.ENABLE_OCTO_SCTP | default $ENABLE_SCTP | toBool -}}
 {{ $ENABLE_AUTO_LOGIN := .Env.ENABLE_AUTO_LOGIN | default "1" | toBool -}}
 {{ $ENABLE_REST := .Env.JICOFO_ENABLE_REST | default "0" | toBool -}}
 {{ $ENABLE_JVB_XMPP_SERVER := .Env.ENABLE_JVB_XMPP_SERVER | default "0" | toBool -}}

--- a/jvb/rootfs/etc/cont-init.d/10-config
+++ b/jvb/rootfs/etc/cont-init.d/10-config
@@ -72,9 +72,3 @@ tpl /defaults/logging.properties > /config/logging.properties
 tpl /defaults/jvb.conf > /config/jvb.conf
 
 chown -R jvb:jitsi /config
-
-# Configuration checks
-if [[ (-z $ENABLE_COLIBRI_WEBSOCKET || $ENABLE_COLIBRI_WEBSOCKET == "0") && $ENABLE_OCTO == "1"  ]]; then
-  echo "ERROR: In order to enable Octo relays (with ENABLE_OCTO=1), you MUST enable Colibri websockets (with ENABLE_COLIBRI_WEBSOCKET=1)";
-  exit 1;
-fi


### PR DESCRIPTION
Hello everyone!

As a follow-up to #1787, here's the PR that:
1. Removes the bogus `cont-init` check;
2. Enables SCTP by default in Jicofo config template.

I'll leave the PR as a draft for now, until @saghul confirms that all that needed to be done is done. :)