### PR TITLE
Grafana/log-analyser not working after fresh setup with docker on Ubuntu24

### DIFF
--- a/grafana.yml
+++ b/grafana.yml
@@ -9,6 +9,7 @@ services:
     volumes:
       - ./log-analyser/grafana:/var/lib/grafana
       - ./log-analyser/grafana-provisioning/dashboards/:/etc/grafana/provisioning/dashboards/
+      - ./log-analyser/grafana-provisioning/datasources/:/etc/grafana/provisioning/datasources/
     ports:
       - "3000:3000"
     networks:

--- a/log-analyser/grafana-provisioning/dashboards/docker-statistics.json
+++ b/log-analyser/grafana-provisioning/dashboards/docker-statistics.json
@@ -24,7 +24,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
+          "uid": "Prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -74,7 +74,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
+              "uid": "Prometheus"
             },
             "editorMode": "code",
             "expr": "container_memory_percent_ratio * 100",
@@ -90,7 +90,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
+          "uid": "Prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -140,7 +140,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
+              "uid": "Prometheus"
             },
             "editorMode": "code",
             "exemplar": false,
@@ -158,7 +158,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
+          "uid": "Prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -237,7 +237,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
+              "uid": "Prometheus"
             },
             "editorMode": "code",
             "expr": "sum(rate(container_blockio_io_service_bytes_recursive_total{operation=\"read\"}[5m])) ",
@@ -250,7 +250,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
+              "uid": "Prometheus"
             },
             "editorMode": "code",
             "expr": "sum(rate(container_blockio_io_service_bytes_recursive_total{operation=\"write\"}[5m])) ",
@@ -267,7 +267,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
+          "uid": "Prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -347,7 +347,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
+              "uid": "Prometheus"
             },
             "editorMode": "code",
             "expr": "rate(container_cpu_usage_kernelmode_nanoseconds_total[5m])",
@@ -359,7 +359,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
+              "uid": "Prometheus"
             },
             "editorMode": "code",
             "expr": "rate(container_cpu_usage_usermode_nanoseconds_total[5m])",
@@ -376,7 +376,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
+          "uid": "Prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -456,7 +456,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
+              "uid": "Prometheus"
             },
             "editorMode": "code",
             "expr": "(container_memory_usage_total_bytes / container_memory_usage_limit_bytes) * 100",
@@ -472,7 +472,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
+          "uid": "Prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -551,7 +551,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
+              "uid": "Prometheus"
             },
             "editorMode": "code",
             "exemplar": false,
@@ -564,7 +564,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
+              "uid": "Prometheus"
             },
             "editorMode": "code",
             "expr": "rate(container_network_io_usage_tx_bytes_total{interface=\"eth0\"}[5m])",
@@ -581,7 +581,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
+          "uid": "Prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -660,7 +660,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
+              "uid": "Prometheus"
             },
             "editorMode": "code",
             "expr": "rate(container_network_io_usage_rx_dropped_total{interface=\"eth0\"}[5m])",
@@ -672,7 +672,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
+              "uid": "Prometheus"
             },
             "editorMode": "code",
             "expr": "rate(container_network_io_usage_tx_dropped_total{interface=\"eth0\"}[5m])",

--- a/log-analyser/grafana-provisioning/dashboards/jicofo.json
+++ b/log-analyser/grafana-provisioning/dashboards/jicofo.json
@@ -24,7 +24,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+        "uid": "Loki"
       },
       "gridPos": {
         "h": 8,
@@ -47,7 +47,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+            "uid": "Loki"
           },
           "editorMode": "code",
           "expr": "{exporter=\"OTLP\"} | json | attributes_attrs_service=\"jitsi-jicofo\"",
