### PR TITLE
fix(prosody): install the new version of jitsi-contrib/prosody-plugins

### DIFF
--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -27,7 +27,7 @@ LABEL org.opencontainers.image.url="https://prosody.im/"
 LABEL org.opencontainers.image.source="https://github.com/jitsi/docker-jitsi-meet"
 LABEL org.opencontainers.image.documentation="https://jitsi.github.io/handbook/"
 
-ARG VERSION_JITSI_CONTRIB_PROSODY_PLUGINS="20241008"
+ARG VERSION_JITSI_CONTRIB_PROSODY_PLUGINS="20241017"
 ARG VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN="1.8.0"
 
 RUN wget -qO /etc/apt/trusted.gpg.d/prosody.gpg https://prosody.im/files/prosody-debian-packages.key && \


### PR DESCRIPTION
This PR installs the new version of [jitsi-contrib/prosody-plugins](https://github.com/jitsi-contrib/prosody-plugins) (_v20241017_) which contains:

- `mod_auth_hybrid_matrix_token` is synchronized with the official `mod_auth_token` (_supporting bearer token, extra logs, etc._)
- supporting the new meeting room name format used in Element's Jitsi widget