### PR TITLE
Enhancement: Improve Access to Recorded Videos by Organizing Saved Files

### DIFF
--- a/backup/README.md
+++ b/backup/README.md
@@ -17,7 +17,7 @@ This script is designed to help administrators and users of Jitsi, who are runni
 - A CronJob for executing script in case you need to have a frequent execution process.
 
 
-## Configuration:
+## Configuration
 
 Open the script "main.go" and configure the following variables:
 
@@ -46,13 +46,29 @@ Open the script "main.go" and configure the following variables:
    go build -o "Name Your Script Here" .
    ```
 
-## Running the Script Manually:
+## Running the Script Manually
 
 **After you've built the script, you can run the script manually to organize your videos:**
    ```bash
    go build -o "Name Your Script Here" .
 
    ./"Your Executable Script"
-
+   ```
 This will rename the videos and move them from folders to the destination directory.
+
+## Automation with CronJob
+To automate the process of organizing recorded videos, you can set up a cron job on your server. This allows the script to run at defined intervals, ensuring that your videos are always organized.
+
+**Open your crontab:**
+
+```bash
+crontab -e
+Add the CronJob:
+
+Add the following line to schedule the script to run at a specific time. For example, to run the script every day at midnight:
+
+0 0 * * * user /path/to/your/script/organize_videos
+```
+Make sure to replace the path with the actual path to your script.
+
 

--- a/backup/README.md
+++ b/backup/README.md
@@ -1,0 +1,33 @@
+# Jitsi Recorded Video Organizer
+
+This script is designed to help administrators and users of Jitsi, who are running the service in Docker, to easily manage and access recorded conference videos. The script automatically organizes the videos by renaming folders that are created for each video into more descriptive names and moving them to a structured directory.
+
+## Features
+
+- Renames videos to descriptive names based on conference names and timestamps.
+- Moves recorded videos to a more accessible directory structure.
+- Logs the actions performed for easy tracking and troubleshooting.
+
+## Prerequisites
+
+- A directory where you can mount it to your Docker.
+- Jitsi installed and running in Docker.
+- Access to the file system where Jitsi stores recorded videos.
+- Access to backup directory where you need to move your recorded videos.
+- A CronJob for executing script in case you need to have a frequent execution process.
+
+
+- Reccomendation: 
+   1) You can change srcDir, dstDir, and videoLog from main.go file that can match with your infrastructure needs.
+   2) Before moving towards the execution, make sure you've built the script on your system with Go.
+
+## Setup
+
+**Clone the Repository:**
+
+   ```bash
+   git clone git@github.com:jitsi/docker-jitsi-meet.git 
+
+   cd docker-jitsi-meet/organizing-videos
+
+   go build -o "Name Your Script Here" .

--- a/backup/README.md
+++ b/backup/README.md
@@ -63,7 +63,6 @@ To automate the process of organizing recorded videos, you can set up a cron job
 
 ```bash
 crontab -e
-Add the CronJob:
 
 Add the following line to schedule the script to run at a specific time. For example, to run the script every day at midnight:
 

--- a/backup/README.md
+++ b/backup/README.md
@@ -19,11 +19,11 @@ This script is designed to help administrators and users of Jitsi, who are runni
 
 ## Configuration:
 
-Open the script and configure the following variables:
+Open the script "main.go" and configure the following variables:
 
-srcDir: The directory where Jitsi stores recorded videos. This should be the directory mounted on your Docker container.
-dstDir: The destination directory where you want to move the organized videos.
-videoLog: The file path where the script will log its actions.
+- srcDir: The directory where Jitsi stores recorded videos. This should be the directory mounted on your Docker container.
+- dstDir: The destination directory where you want to move the organized videos.
+- videoLog: The file path where the script will log its actions.
 
 **Variables available to change:**
    ```bash
@@ -32,6 +32,7 @@ videoLog: The file path where the script will log its actions.
    dstDir = "/path/to/your/organized/videos"
 
    videoLog = "/path/to/your/log/file.log"
+   ```
 
 ## Setup
 
@@ -43,6 +44,7 @@ videoLog: The file path where the script will log its actions.
    cd docker-jitsi-meet/organizing-videos
 
    go build -o "Name Your Script Here" .
+   ```
 
 ## Running the Script Manually:
 

--- a/backup/README.md
+++ b/backup/README.md
@@ -1,6 +1,6 @@
 # Jitsi Video Organizer
 
-This script is designed to help administrators and users of Jitsi, who are running the service in Docker, to easily manage and access recorded conference videos. The script automatically organizes the videos by renaming folders that are created for each video into more descriptive names and moving them to a structured directory.
+This script is designed to help administrators and users of Jitsi who are running the service in Docker to easily manage and access recorded conference videos. The script automatically organizes the videos by renaming folders that are created for each video into more descriptive names and moving them to a structured directory.
 
 ## Features
 

--- a/backup/README.md
+++ b/backup/README.md
@@ -1,4 +1,4 @@
-# Jitsi Recorded Video Organizer
+# Jitsi Video Organizer
 
 This script is designed to help administrators and users of Jitsi, who are running the service in Docker, to easily manage and access recorded conference videos. The script automatically organizes the videos by renaming folders that are created for each video into more descriptive names and moving them to a structured directory.
 

--- a/backup/README.md
+++ b/backup/README.md
@@ -17,9 +17,21 @@ This script is designed to help administrators and users of Jitsi, who are runni
 - A CronJob for executing script in case you need to have a frequent execution process.
 
 
