### PR TITLE
Replace deprecated logging exporter with debug exporter in otel-colle…

### DIFF
--- a/log-analyser/otel-collector-config.yaml
+++ b/log-analyser/otel-collector-config.yaml
@@ -68,12 +68,12 @@ processors:
   batch:
 
 exporters:
-  logging:
-    loglevel: debug
   loki:
     endpoint: "http://loki:3100/loki/api/v1/push"
   prometheus:
     endpoint: "0.0.0.0:9464"
+  debug:
+    verbosity: detailed
 
 service:
   pipelines:


### PR DESCRIPTION
# Replace deprecated 'logging' exporter with 'debug' exporter in OpenTelemetry Collector config
This PR updates the OpenTelemetry Collector configuration by replacing the deprecated logging exporter with the new debug exporter. The logging exporter was removed in OpenTelemetry Collector version 0.111.0 in favor of debug, which better reflects its purpose.

## Changes Made:

### Replaced:
```
exporters:
    logging:
        loglevel: debug
```
### with:
```
exporters:
    debug:
        verbosity: detailed
```

The logging exporter has been deprecated and removed in newer versions of the OpenTelemetry Collector ([GitHub Issue #11337](https://github.com/open-telemetry/opentelemetry-collector/issues/11337)).

[GitHub Issue #11337 - Remove logging Exporter](https://github.com/open-telemetry/opentelemetry-collector/issues/11337)