### PR TITLE
Update acme.sh Version to 3.0.7

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.url="https://jitsi.org/jitsi-meet/"
 LABEL org.opencontainers.image.source="https://github.com/jitsi/docker-jitsi-meet"
 LABEL org.opencontainers.image.documentation="https://jitsi.github.io/handbook/"
 
-ADD https://raw.githubusercontent.com/acmesh-official/acme.sh/3.0.1/acme.sh /opt
+ADD https://raw.githubusercontent.com/acmesh-official/acme.sh/3.0.7/acme.sh /opt
 COPY rootfs/ /
 
 RUN apt-dpkg-wrap apt-get update && \

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.url="https://jitsi.org/jitsi-meet/"
 LABEL org.opencontainers.image.source="https://github.com/jitsi/docker-jitsi-meet"
 LABEL org.opencontainers.image.documentation="https://jitsi.github.io/handbook/"
 
-ADD https://raw.githubusercontent.com/acmesh-official/acme.sh/2.8.8/acme.sh /opt
+ADD https://raw.githubusercontent.com/acmesh-official/acme.sh/3.0.1/acme.sh /opt
 COPY rootfs/ /
 
 RUN apt-dpkg-wrap apt-get update && \


### PR DESCRIPTION
Upgrade acme.sh version to 3.0.7

Having ACME error on cert creation when using the older version, upgrade to 3.0.7 official as of 25 April 2024

[3.0.7](https://github.com/acmesh-official/acme.sh/releases/tag/3.0.7)