### PR TITLE
Add new environment variables for jigasi configuration

### DIFF
--- a/jigasi/rootfs/defaults/sip-communicator.properties
+++ b/jigasi/rootfs/defaults/sip-communicator.properties
@@ -1,6 +1,10 @@
 {{ $ENABLE_TRANSCRIPTIONS := .Env.ENABLE_TRANSCRIPTIONS | default "0" | toBool -}}
 {{ $JIGASI_BREWERY_MUC := .Env.JIGASI_BREWERY_MUC | default "jigasibrewery" -}}
 {{ $JIGASI_XMPP_USER := .Env.JIGASI_XMPP_USER | default "jigasi" -}}
+{{ $JIGASI_JVB_TIMEOUT := .Env.JIGASI_JVB_TIMEOUT | default "30000" -}}
+{{ $JIGASI_LOCAL_REGION := .Env.JIGASI_LOCAL_REGION | default "" -}}
+{{ $BOSH_URL_PATTERN := .Env.BOSH_URL_PATTERN | default "" -}}
+{{ $USE_TRANSLATOR_IN_CONFERENCE := .Env.USE_TRANSLATOR_IN_CONFERENCE | default "0" | toBool -}}
 {{ $XMPP_AUTH_DOMAIN := .Env.XMPP_AUTH_DOMAIN | default "auth.meet.jitsi" -}}
 {{ $XMPP_MUC_DOMAIN := .Env.XMPP_MUC_DOMAIN | default "muc.meet.jitsi" -}}
 {{ $XMPP_GUEST_DOMAIN := .Env.XMPP_GUEST_DOMAIN | default "guest.meet.jitsi" -}}
@@ -187,3 +191,24 @@ org.jitsi.jigasi.MUC_SERVICE_ADDRESS={{ $XMPP_MUC_DOMAIN }}
 {{ if $TRUSTED_DOMAIN_LIST }}
 org.jitsi.jigasi.TRUSTED_DOMAINS=[ {{ range $index, $element := $TRUSTED_DOMAINS }}{{ if gt $index 0 }},{{ end }}"{{ $element }}"{{ end}} ]
 {{ end }}
+
+org.jitsi.jigasi.JVB_INVITE_TIMEOUT={{ $JIGASI_JVB_TIMEOUT }}
+
+{{ if $JIGASI_LOCAL_REGION }}
+org.jitsi.jigasi.LOCAL_REGION={{ $JIGASI_LOCAL_REGION }}
+{{ end }}
+
+{{ if $BOSH_URL_PATTERN }}
+org.jitsi.jigasi.xmpp.acc.BOSH_URL_PATTERN={{ $BOSH_URL_PATTERN }}
+{{ end }}
+
+{{ if $USE_TRANSLATOR_IN_CONFERENCE }}
+org.jitsi.jigasi.xmpp.acc.USE_TRANSLATOR_IN_CONFERENCE=true
+net.java.sip.communicator.impl.protocol.sip.acc1.USE_TRANSLATOR_IN_CONFERENCE=true
+# Should be enabled when using translator mode
+net.java.sip.communicator.impl.neomedia.audioSystem.audiosilence.captureDevice_list=["AudioSilenceCaptureDevice:noTransferData"]
+{{ end }}
+
+{{ if .Env.JIGASI_CONFIGURATION -}}
+{{ join "\n" (splitList "," .Env.JIGASI_CONFIGURATION) }}
+{{ end -}}


### PR DESCRIPTION
As mentioned in https://community.jitsi.org/t/jigasi-sip-dialin-enable-sound-notification/132331/2

We are using 
* org.jitsi.jigasi.JVB_INVITE_TIMEOUT (needed for more than 30 seconds waiting time in the lobby)
* org.jitsi.jigasi.LOCAL_REGION (Jigasi should use the internal JVBs in our setup)
* org.jitsi.jigasi.xmpp.acc.BOSH_URL_PATTERN (to have Jigasi use Bosh to get the right shard via HAProxy)

I am open for discussions - of course everythin could be handled with .Env.JIGASI_CONFIGURATION but i think exposing some useful switches makes sense anyhow.. But let me know what you are thinking :)