### PR TITLE
fix(log-analyser): added Jitsi network to loki service

### DIFF
--- a/log-analyser.yml
+++ b/log-analyser.yml
@@ -12,6 +12,8 @@ services:
       - ./log-analyser/loki/conf:/conf
     ports:
       - "3100:3100"
+    networks:
+      meet.jitsi:
 
   otel-collector:
     container_name: otel


### PR DESCRIPTION
Jitsi network has been added to the Loki service for the Loki connection to work.