### PR TITLE
fix(jibri): IGNORE_CERTIFICATE_ERRORS as boolean

### DIFF
--- a/jibri/rootfs/defaults/jibri.conf
+++ b/jibri/rootfs/defaults/jibri.conf
@@ -1,3 +1,4 @@
+{{ $IGNORE_CERTIFICATE_ERRORS := .Env.IGNORE_CERTIFICATE_ERRORS | default "false" | toBool -}}
 {{ $ENABLE_PROMETHEUS := .Env.JIBRI_ENABLE_PROMETHEUS | default "false" | toBool -}}
 {{ $JIBRI_RECORDING_RESOLUTION := .Env.JIBRI_RECORDING_RESOLUTION | default "1280x720" -}}
 {{ $JIBRI_RECORDING_VIDEO_ENCODE_PRESET := .Env.JIBRI_RECORDING_VIDEO_ENCODE_PRESET | default "veryfast" -}}
@@ -64,7 +65,7 @@ jibri {
         "{{ join "\",\"" (splitList "," .Env.CHROMIUM_FLAGS) }}"
       ]
     }
-    {{ else if .Env.IGNORE_CERTIFICATE_ERRORS -}}
+    {{ else if $IGNORE_CERTIFICATE_ERRORS -}}
     chrome {
       flags = [
         "--use-fake-ui-for-media-stream",


### PR DESCRIPTION
Currently, `IGNORE_CERTIFICATE_ERRORS` is handled as string. So, any value (such as `0`, `false`) makes it to be set.

This commit allows the template to check it as boolean.