@@ -61,7 +61,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+        "uid": "Loki"
       },
       "fieldConfig": {
         "defaults": {
@@ -114,7 +114,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "b8130a28-4867-4668-917d-539c93852857"
+            "uid": "Loki"
           },
           "editorMode": "code",
           "expr": "sum by (attributes_level) (\n  rate({exporter=\"OTLP\"} | json|attributes_attrs_service=\"jitsi-jicofo\"| line_format \"{{.log}}\" | logfmt | pattern \"[<_>] <_level>: <_>\"[5m])\n)",
@@ -129,7 +129,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+        "uid": "Loki"
       },
       "fieldConfig": {
         "defaults": {
@@ -181,7 +181,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "b8130a28-4867-4668-917d-539c93852857"
+            "uid": "Loki"
           },
           "editorMode": "code",
           "expr": "sum by (attributes_level, attributes_attrs_service) (\n  rate({exporter=\"OTLP\"} | json|attributes_attrs_service=\"jitsi-jicofo\"| line_format \"{{.attributes_message}}\" | logfmt | pattern \"[<_>] <attributes_level>#<attributes_attrs_service>: <_>\"[5m]))",
@@ -197,7 +197,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+        "uid": "Loki"
       },
       "fieldConfig": {
         "defaults": {
@@ -291,7 +291,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+        "uid": "Loki"
       },
       "description": "This panel shows the number of conference requests over time.",
       "fieldConfig": {
@@ -372,7 +372,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+            "uid": "Loki"
           },
           "editorMode": "code",
           "expr": "count_over_time({exporter=\"OTLP\"} | json | attributes_attrs_service=\"jitsi-jicofo\" |= \"Conference request\" [1m])",
@@ -386,7 +386,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+        "uid": "Loki"
       },
       "fieldConfig": {
         "defaults": {
@@ -429,7 +429,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+            "uid": "Loki"
           },
           "editorMode": "code",
           "expr": "sum(count_over_time({exporter=\"OTLP\"} | json | attributes_attrs_service=\"jitsi-jicofo\" |~ \"Member left|Terminating|Removed participant\" [1m]))",

--- a/log-analyser/grafana-provisioning/dashboards/jitsi-all.json
+++ b/log-analyser/grafana-provisioning/dashboards/jitsi-all.json
@@ -24,7 +24,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+        "uid": "Loki"
       },
       "description": "",
       "fieldConfig": {
@@ -104,7 +104,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "b8130a28-4867-4668-917d-539c93852857"
+            "uid": "Loki"
           },
           "editorMode": "code",
           "expr": "sum by (attributes_attrs_service) (\n  rate({exporter=\"OTLP\"} | json | line_format \"{{.attributes_message}}\" | logfmt | pattern \"[<_>] <_level>: <_>\"[5m]))",
@@ -119,7 +119,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+        "uid": "Loki"
       },
       "gridPos": {
         "h": 8,
@@ -142,7 +142,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+            "uid": "Loki"
           },
           "editorMode": "code",
           "expr": "{exporter=\"OTLP\"} ",

--- a/log-analyser/grafana-provisioning/dashboards/jitsi-web.json
+++ b/log-analyser/grafana-provisioning/dashboards/jitsi-web.json
@@ -24,7 +24,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+        "uid": "Loki"
       },
       "gridPos": {
         "h": 8,
@@ -48,7 +48,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+            "uid": "Loki"
           },
           "editorMode": "code",
           "expr": "{exporter=\"OTLP\"} | json | attributes_attrs_service=\"jitsi-web\"",
@@ -62,7 +62,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+        "uid": "Loki"
       },
       "fieldConfig": {
         "defaults": {
@@ -115,7 +115,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+            "uid": "Loki"
           },
           "editorMode": "code",
           "expr": "sum by (attributes_level) (\n  rate({exporter=\"OTLP\"} | json|attributes_attrs_service=\"jitsi-web\"| line_format \"{{.log}}\" | logfmt | pattern \"[<_>] <_level>: <_>\"[5m])\n)",
@@ -130,7 +130,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+        "uid": "Loki"
       },
       "fieldConfig": {
         "defaults": {
@@ -182,7 +182,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+            "uid": "Loki"
           },
           "editorMode": "code",
           "expr": "sum by (attributes_level, attributes_attrs_service) (\n  rate({exporter=\"OTLP\"} | json|attributes_attrs_service=\"jitsi-web\"| line_format \"{{.attributes_message}}\" | logfmt | pattern \"[<_>] <attributes_level>#<attributes_attrs_service>: <_>\"[5m]))",
@@ -197,7 +197,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+        "uid": "Loki"
       },
       "fieldConfig": {
         "defaults": {
@@ -244,7 +244,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+            "uid": "Loki"
           },
           "editorMode": "code",
           "expr": "sum(count_over_time({exporter=\"OTLP\"} | json | attributes_attrs_service=\"jitsi-web\" |= \"GET\" [5m])) by (instance)",

--- a/log-analyser/grafana-provisioning/dashboards/jvb.json
+++ b/log-analyser/grafana-provisioning/dashboards/jvb.json
@@ -24,7 +24,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+        "uid": "Loki"
       },
       "gridPos": {
         "h": 8,
@@ -47,7 +47,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+            "uid": "Loki"
           },
           "editorMode": "code",
           "expr": "{exporter=\"OTLP\"} | json | attributes_attrs_service=\"jitsi-jvb\"",
