### PR TITLE
jibri: fail to start if the SYS_ADMIN cap is missing

### DIFF
--- a/jibri/Dockerfile
+++ b/jibri/Dockerfile
@@ -16,7 +16,20 @@ ARG CHROME_RELEASE=121.0.6167.85
 COPY rootfs/ /
 
 RUN apt-dpkg-wrap apt-get update && \
-    apt-dpkg-wrap apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" jibri libgl1-mesa-dri procps jitsi-upload-integrations jitsi-autoscaler-sidecar jq pulseaudio dbus dbus-x11 rtkit unzip fonts-noto && \
+    apt-dpkg-wrap apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+        jibri \
+        libgl1-mesa-dri \
+        procps \
+        jitsi-upload-integrations \
+        jitsi-autoscaler-sidecar \
+        jq \
+        pulseaudio \
+        dbus \
+        dbus-x11 \
+        rtkit \
+        unzip \
+        fonts-noto \
+        libcap2-bin && \
     /usr/bin/install-chrome.sh && \
     apt-cleanup && \
     adduser jibri rtkit && \

--- a/jibri/rootfs/etc/cont-init.d/10-config
+++ b/jibri/rootfs/etc/cont-init.d/10-config
@@ -1,5 +1,11 @@
 #!/usr/bin/with-contenv bash
 
+# Check if the SYS_ADMIN cap is set
+if ! capsh --has-p=cap_sys_admin; then
+    echo "Required capability SYS_ADMIN is missing"
+    exit 1
+fi
+
 # Check if /dev/shm is large enough (2GB at least)
 if ! shm-check; then
     echo "/dev/shm must be at least 2GB in size"


### PR DESCRIPTION
The container will refuse to start and provide some useful information to the user:

```
docker-jitsi-meet-jibri-1    | cap[cap_sys_admin] not permitted
docker-jitsi-meet-jibri-1    | Required capability SYS_ADMIN is missing
docker-jitsi-meet-jibri-1    | [cont-init.d] 10-config: exited 1.
docker-jitsi-meet-jibri-1    | [cont-finish.d] executing container finish scripts...
docker-jitsi-meet-jibri-1    | [cont-finish.d] done.
docker-jitsi-meet-jibri-1    | [s6-finish] waiting for services.
```