-- Reccomendation: 
-   1) You can change srcDir, dstDir, and videoLog from main.go file that can match with your infrastructure needs.
-   2) Before moving towards the execution, make sure you've built the script on your system with Go.
+## Configuration:
+
+Open the script and configure the following variables:
+
+srcDir: The directory where Jitsi stores recorded videos. This should be the directory mounted on your Docker container.
+dstDir: The destination directory where you want to move the organized videos.
+videoLog: The file path where the script will log its actions.
+
+**Variables available to change:**
+   ```bash
+   srcDir = "/path/to/your/mounted/jitsi/recordings"
+
+   dstDir = "/path/to/your/organized/videos"
+
+   videoLog = "/path/to/your/log/file.log"
 
 ## Setup
 
@@ -31,3 +43,14 @@ This script is designed to help administrators and users of Jitsi, who are runni
    cd docker-jitsi-meet/organizing-videos
 
    go build -o "Name Your Script Here" .
+
+## Running the Script Manually:
+
+**After you've built the script, you can run the script manually to organize your videos:**
+   ```bash
+   go build -o "Name Your Script Here" .
+
+   ./"Your Executable Script"
+
+This will rename the videos and move them from folders to the destination directory.
+

--- a/backup/README.md
+++ b/backup/README.md
@@ -41,7 +41,7 @@ Open the script "main.go" and configure the following variables:
    ```bash
    git clone git@github.com:jitsi/docker-jitsi-meet.git 
 
-   cd docker-jitsi-meet/organizing-videos
+   cd docker-jitsi-meet/backup
 
    go build -o "Name Your Script Here" .
    ```

--- a/backup/go.mod
+++ b/backup/go.mod
@@ -1,0 +1,3 @@
+module jitsi-videos
+
+go 1.22.6

--- a/backup/main.go
+++ b/backup/main.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	srcDir   = "/srv/recordings/"
+	dstDir   = "/srv/record/"
+	videoLog = "/srv/record/logfile.log"
+)
+
+func calculateHashSum(filePath string) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+
+}
+
+func checkMetadataExist(dir string) bool {
+	metadataPath := filepath.Join(dir, "metadata.json")
+	_, err := os.Stat(metadataPath)
+	return !os.IsNotExist(err)
+}
+
+func copyFiles(src, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	_, err = io.Copy(dstFile, srcFile)
+	if err != nil {
+		return err
+	}
+
+	srcInfo, err := srcFile.Stat()
+	if err != nil {
+		return err
+	}
+	return os.Chmod(dst, srcInfo.Mode())
+
+}
+
+func main() {
+	var directoriesToRemove []string
+
+	err := filepath.Walk(srcDir,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if !info.IsDir() {
+				metaPath := filepath.Dir(path)
+				if checkMetadataExist(metaPath) {
+					fileName := info.Name()
+					fileParts := strings.Split(fileName, "_")
+					if len(fileParts) > 1 {
+						newFileName := fileParts[0] + filepath.Ext(fileName)
+						newPath := filepath.Join(dstDir, newFileName)
+						if _, err := os.Stat(newPath); err == nil {
+							srcHash, err := calculateHashSum(path)
+							if err != nil {
+								return err
+							}
+
+							dstHash, err := calculateHashSum(newPath)
+							if err != nil {
+								return err
+
+							}
+							if srcHash == dstHash {
+
+								fmt.Printf("File already Exist and has been removed, skipping: %s\n", metaPath)
+								return nil
+							}
+						} else {
+							err := copyFiles(path, newPath)
+							if err != nil {
+								return err
+							}
+
+							logFile, err := os.OpenFile(videoLog, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+							if err != nil {
+								log.Fatal(err)
+							}
+
+							defer logFile.Close()
+
+							log.SetOutput(logFile)
+
+							log.Printf("Copied: %s -> %s\n", path, newPath)
+
+						}
+					}
+
+					directoriesToRemove = append(directoriesToRemove, metaPath)
+				}
+
+			}
+			return err
+		})
+
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+	}
+
+	for _, pathsToRemove := range directoriesToRemove {
+		os.RemoveAll(pathsToRemove)
+		if err != nil {
+			fmt.Printf("Error removing directory %s: %v\n", pathsToRemove, err)
+		} else {
+			fmt.Printf("Removed directory: %s\n", pathsToRemove)
+		}
+	}
+}


### PR DESCRIPTION
I'm using Jitsi with Docker, and I encountered some challenges when trying to manage recorded conference videos. The videos are saved in a directory mounted on the Docker container, but they are stored in folders with hash string names. This makes it difficult to identify and locate specific recordings.

Currently, after recording a conference, the videos are saved in a directory with a hashed folder name. Administrators or users who need to access these videos must manually navigate through the hash-named directories, which can be time-consuming and confusing, especially as the number of recordings grows.

To address this, I developed a script that organizes the recorded videos in a more user-friendly manner. The script automatically:
- Renames the videos to more descriptive names based on the conference name and timestamp.
- Moves the videos to a structured directory hierarchy for easier access.

This enhancement will simplify the process of managing recorded videos, making it more intuitive and less error-prone.


Users can quickly find and access recorded videos without dealing with hash strings.
Administrators will spend less time managing the video storage, reducing overhead.
 As the number of recordings increases, this approach will help keep the file system organized.

I would love to contribute this script to the Jitsi project if you find it useful. Please let me know your thoughts on this enhancement.
