### PR TITLE
jaas: add ability to run the web container targetting JaaS

### DIFF
--- a/web/rootfs/defaults/settings-config.js
+++ b/web/rootfs/defaults/settings-config.js
@@ -567,3 +567,54 @@ config.whiteboard = {
 config.testing = {
     enableAv1Support: {{ $TESTING_AV1_SUPPORT }}
 };
+
+// JaaS support: pre-configure image if JAAS_APP_ID was set.
+{{ if .Env.JAAS_APP_ID -}}
+{{ $JAAS_USE_STAGING := .Env.JAAS_USE_STAGING | default "false" | toBool -}}
+{{ $JAAS_DOMAIN := $JAAS_USE_STAGING | ternary "stage.8x8.vc" "8x8.vc" -}}
+{{ $VO_API_DOMAIN := $JAAS_USE_STAGING | ternary "api-vo-pilot.cloudflare.jitsi.net" "api-vo.cloudflare.jitsi.net" -}}
+
+config.hosts.domain = '{{ $JAAS_DOMAIN }}';
+config.hosts.muc = 'conference.{{ .Env.JAAS_APP_ID }}.{{ $JAAS_DOMAIN }}';
+config.hosts.focus = 'focus.{{ $JAAS_DOMAIN }}';
+
+config.analytics.rtcstatsEnabled = true;
+config.analytics.rtcstatsStoreLogs = true;
+config.analytics.rtcstatsUseLegacy = false;
+config.analytics.rtcstatsEndpoint = 'wss://rtcstats-server-8x8.jitsi.net/';
+config.analytics.rtcstatsPollInterval = 10000;
+config.analytics.rtcstatsSendSdp = true;
+
+config.bosh = 'https://{{ $JAAS_DOMAIN }}/{{ .Env.JAAS_APP_ID }}/http-bind';
+config.websocket = 'wss://{{ $JAAS_DOMAIN }}/{{ .Env.JAAS_APP_ID }}/xmpp-websocket';
+config.websocketKeepAliveUrl = 'https://{{ $JAAS_DOMAIN }}/{{ .Env.JAAS_APP_ID }}/_unlock';
+config.conferenceRequestUrl = 'https://{{ $JAAS_DOMAIN }}/{{ .Env.JAAS_APP_ID }}/conference-request/v1';
+
+config.hiddenDomain = 'recorder.{{ $JAAS_DOMAIN }}';
+config.hiddenFromRecorderFeatureEnabled = true;
+config.enableEmailInStats = true;
+
+config.jaasActuatorUrl = 'https://{{ $VO_API_DOMAIN }}/jaas-actuator';
+config.jaasTokenUrl = 'https://{{ $VO_API_DOMAIN }}/token-mapping';
+config.jaasConferenceCreatorUrl = 'https://{{ $VO_API_DOMAIN }}/vmms-conference-mapper/v1/access/conference-creator';
+config.webhookProxyUrl = 'https://{{ $VO_API_DOMAIN }}/webhook-proxy';
+config.billingCounterUrl = 'https://{{ $VO_API_DOMAIN }}/billing-counter/v1/connection';
+config.brandingDataUrl = 'https://{{ $VO_API_DOMAIN }}/branding/public/v1/conferences';
+config.dialInNumbersUrl = 'https://{{ $VO_API_DOMAIN }}/vmms-conference-mapper/access/v1/dids';
+config.dialInConfCodeUrl = 'https://{{ $VO_API_DOMAIN }}/vmms-conference-mapper/v1/access';
+config.dialOutAuthUrl = 'https://{{ $VO_API_DOMAIN }}/phone-authorize';
+config.dialOutRegionUrl = 'https://{{ $VO_API_DOMAIN }}/customer-configs/v1/outbound-destination';
+config.peopleSearchUrl = 'https://{{ $VO_API_DOMAIN }}/v1/directory/search';
+config.inviteServiceUrl = 'https://{{ $VO_API_DOMAIN }}/v1/meeting/invite';
+config.recordingSharingUrl = 'https://{{ $VO_API_DOMAIN }}/jaas-recordings/link';
+config.peopleSearchQueryTypes = ['user','conferenceRooms'];
+config.sipInviteUrl = 'https://{{ $VO_API_DOMAIN }}/sip-jibri-gateway/jibris/invite';
+config.jaasFeedbackMetadataURL = 'https://{{ $VO_API_DOMAIN }}/webhook-proxy/feedback';
+
+{{ if $JAAS_USE_STAGING -}}
+config.whiteboard.collabServerBaseUrl = 'https://eght-excalidraw-backend-pilot.cloudflare.jitsi.net';
+{{ else -}}
+config.whiteboard.collabServerBaseUrl = 'https://eght-excalidraw-backend.cloudflare.jitsi.net';
+{{ end -}}
+config.whiteboard.userLimit = 25;
+{{ end -}}


### PR DESCRIPTION
If JAAS_APP_ID is set, the config will be updated to point to the production JaaS deployment for the given App ID.