### PR TITLE
feat(web): include custom nginx conf files

### DIFF
--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -38,6 +38,8 @@ add_header X-Jitsi-Shard {{ .Env.DEPLOYMENTINFO_SHARD }};
 # Opt out of FLoC (deprecated)
 add_header Permissions-Policy "interest-cohort=()";
 
+include /config/nginx-custom/*.conf;
+
 location = /config.js {
     alias /config/config.js;
 }


### PR DESCRIPTION
PR adds an include line into Nginx config to allow custom configuration in it.

Like `include /etc/jitsi/meet/jaas/*.conf` line in [jitsi-meet.example](https://github.com/jitsi/jitsi-meet/blob/master/doc/debian/jitsi-meet/jitsi-meet.example).

In my use-case, I will add my OIDC backend as proxy by creating a config file in this folder.
Not having this folder (`/config/nginx-custom/`) by default is not a problem for Nginx.