### PR TITLE
feat(prosody) - Added TURN_USERNAME and TURN_PASSWORD

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -303,6 +303,8 @@ services:
             - STUN_HOST
             - STUN_PORT
             - TURN_CREDENTIALS
+            - TURN_USERNAME
+            - TURN_PASSWORD
             - TURN_HOST
             - TURNS_HOST
             - TURN_PORT

--- a/prosody/rootfs/defaults/prosody.cfg.lua
+++ b/prosody/rootfs/defaults/prosody.cfg.lua
@@ -331,7 +331,7 @@ log = {
 {{ end }}
 }
 
-{{ if $PROSODY_ENABLE_METRICS }} 
+{{ if $PROSODY_ENABLE_METRICS }}
 -- Statistics Provider configuration
 statistics = "internal"
 statistics_interval = "manual"
@@ -351,7 +351,26 @@ external_services = {
     {{- range $idx1, $host := $TURN_HOSTS -}}
       {{- range $idx2, $transport := $TURN_TRANSPORTS -}}
         {{- if or $STUN_HOST $idx1 $idx2 -}},{{- end }}
-        { type = "turn", host = "{{ $host }}", port = {{ $TURN_PORT }}, transport = "{{ $transport }}", secret = true, ttl = {{ $TURN_TTL }}, algorithm = "turn" }
+        {
+            type = "turn",
+            host = "{{ $host }}",
+            port = {{ $TURN_PORT }},
+            transport = "{{ $transport }}",
+            ttl = {{ $TURN_TTL }},
+
+            {{ if $.Env.TURN_CREDENTIALS -}}
+            secret = true,
+            algorithm = "turn",
+            {{- end }}
+
+            {{ if $.Env.TURN_USERNAME -}}
+            username = "{{$.Env.TURN_USERNAME}}",
+            {{- end }}
+
+            {{ if $.Env.TURN_PASSWORD -}}
+            password = "{{$.Env.TURN_PASSWORD}}",
+            {{- end }}
+        }
       {{- end -}}
     {{- end -}}
   {{- end -}}
@@ -359,7 +378,26 @@ external_services = {
   {{- if $TURNS_HOST -}}
     {{- range $idx, $host := $TURNS_HOSTS -}}
         {{- if or $STUN_HOST $TURN_HOST $idx -}},{{- end }}
-        { type = "turns", host = "{{ $host }}", port = {{ $TURNS_PORT }}, transport = "tcp", secret = true, ttl = {{ $TURN_TTL }}, algorithm = "turn" }
+        {
+            type = "turns",
+            host = "{{ $host }}",
+            port = {{ $TURNS_PORT }},
+            transport = "tcp",
+            ttl = {{ $TURN_TTL }},
+
+            {{ if $.Env.TURN_CREDENTIALS -}}
+            secret = true,
+            algorithm = "turn",
+            {{- end }}
+
+            {{ if $.Env.TURN_USERNAME -}}
+            username = "{{$.Env.TURN_USERNAME}}",
+            {{- end }}
+
+            {{ if $.Env.TURN_PASSWORD -}}
+            password = "{{$.Env.TURN_PASSWORD}}",
+            {{- end }}
+        }
     {{- end }}
   {{- end }}
 };


### PR DESCRIPTION
# Fix: Add support for TURN servers that don't implement draft-uberti-behave-turn-rest-00

## Problem
Cloudflare TURN servers do not support the draft-uberti-behave-turn-rest-00 specification, which is the default method used by mod_external_services to generate TURN credentials (username and password).

## Solution
Added two new environment variables:
- `TURN_USERNAME`: Define a static TURN username
- `TURN_PASSWORD`: Define a static TURN password

When `TURN_CREDENTIALS` is not set, the module will not attempt to generate credentials using the draft-uberti-behave-turn-rest-00 method. Instead, it will use the static credentials if provided through `TURN_USERNAME` and `TURN_PASSWORD`.

This change allows Prosody to work with TURN servers that don't implement the expired draft spec, such as Cloudflare TURN.

## Reference
- [Cloudflare TURN FAQ](https://developers.cloudflare.com/calls/turn/faq/#does-cloudflare-calls-turn-support-the-expired-ietf-rfc-draft-draft-uberti-behave-turn-rest-00)