### PR TITLE
Add config parameter for ENABLE_MODERATOR_CHECKS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -339,6 +339,7 @@ services:
             - BRIDGE_STRESS_THRESHOLD
             - ENABLE_AUTH
             - ENABLE_AUTO_OWNER
+            - ENABLE_MODERATOR_CHECKS
             - ENABLE_CODEC_VP8
             - ENABLE_CODEC_VP9
             - ENABLE_CODEC_AV1

--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -142,6 +142,10 @@ jicofo {
       enable-auto-owner = {{ .Env.ENABLE_AUTO_OWNER | toBool }}
       {{ end }}
 
+      {{ if .Env.ENABLE_MODERATOR_CHECKS }}
+      enable-moderator-checks = {{ .Env.ENABLE_MODERATOR_CHECKS | toBool }}
+      {{ end }}
+
       {{ if .Env.JICOFO_CONF_INITIAL_PARTICIPANT_WAIT_TIMEOUT }}
       initial-timeout = "{{ .Env.JICOFO_CONF_INITIAL_PARTICIPANT_WAIT_TIMEOUT }}"
       {{ end }}


### PR DESCRIPTION
Adds a new config parameter to disable moderation checks in jicofo