### PR TITLE
Add HTTPS port to URL in env.example

### DIFF
--- a/env.example
+++ b/env.example
@@ -18,7 +18,7 @@
 # Directory where all configuration will be stored
 CONFIG=~/.jitsi-meet-cfg
 
-# Exposed HTTP port
+# Exposed HTTP port (will redirect to HTTPS port)
 HTTP_PORT=8000
 
 # Exposed HTTPS port
@@ -28,7 +28,8 @@ HTTPS_PORT=8443
 TZ=UTC
 
 # Public URL for the web service (required)
-#PUBLIC_URL=https://meet.example.com
+# Keep in mind that if you use a non-standard HTTPS port, it has to appear in the public URL
+#PUBLIC_URL=https://meet.example.com:${HTTPS_PORT}
 
 # Media IP addresses to advertise by the JVB
 # This setting deprecates DOCKER_HOST_ADDRESS, and supports a comma separated list of IPs
@@ -115,10 +116,10 @@ TZ=UTC
 # Authentication configuration (see handbook for details)
 #
 
-# Enable authentication
+# Enable authentication (will ask for login and password to join the meeting)
 #ENABLE_AUTH=1
 
-# Enable guest access
+# Enable guest access (if authentication is enabled, this allows for users to be held in lobby until registered user lets them in)
 #ENABLE_GUESTS=1
 
 # Select authentication type: internal, jwt, ldap or matrix


### PR DESCRIPTION
This prevents the issue where default env.example results in a non-functional system unless user manually adds HTTPS port into the URL

Addresses https://github.com/jitsi/docker-jitsi-meet/issues/1901