### PR TITLE
Add Env for Shared document random name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -362,6 +362,7 @@ services:
             - ENABLE_OCTO_SCTP
             - ENABLE_RECORDING
             - ENABLE_SCTP
+            - ENABLE_SHARED_DOCUMENT_RANDOM_NAME
             - ENABLE_TRANSCRIPTIONS
             - ENABLE_VISITORS
             - ENABLE_AUTO_LOGIN

--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -188,10 +188,12 @@ jicofo {
       enable-multi-stream-backward-compat = {{ .Env.JICOFO_MULTI_STREAM_BACKWARD_COMPAT | toBool }}
       {{ end }}
 
+      {{ if .Env.ENABLE_SHARED_DOCUMENT_RANDOM_NAME }}
       shared-document {
         use-random-name = {{ .Env.ENABLE_SHARED_DOCUMENT_RANDOM_NAME | toBool }}
       }
-      
+      {{ end }}
+
     }
 
     {{ if .Env.JICOFO_ENABLE_HEALTH_CHECKS }}

--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -190,7 +190,7 @@ jicofo {
 
       {{ if $ENABLE_SHARED_DOCUMENT_RANDOM_NAME }}
       shared-document {
-        use-random-name = {{ .Env.ENABLE_SHARED_DOCUMENT_RANDOM_NAME | toBool }}
+        use-random-name = {{ $ENABLE_SHARED_DOCUMENT_RANDOM_NAME }}
       }
       {{ end }}
 

--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -12,6 +12,7 @@
 {{ $ENABLE_AUTO_LOGIN := .Env.ENABLE_AUTO_LOGIN | default "1" | toBool -}}
 {{ $ENABLE_REST := .Env.JICOFO_ENABLE_REST | default "0" | toBool -}}
 {{ $ENABLE_JVB_XMPP_SERVER := .Env.ENABLE_JVB_XMPP_SERVER | default "0" | toBool -}}
+{{ $ENABLE_SHARED_DOCUMENT_RANDOM_NAME := .Env.ENABLE_SHARED_DOCUMENT_RANDOM_NAME | default "0" | toBool -}}
 {{ $HEALTH_CHECKS_USE_PRESENCE := .Env.JICOFO_HEALTH_CHECKS_USE_PRESENCE | default "0" | toBool -}}
 {{ $JIBRI_BREWERY_MUC := .Env.JIBRI_BREWERY_MUC | default "jibribrewery" -}}
 {{ $JIGASI_BREWERY_MUC := .Env.JIGASI_BREWERY_MUC | default "jigasibrewery" -}}
@@ -187,6 +188,10 @@ jicofo {
       enable-multi-stream-backward-compat = {{ .Env.JICOFO_MULTI_STREAM_BACKWARD_COMPAT | toBool }}
       {{ end }}
 
+      shared-document {
+        use-random-name = {{ .Env.ENABLE_SHARED_DOCUMENT_RANDOM_NAME | toBool }}
+      }
+      
     }
 
     {{ if .Env.JICOFO_ENABLE_HEALTH_CHECKS }}

--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -188,7 +188,7 @@ jicofo {
       enable-multi-stream-backward-compat = {{ .Env.JICOFO_MULTI_STREAM_BACKWARD_COMPAT | toBool }}
       {{ end }}
 
-      {{ if .Env.ENABLE_SHARED_DOCUMENT_RANDOM_NAME }}
+      {{ if $ENABLE_SHARED_DOCUMENT_RANDOM_NAME }}
       shared-document {
         use-random-name = {{ .Env.ENABLE_SHARED_DOCUMENT_RANDOM_NAME | toBool }}
       }


### PR DESCRIPTION
Hi,
Since many years, Jicofo has a parameter to use a random name in Etherpad : https://github.com/jitsi/jicofo/blob/5803269e775b84aa53d18cade50e81c33a26cc47/jicofo-selector/src/main/resources/reference.conf#L223.
 
It makes the Etherpad link only known by conference participant and more secure.
This pull request adds this option in the docker version. 