### PR TITLE
feat(prosody): Drop non existing config.

### DIFF
--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -124,7 +124,6 @@ consider_websocket_secure = true;
 {{ if $ENABLE_XMPP_WEBSOCKET }}
 smacks_max_unacked_stanzas = 5;
 smacks_hibernation_time = 60;
-smacks_max_hibernated_sessions = 1;
 smacks_max_old_sessions = 1;
 {{ end }}
 


### PR DESCRIPTION
smacks_max_hibernated_sessions config does not exist in prosody 0.12 and the internal smacks. This existed in the external smack module used for prosody 0.11.