### PR TITLE
feat(transcriber): fix exposing transcript path in web

### DIFF
--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -60,7 +60,7 @@ location = /_api/room-info {
 {{ end }}
 
 # ensure all static content can always be found first
-location ~ ^/(libs|css|static|images|fonts|lang|sounds|connection_optimization|.well-known)/(.*)$ {
+location ~ ^/(libs|css|static|images|fonts|lang|sounds|connection_optimization|.well-known|transcripts)/(.*)$ {
     add_header 'Access-Control-Allow-Origin' '{{ $CORS_HEADER_ACCESS_CONTROL_ALLOW_ORIGIN }}';
     alias /usr/share/jitsi-meet/$1/$2;
 


### PR DESCRIPTION
This addes the transcipts path to the list of static items that should be allowed by nginx.

Fixes #1427