### PR TITLE
Add the ability to easily customize the application (name and logo)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
             - AMPLITUDE_ID
             - ANALYTICS_SCRIPT_URLS
             - ANALYTICS_WHITELISTED_EVENTS
+            - APP_NAME
             - AUDIO_QUALITY_OPUS_BITRATE
             - AUTO_CAPTION_ON_RECORD
             - BRANDING_DATA_URL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,6 +115,7 @@ services:
             - LETSENCRYPT_DOMAIN
             - LETSENCRYPT_EMAIL
             - LETSENCRYPT_USE_STAGING
+            - LOGO_URL
             - MATOMO_ENDPOINT
             - MATOMO_SITE_ID
             - MICROSOFT_API_APP_CLIENT_ID

--- a/web/rootfs/defaults/interface-config.js
+++ b/web/rootfs/defaults/interface-config.js
@@ -1,0 +1,3 @@
+{{ if .Env.APP_NAME -}}
+interfaceConfig.APP_NAME = '{{ .Env.APP_NAME | js }}';
+{{ end -}}

--- a/web/rootfs/defaults/system-config.js
+++ b/web/rootfs/defaults/system-config.js
@@ -68,3 +68,7 @@ config.websocket = 'wss://{{ $PUBLIC_URL_DOMAIN }}/xmpp-websocket';
 config.bridgeChannel = {
     preferSctp: {{ $JVB_PREFER_SCTP }}
 };
+
+{{ if .Env.LOGO_URL -}}
+config.defaultLogoUrl = '{{ .Env.LOGO_URL }}';
+{{ end -}}

--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -129,3 +129,7 @@ cp /defaults/interface_config.js /config/interface_config.js
 if [[ -f /config/custom-interface_config.js ]]; then
     cat /config/custom-interface_config.js >> /config/interface_config.js
 fi
+
+if [[ -n "${LOGO_URL}" ]]; then
+  ln -s /config/custom-images /usr/share/jitsi-meet/images/custom-images
+fi

--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -126,6 +126,7 @@ if [[ -f /config/custom-config.js ]]; then
 fi
 
 cp /defaults/interface_config.js /config/interface_config.js
+tpl /defaults/interface-config.js >> /config/interface_config.js
 if [[ -f /config/custom-interface_config.js ]]; then
     cat /config/custom-interface_config.js >> /config/interface_config.js
 fi


### PR DESCRIPTION
Add 2 environment variables to configure the application name (`APP_NAME`)  and the logo url (`LOGO_URL`).

`LOGO_URL` requires the logo to be served by the web server, so in the case this variable is defined I made the `$CONFIG/web/custom-images/` directory accessible from the web server thanks to a symbolic link. For instance, for a logo located in the `$CONFIG/web/custom-images/` directory, the `LOGO_URL` variable must be defined to `images/custom-images/logo.svg`.

I wrote the associated documentation [here](https://github.com/bsautel/jitsi-handbook/blob/add-app-configuration-documentation/docs/devops-guide/docker.md), I'll submit a PR to the handbook when this one is merged.