### PR TITLE
Rename recorder domain to hidden domain

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,7 +173,7 @@ services:
             - XMPP_DOMAIN
             - XMPP_GUEST_DOMAIN
             - XMPP_MUC_DOMAIN
-            - XMPP_RECORDER_DOMAIN
+            - XMPP_HIDDEN_DOMAIN
             - XMPP_PORT
             - WHITEBOARD_COLLAB_SERVER_PUBLIC_URL
             - WHITEBOARD_COLLAB_SERVER_URL_BASE
@@ -318,7 +318,7 @@ services:
             - XMPP_MUC_MODULES
             - XMPP_MUC_CONFIGURATION
             - XMPP_INTERNAL_MUC_MODULES
-            - XMPP_RECORDER_DOMAIN
+            - XMPP_HIDDEN_DOMAIN
             - XMPP_PORT
             - XMPP_SERVER_S2S_PORT
             - XMPP_SPEAKERSTATS_MODULES
@@ -404,7 +404,7 @@ services:
             - XMPP_AUTH_DOMAIN
             - XMPP_INTERNAL_MUC_DOMAIN
             - XMPP_MUC_DOMAIN
-            - XMPP_RECORDER_DOMAIN
+            - XMPP_HIDDEN_DOMAIN
             - XMPP_SERVER
             - XMPP_PORT
             - MAX_SSRCS_PER_USER

--- a/jibri.yml
+++ b/jibri.yml
@@ -55,7 +55,7 @@ services:
             - XMPP_DOMAIN
             - XMPP_INTERNAL_MUC_DOMAIN
             - XMPP_MUC_DOMAIN
-            - XMPP_RECORDER_DOMAIN
+            - XMPP_HIDDEN_DOMAIN
             - XMPP_SERVER
             - XMPP_PORT
             - XMPP_TRUST_ALL_CERTS

--- a/jibri/rootfs/defaults/xmpp.conf
+++ b/jibri/rootfs/defaults/xmpp.conf
@@ -8,7 +8,7 @@
 {{ $XMPP_AUTH_DOMAIN := .Env.XMPP_AUTH_DOMAIN | default "auth.meet.jitsi" -}}
 {{ $XMPP_DOMAIN := .Env.XMPP_DOMAIN | default "meet.jitsi" -}}
 {{ $XMPP_INTERNAL_MUC_DOMAIN := .Env.XMPP_INTERNAL_MUC_DOMAIN | default "internal-muc.meet.jitsi" -}}
-{{ $XMPP_RECORDER_DOMAIN := .Env.XMPP_RECORDER_DOMAIN | default "recorder.meet.jitsi" -}}
+{{ $XMPP_HIDDEN_DOMAIN := .Env.XMPP_HIDDEN_DOMAIN | default "hidden.meet.jitsi" -}}
 {{ $XMPP_TRUST_ALL_CERTS := .Env.XMPP_TRUST_ALL_CERTS | default "true" | toBool -}}
 {{ $XMPP_PORT := .Env.XMPP_PORT | default "5222" -}}
 {{ $XMPP_SERVER := .Env.XMPP_SERVER | default "xmpp.meet.jitsi" -}}
