### PR TITLE
Revert "feat(jigasi): install openjdk nonheadless, currently required for dependencies"

### DIFF
--- a/jigasi/Dockerfile
+++ b/jigasi/Dockerfile
@@ -11,8 +11,8 @@ LABEL org.opencontainers.image.documentation="https://jitsi.github.io/handbook/"
 ENV GOOGLE_APPLICATION_CREDENTIALS /config/key.json
 
 RUN apt-dpkg-wrap apt-get update && \
-    apt-dpkg-wrap apt-get install -y openjdk-17-jre openjdk-17-jdk jigasi jq jitsi-autoscaler-sidecar && \
-apt-cleanup
+    apt-dpkg-wrap apt-get install -y jigasi jq jitsi-autoscaler-sidecar && \
+    apt-cleanup
 
 COPY rootfs/ /
 


### PR DESCRIPTION
Reverts jitsi/docker-jitsi-meet#1895
After further testing it appears the DISPLAY variable is the culprit