### PR TITLE
Change: Drive image compilation with JITSI_IMAGE_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ JITSI_SERVICES := base base-java web prosody jicofo jvb jigasi jibri
 
 BUILD_ARGS := \
 	--build-arg JITSI_REPO=$(JITSI_REPO) \
-	--build-arg JITSI_RELEASE=$(JITSI_RELEASE)
+	--build-arg JITSI_RELEASE=$(JITSI_RELEASE) \
+	--build-arg BASE_TAG=$(JITSI_BUILD)
 
 ifeq ($(FORCE_REBUILD), 1)
   BUILD_ARGS := $(BUILD_ARGS) --no-cache
@@ -23,7 +24,7 @@ buildx:
 	docker buildx build \
 		--platform linux/amd64,linux/arm64 \
 		--progress=plain \
-		$(BUILD_ARGS) --build-arg BASE_TAG=$(JITSI_BUILD) \
+		$(BUILD_ARGS) \
 		--pull --push \
 		--tag $(JITSI_REPO)/$(JITSI_SERVICE):$(JITSI_BUILD) \
 		--tag $(JITSI_REPO)/$(JITSI_SERVICE):$(JITSI_RELEASE) \
@@ -36,7 +37,7 @@ build:
 	docker build \
 		$(BUILD_ARGS) \
 		--progress plain \
-		--tag $(JITSI_REPO)/$(JITSI_SERVICE) \
+		--tag $(JITSI_REPO)/$(JITSI_SERVICE):$(JITSI_BUILD) \
 		$(JITSI_SERVICE)
 
 $(addprefix build_,$(JITSI_SERVICES)):

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 FORCE_REBUILD ?= 0
 JITSI_RELEASE ?= stable
-JITSI_BUILD ?= unstable
+JITSI_IMAGE_VERSION ?= unstable
 JITSI_REPO ?= jitsi
 
 JITSI_SERVICES := base base-java web prosody jicofo jvb jigasi jibri
@@ -8,7 +8,7 @@ JITSI_SERVICES := base base-java web prosody jicofo jvb jigasi jibri
 BUILD_ARGS := \
 	--build-arg JITSI_REPO=$(JITSI_REPO) \
 	--build-arg JITSI_RELEASE=$(JITSI_RELEASE) \
-	--build-arg BASE_TAG=$(JITSI_BUILD)
+	--build-arg BASE_TAG=$(JITSI_IMAGE_VERSION)
 
 ifeq ($(FORCE_REBUILD), 1)
   BUILD_ARGS := $(BUILD_ARGS) --no-cache
@@ -26,7 +26,7 @@ buildx:
 		--progress=plain \
 		$(BUILD_ARGS) \
 		--pull --push \
-		--tag $(JITSI_REPO)/$(JITSI_SERVICE):$(JITSI_BUILD) \
+		--tag $(JITSI_REPO)/$(JITSI_SERVICE):$(JITSI_IMAGE_VERSION) \
 		--tag $(JITSI_REPO)/$(JITSI_SERVICE):$(JITSI_RELEASE) \
 		$(JITSI_SERVICE)
 
@@ -37,17 +37,17 @@ build:
 	docker build \
 		$(BUILD_ARGS) \
 		--progress plain \
-		--tag $(JITSI_REPO)/$(JITSI_SERVICE):$(JITSI_BUILD) \
+		--tag $(JITSI_REPO)/$(JITSI_SERVICE):$(JITSI_IMAGE_VERSION) \
 		$(JITSI_SERVICE)
 
 $(addprefix build_,$(JITSI_SERVICES)):
 	$(MAKE) --no-print-directory JITSI_SERVICE=$(patsubst build_%,%,$@) build
 
 tag:
-	docker tag $(JITSI_REPO)/$(JITSI_SERVICE) $(JITSI_REPO)/$(JITSI_SERVICE):$(JITSI_BUILD)
+	docker tag $(JITSI_REPO)/$(JITSI_SERVICE) $(JITSI_REPO)/$(JITSI_SERVICE):$(JITSI_IMAGE_VERSION)
 
 push:
-	docker push $(JITSI_REPO)/$(JITSI_SERVICE):$(JITSI_BUILD)
+	docker push $(JITSI_REPO)/$(JITSI_SERVICE):$(JITSI_IMAGE_VERSION)
 
 %-all:
 	@$(foreach SERVICE, $(JITSI_SERVICES), $(MAKE) --no-print-directory JITSI_SERVICE=$(SERVICE) $(subst -all,;,$@))


### PR DESCRIPTION
The `JITSI_IMAGE_VERSION` environment variable, part of `env.example`, is already made for driving images tag selection at runtime.

This proposal aims at:
* Using `JITSI_IMAGE_VERSION` environment variable also at build time, making image generation and stack deployment coherent
* Ensuring compilation of all images is done with that same tag