@@ -55,7 +55,7 @@ jibri.api.xmpp.environments = [
 
                 // The login information the selenium web client will use
                 call-login {
-                    domain = "{{ $XMPP_RECORDER_DOMAIN }}"
+                    domain = "{{ $XMPP_HIDDEN_DOMAIN }}"
                     username = "{{ $JIBRI_RECORDER_USER }}"
                     password = "{{ $ENV.JIBRI_RECORDER_PASSWORD }}"
                 }

--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -6,6 +6,7 @@
 {{ $JICOFO_AUTH_LIFETIME := .Env.JICOFO_AUTH_LIFETIME | default "24 hours" -}}
 {{ $ENABLE_SCTP := .Env.ENABLE_SCTP | default "1" | toBool -}}
 {{ $ENABLE_RECORDING := .Env.ENABLE_RECORDING | default "0" | toBool -}}
+{{ $ENABLE_TRANSCRIPTIONS := .Env.ENABLE_TRANSCRIPTIONS | default "0" | toBool -}}
 {{ $ENABLE_OCTO := .Env.ENABLE_OCTO | default "0" | toBool -}}
 {{ $ENABLE_OCTO_SCTP := .Env.ENABLE_OCTO_SCTP | default $ENABLE_SCTP | toBool -}}
 {{ $ENABLE_AUTO_LOGIN := .Env.ENABLE_AUTO_LOGIN | default "1" | toBool -}}
@@ -33,12 +34,12 @@
 {{ $XMPP_MUC_DOMAIN := .Env.XMPP_MUC_DOMAIN | default "muc.meet.jitsi" -}}
 {{ $XMPP_INTERNAL_MUC_DOMAIN := .Env.XMPP_INTERNAL_MUC_DOMAIN | default "internal-muc.meet.jitsi" -}}
 {{ $XMPP_DOMAIN := .Env.XMPP_DOMAIN | default "meet.jitsi" -}}
-{{ $XMPP_RECORDER_DOMAIN := .Env.XMPP_RECORDER_DOMAIN | default "recorder.meet.jitsi" -}}
+{{ $XMPP_HIDDEN_DOMAIN := .Env.XMPP_HIDDEN_DOMAIN | default "hidden.meet.jitsi" -}}
 {{ $XMPP_PORT := .Env.XMPP_PORT | default "5222" -}}
 {{ $XMPP_SERVER := .Env.XMPP_SERVER | default "xmpp.meet.jitsi" -}}
 {{ $MAX_SSRCS_PER_USER := .Env.MAX_SSRCS_PER_USER | default "20" -}}
 {{ $MAX_SSRC_GROUPS_PER_USER := .Env.MAX_SSRC_GROUPS_PER_USER | default $MAX_SSRCS_PER_USER -}}
-{{ $TRUSTED_DOMAIN_LIST := .Env.JICOFO_TRUSTED_DOMAINS | default ($ENABLE_RECORDING | ternary $XMPP_RECORDER_DOMAIN "") -}}
+{{ $TRUSTED_DOMAIN_LIST := .Env.JICOFO_TRUSTED_DOMAINS | default (or $ENABLE_RECORDING $ENABLE_TRANSCRIPTIONS | ternary $XMPP_HIDDEN_DOMAIN "") -}}
 {{ $TRUSTED_DOMAINS := splitList "," $TRUSTED_DOMAIN_LIST | compact -}}
 {{ $ENV := .Env }}
 

--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -14,7 +14,6 @@
 {{ $ENABLE_JVB_XMPP_SERVER := .Env.ENABLE_JVB_XMPP_SERVER | default "0" | toBool -}}
 {{ $HEALTH_CHECKS_USE_PRESENCE := .Env.JICOFO_HEALTH_CHECKS_USE_PRESENCE | default "0" | toBool -}}
 {{ $JIBRI_BREWERY_MUC := .Env.JIBRI_BREWERY_MUC | default "jibribrewery" -}}
-{{ $ENABLE_TRANSCRIPTIONS := .Env.ENABLE_TRANSCRIPTIONS | default "0" | toBool -}}
 {{ $JIGASI_BREWERY_MUC := .Env.JIGASI_BREWERY_MUC | default "jigasibrewery" -}}
 {{ $JVB_BREWERY_MUC := .Env.JVB_BREWERY_MUC | default "jvbbrewery" -}}
 {{ $JIBRI_PENDING_TIMEOUT := .Env.JIBRI_PENDING_TIMEOUT | default "90 seconds" -}}

--- a/jigasi/rootfs/defaults/transcriber-sip-communicator.properties
+++ b/jigasi/rootfs/defaults/transcriber-sip-communicator.properties
@@ -1,11 +1,11 @@
 {{ $JIGASI_TRANSCRIBER_USER := .Env.JIGASI_TRANSCRIBER_USER | default "transcriber" -}}
 {{ $JIGASI_TRANSCRIBER_FILTER_SILENCE := .Env.JIGASI_TRANSCRIBER_FILTER_SILENCE | default "0" | toBool -}}
-{{ $XMPP_RECORDER_DOMAIN := .Env.XMPP_RECORDER_DOMAIN | default "recorder.meet.jitsi" -}}
+{{ $XMPP_HIDDEN_DOMAIN := .Env.XMPP_HIDDEN_DOMAIN | default "hidden.meet.jitsi" -}}
 {{ $JIGASI_TRANSCRIBER_ENABLE_SAVING := .Env.JIGASI_TRANSCRIBER_ENABLE_SAVING | default "1" | toBool -}}
 {{ $JIGASI_TRANSCRIBER_ENABLE_TRANSLATION := .Env.JIGASI_TRANSCRIBER_ENABLE_TRANSLATION | default "0" | toBool -}}
 
 org.jitsi.jigasi.ENABLE_SIP=false
-org.jitsi.jigasi.xmpp.acc.USER_ID={{ $JIGASI_TRANSCRIBER_USER }}@{{ $XMPP_RECORDER_DOMAIN }}
+org.jitsi.jigasi.xmpp.acc.USER_ID={{ $JIGASI_TRANSCRIBER_USER }}@{{ $XMPP_HIDDEN_DOMAIN }}
 org.jitsi.jigasi.xmpp.acc.PASS={{ .Env.JIGASI_TRANSCRIBER_PASSWORD }}
 org.jitsi.jigasi.xmpp.acc.ANONYMOUS_AUTH=false
 org.jitsi.jigasi.xmpp.acc.ALLOW_NON_SECURE=true

--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -47,7 +47,7 @@
 {{ $XMPP_INTERNAL_MUC_DOMAIN := .Env.XMPP_INTERNAL_MUC_DOMAIN | default "internal-muc.meet.jitsi" -}}
 {{ $XMPP_MUC_DOMAIN := .Env.XMPP_MUC_DOMAIN | default "muc.meet.jitsi" -}}
 {{ $XMPP_MUC_DOMAIN_PREFIX := (split "." $XMPP_MUC_DOMAIN)._0 -}}
-{{ $XMPP_RECORDER_DOMAIN := .Env.XMPP_RECORDER_DOMAIN | default "recorder.meet.jitsi" -}}
+{{ $XMPP_HIDDEN_DOMAIN := .Env.XMPP_HIDDEN_DOMAIN | default "hidden.meet.jitsi" -}}
 
 admins = {
     {{ if .Env.JIGASI_XMPP_PASSWORD }}
@@ -204,7 +204,7 @@ VirtualHost "{{ $XMPP_DOMAIN }}"
     {{ if $ENABLE_LOBBY }}
     lobby_muc = "lobby.{{ $XMPP_DOMAIN }}"
     {{ if or $ENABLE_RECORDING $ENABLE_TRANSCRIPTIONS }}
-    muc_lobby_whitelist = { "{{ $XMPP_RECORDER_DOMAIN }}" }
+    muc_lobby_whitelist = { "{{ $XMPP_HIDDEN_DOMAIN }}" }
     {{ end }}
     {{ end }}
 
@@ -230,7 +230,7 @@ VirtualHost "{{ $XMPP_DOMAIN }}"
     c2s_require_encryption = {{ $C2S_REQUIRE_ENCRYPTION }}
 
     {{ if $ENABLE_VISITORS -}}
-    visitors_ignore_list = { "{{ $XMPP_RECORDER_DOMAIN }}" }
+    visitors_ignore_list = { "{{ $XMPP_HIDDEN_DOMAIN }}" }
     {{ end }}
 
     {{ if .Env.XMPP_CONFIGURATION -}}
@@ -267,7 +267,7 @@ VirtualHost "{{ $XMPP_AUTH_DOMAIN }}"
     authentication = "internal_hashed"
 
 {{ if or $ENABLE_RECORDING $ENABLE_TRANSCRIPTIONS }}
-VirtualHost "{{ $XMPP_RECORDER_DOMAIN }}"
+VirtualHost "{{ $XMPP_HIDDEN_DOMAIN }}"
     modules_enabled = {
       "smacks";
     }
@@ -343,7 +343,7 @@ Component "{{ $XMPP_MUC_DOMAIN }}" "muc"
     };
 
     rate_limit_whitelist_hosts = {
-        "{{ $XMPP_RECORDER_DOMAIN }}";
+        "{{ $XMPP_HIDDEN_DOMAIN }}";
     }
     {{ end -}}
 
@@ -360,10 +360,10 @@ Component "{{ $XMPP_MUC_DOMAIN }}" "muc"
     muc_access_whitelist = {
         "focus@{{ $XMPP_AUTH_DOMAIN }}";
         {{- if $ENABLE_RECORDING }}
-        "{{ $JIBRI_RECORDER_USER }}@{{ $XMPP_RECORDER_DOMAIN }}";
+        "{{ $JIBRI_RECORDER_USER }}@{{ $XMPP_HIDDEN_DOMAIN }}";
         {{- end }}
         {{- if $ENABLE_TRANSCRIPTIONS }}
-        "{{ $JIGASI_TRANSCRIBER_USER }}@{{ $XMPP_RECORDER_DOMAIN }}";
+        "{{ $JIGASI_TRANSCRIBER_USER }}@{{ $XMPP_HIDDEN_DOMAIN }}";
         {{- end }}
     }
     muc_max_occupants = "{{ .Env.MAX_PARTICIPANTS }}"
@@ -371,10 +371,10 @@ Component "{{ $XMPP_MUC_DOMAIN }}" "muc"
     muc_password_whitelist = {
         "focus@{{ $XMPP_AUTH_DOMAIN }}";
 {{- if $ENABLE_RECORDING }}
-        "{{ $JIBRI_RECORDER_USER }}@{{ $XMPP_RECORDER_DOMAIN }}";
+        "{{ $JIBRI_RECORDER_USER }}@{{ $XMPP_HIDDEN_DOMAIN }}";
 {{- end }}
 {{- if $ENABLE_TRANSCRIPTIONS }}
-        "{{ $JIGASI_TRANSCRIBER_USER }}@{{ $XMPP_RECORDER_DOMAIN }}";
+        "{{ $JIGASI_TRANSCRIBER_USER }}@{{ $XMPP_HIDDEN_DOMAIN }}";
 {{- end }}
     }
     muc_tombstones = false

--- a/prosody/rootfs/defaults/prosody.cfg.lua
+++ b/prosody/rootfs/defaults/prosody.cfg.lua
@@ -47,7 +47,7 @@
 {{ $XMPP_GUEST_DOMAIN := .Env.XMPP_GUEST_DOMAIN | default "guest.meet.jitsi" -}}
 {{ $XMPP_MUC_DOMAIN := .Env.XMPP_MUC_DOMAIN | default "muc.meet.jitsi" -}}
 {{ $XMPP_PORT := .Env.XMPP_PORT | default "5222" -}}
-{{ $XMPP_RECORDER_DOMAIN := .Env.XMPP_RECORDER_DOMAIN | default "recorder.meet.jitsi" -}}
+{{ $XMPP_HIDDEN_DOMAIN := .Env.XMPP_HIDDEN_DOMAIN | default "hidden.meet.jitsi" -}}
 
 -- Prosody Example Configuration File
 --
@@ -245,7 +245,7 @@ s2s_whitelist = {
     '{{ $XMPP_GUEST_DOMAIN }}';
     {{- end }}
     {{ if or $ENABLE_RECORDING $ENABLE_TRANSCRIPTIONS -}}
-    '{{ $XMPP_RECORDER_DOMAIN }}';
+    '{{ $XMPP_HIDDEN_DOMAIN }}';
 	{{- end }}
 
     {{- if .Env.PROSODY_VISITORS_S2S_VHOSTS }}

--- a/prosody/rootfs/etc/cont-init.d/10-config
+++ b/prosody/rootfs/etc/cont-init.d/10-config
@@ -77,7 +77,7 @@ fi
 [ -z "${JVB_AUTH_USER}" ] && export JVB_AUTH_USER=jvb
 [ -z "${XMPP_DOMAIN}" ] && export XMPP_DOMAIN=meet.jitsi
 [ -z "${XMPP_AUTH_DOMAIN}" ] && export XMPP_AUTH_DOMAIN=auth.meet.jitsi
-[ -z "${XMPP_RECORDER_DOMAIN}" ] && export XMPP_RECORDER_DOMAIN=recorder.meet.jitsi
+[ -z "${XMPP_HIDDEN_DOMAIN}" ] && export XMPP_HIDDEN_DOMAIN=hidden.meet.jitsi
 
 prosodyctl --config $PROSODY_CFG register focus $XMPP_AUTH_DOMAIN $JICOFO_AUTH_PASSWORD
 
@@ -115,12 +115,12 @@ if [[ "$PROSODY_MODE" == "client" ]]; then
             echo 'FATAL ERROR: Jibri recorder password must be changed, check the README'
             exit 1
         fi
-        prosodyctl --config $PROSODY_CFG register $JIBRI_RECORDER_USER $XMPP_RECORDER_DOMAIN $JIBRI_RECORDER_PASSWORD
+        prosodyctl --config $PROSODY_CFG register $JIBRI_RECORDER_USER $XMPP_HIDDEN_DOMAIN $JIBRI_RECORDER_PASSWORD
     fi
     if [[ "$(echo "$ENABLE_TRANSCRIPTIONS" | tr '[:upper:]' '[:lower:]')" == "true" ]] || [[ "$ENABLE_TRANSCRIPTIONS" == "1" ]]; then
         if [[ ! -z $JIGASI_TRANSCRIBER_PASSWORD ]]; then
             [ -z "$JIGASI_TRANSCRIBER_USER" ] && JIGASI_TRANSCRIBER_USER="transcriber"
-            prosodyctl --config $PROSODY_CFG register $JIGASI_TRANSCRIBER_USER $XMPP_RECORDER_DOMAIN $JIGASI_TRANSCRIBER_PASSWORD
+            prosodyctl --config $PROSODY_CFG register $JIGASI_TRANSCRIBER_USER $XMPP_HIDDEN_DOMAIN $JIGASI_TRANSCRIBER_PASSWORD
         fi
     fi
 fi

--- a/transcriber.yml
+++ b/transcriber.yml
@@ -25,7 +25,7 @@ services:
             - XMPP_INTERNAL_MUC_DOMAIN
             - XMPP_SERVER
             - XMPP_PORT
-            - XMPP_RECORDER_DOMAIN
+            - XMPP_HIDDEN_DOMAIN
             - XMPP_DOMAIN
             - PUBLIC_URL
             - JIGASI_CONFIGURATION

--- a/web/rootfs/defaults/settings-config.js
+++ b/web/rootfs/defaults/settings-config.js
@@ -48,7 +48,7 @@
 {{ $DESKTOP_SHARING_FRAMERATE_MIN := .Env.DESKTOP_SHARING_FRAMERATE_MIN | default 5 -}}
 {{ $DESKTOP_SHARING_FRAMERATE_MAX := .Env.DESKTOP_SHARING_FRAMERATE_MAX | default 5 -}}
 {{ $XMPP_DOMAIN := .Env.XMPP_DOMAIN | default "meet.jitsi" -}}
-{{ $XMPP_RECORDER_DOMAIN := .Env.XMPP_RECORDER_DOMAIN | default "recorder.meet.jitsi" -}}
+{{ $XMPP_HIDDEN_DOMAIN := .Env.XMPP_HIDDEN_DOMAIN | default "hidden.meet.jitsi" -}}
 {{ $DISABLE_DEEP_LINKING  := .Env.DISABLE_DEEP_LINKING | default "false" | toBool -}}
 {{ $DISABLE_POLLS := .Env.DISABLE_POLLS | default "false" | toBool -}}
 {{ $DISABLE_REACTIONS := .Env.DISABLE_REACTIONS | default "false" | toBool -}}
@@ -151,7 +151,7 @@ config.etherpad_base = '{{ $PUBLIC_URL }}/etherpad/p/';
 
 {{ if or $ENABLE_RECORDING $ENABLE_TRANSCRIPTIONS  -}}
 
-config.hiddenDomain = '{{ $XMPP_RECORDER_DOMAIN }}';
+config.hiddenDomain = '{{ $XMPP_HIDDEN_DOMAIN }}';
 {{ end -}}
 
 {{ if $ENABLE_RECORDING -}}


### PR DESCRIPTION
This is bacially the leftovers of #1737.
Since the addition of `transcriber.yaml` by @aaronkvanmeerten the main functionality from the original PR already exist.
This PR simply renames the "recorder" domain to a more generic "hidden" domain, since it is used not only by the recorder, but also by the transcriber.