@@ -61,7 +61,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+        "uid": "Loki"
       },
       "fieldConfig": {
         "defaults": {
@@ -113,7 +113,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "b8130a28-4867-4668-917d-539c93852857"
+            "uid": "Loki"
           },
           "editorMode": "code",
           "expr": "sum by (attributes_level) (\n  rate({exporter=\"OTLP\"} | json|attributes_attrs_service=\"jitsi-jvb\"| line_format \"{{.log}}\" | logfmt | pattern \"[<_>] <_level>: <_>\"[5m])\n)",
@@ -128,7 +128,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+        "uid": "Loki"
       },
       "fieldConfig": {
         "defaults": {
@@ -181,7 +181,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "b8130a28-4867-4668-917d-539c93852857"
+            "uid": "Loki"
           },
           "editorMode": "code",
           "expr": "sum by (attributes_level, attributes_attrs_service) (\n  rate({exporter=\"OTLP\"} | json|attributes_attrs_service=\"jitsi-jvb\" | line_format \"{{.attributes_message}}\" | logfmt | pattern \"[<_>] <attributes_level>#<attributes_attrs_service>: <_>\"[5m]))",

--- a/log-analyser/grafana-provisioning/dashboards/prosody.json
+++ b/log-analyser/grafana-provisioning/dashboards/prosody.json
@@ -24,7 +24,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+        "uid": "Loki"
       },
       "gridPos": {
         "h": 8,
@@ -47,7 +47,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+            "uid": "Loki"
           },
           "editorMode": "code",
           "expr": "{exporter=\"OTLP\"} | json | attributes_attrs_service=\"jitsi-prosody\"",
@@ -61,7 +61,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+        "uid": "Loki"
       },
       "fieldConfig": {
         "defaults": {
@@ -114,7 +114,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+            "uid": "Loki"
           },
           "editorMode": "code",
           "expr": "sum by (attributes_level) (\n  rate({exporter=\"OTLP\"} | json|attributes_attrs_service=\"jitsi-prosody\"| line_format \"{{.log}}\" | logfmt | pattern \"[<_>] <_level>: <_>\"[5m])\n)",
@@ -129,7 +129,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+        "uid": "Loki"
       },
       "fieldConfig": {
         "defaults": {
@@ -181,7 +181,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+            "uid": "Loki"
           },
           "editorMode": "code",
           "expr": "sum by (attributes_level, attributes_attrs_service) (\n  rate({exporter=\"OTLP\"} | json|attributes_attrs_service=\"jitsi-prosody\"| line_format \"{{.attributes_message}}\" | logfmt | pattern \"[<_>] <attributes_level>#<attributes_attrs_service>: <_>\"[5m]))",
@@ -196,7 +196,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+        "uid": "Loki"
       },
       "fieldConfig": {
         "defaults": {
@@ -247,7 +247,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+            "uid": "Loki"
           },
           "editorMode": "code",
           "expr": "sum(count_over_time({exporter=\"OTLP\"} | json | attributes_attrs_service=\"jitsi-prosody\" |~ \"Starting room\" [1m]))",
@@ -261,7 +261,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+        "uid": "Loki"
       },
       "fieldConfig": {
         "defaults": {
@@ -312,7 +312,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+            "uid": "Loki"
           },
           "editorMode": "code",
           "expr": "sum(count_over_time({exporter=\"OTLP\"} | json | attributes_attrs_service=\"jitsi-prosody\" |~ \"Client disconnected\" [1m]))",
@@ -326,7 +326,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+        "uid": "Loki"
       },
       "fieldConfig": {
         "defaults": {
@@ -377,7 +377,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
+            "uid": "Loki"
           },
           "editorMode": "code",
           "expr": "sum(count_over_time({exporter=\"OTLP\"} | json |attributes_attrs_service=\"jitsi-prosody\" |~ \"Client connected\" [1m]))",

--- a/log-analyser/loki/conf/loki-config.yaml
+++ b/log-analyser/loki/conf/loki-config.yaml
@@ -6,6 +6,8 @@ auth_enabled: false
 server:
   http_listen_port: 3100
   grpc_listen_port: 9096
+  grpc_server_max_recv_msg_size: 33554432 # 32MiB (int bytes), default 4MB
+  grpc_server_max_send_msg_size: 33554432 # 32MiB (int bytes), default 4MB
 
 common:
   instance_addr: 127.0.0.1
@@ -47,5 +49,5 @@ schema_config:
 # Refer to the buildReport method to see what goes into a report.
 #
 # If you would like to disable reporting, uncomment the following lines:
-#analytics:
-#  reporting_enabled: false
+analytics:
+  reporting_enabled: false

--- a/log-analyser/otel-collector-config.yaml
+++ b/log-analyser/otel-collector-config.yaml
@@ -68,8 +68,7 @@ processors:
   batch:
 
 exporters:
-  logging:
-    loglevel: debug
+  debug:
   loki:
     endpoint: "http://loki:3100/loki/api/v1/push"
   prometheus:


### PR DESCRIPTION
As complained in this bug https://github.com/jitsi/docker-jitsi-meet/issues/1956 I have now found a solution what needs to be changed:

- it seems the datasource ids are random ids. The current grafana version can handle plaintext names of the datsources
- the datasources were not imported, because ./log-analyser/grafana-provisioning/datasources was not mounted
- after one day I have always reached some max_send_msg_size limit and Grafana could not get data from loki, to the limit has been set from 4mb to 32mb and works now much much better than before
- the otel component has complained about "loglevel: debug" which seems to be some old style format