### PR TITLE
Fixes and Problem Resolutions

### DIFF
--- a/grafana.yml
+++ b/grafana.yml
@@ -7,9 +7,13 @@ services:
     environment:
       - GF_ANALYTICS_REPORTING_ENABLED=false
     volumes:
-      - ./log-analyser/grafana:/var/lib/grafana
+      - grafana-storage:/var/log/grafana
       - ./log-analyser/grafana-provisioning/dashboards/:/etc/grafana/provisioning/dashboards/
+      - ./log-analyser/grafana-provisioning/datasources/:/etc/grafana/provisioning/datasources/
     ports:
       - "3000:3000"
     networks:
       meet.jitsi:
+      
+volumes:
+  grafana-storage:

--- a/log-analyser/grafana-provisioning/datasources/datasource_loki.yml
+++ b/log-analyser/grafana-provisioning/datasources/datasource_loki.yml
@@ -2,7 +2,7 @@ apiVersion: 1
 
 datasources:
   - name: Loki
-    isDefault: true
+    isDefault: false
     type: loki
     access: proxy
     url: http://loki:3100


### PR DESCRIPTION
1. **Grafana Storage Mount and Volume Adjustment**
    - Removed the `./log - analyser/grafana:/var/lib/grafana` mount. Instead, a named volume `grafana - storage:/var/log/grafana` was added to store Grafana data. Leveraging Docker's named volume approach enhances isolation and data persistence.
    - **Resolved Error**:
      ```
      grafana-1  | GF_PATHS_DATA='/var/lib/grafana' is not writable.
      grafana-1  | You may have issues with file permissions, more information here: http://docs.grafana.org/installation/docker/#migrate-to-v51-or-later
      grafana-1  | mkdir: can't create directory '/var/lib/grafana/plugins': Permission denied
      ```
      The previous mount led to permission - related write issues in the `/var/lib/grafana` directory. By switching to a named volume, these permission problems are effectively resolved.

2. **Grafana Datasource Provisioning Mount Addition**
    - Added the mount `./log - analyser/grafana - provisioning/datasources/:/etc/grafana/provisioning/datasources/`. This enables the automatic loading of Grafana data source configurations during startup.
    - **Resolved Error**:
      ```
      Datasource xxx was not found
      ```
      Without this mount, Grafana was unable to locate the specified data source configurations. The new mount ensures that the necessary configurations are available and can be loaded properly.

3. **Loki Datasource `isDefault` Attribute Update**
    - In the Loki datasource configuration, the `isDefault` attribute has been modified from `true` to `false`, meaning Loki is no longer set as the default datasource.
    - **Resolved Error**:
      ```
      Error: ✗ Datasource provisioning error: datasource.yaml config is invalid. Only one datasource per organization can be marked as default
      ```
      The previous setting where multiple data sources might have been marked as default (or conflicting default settings) caused the configuration to be invalid. Changing Loki's `isDefault` attribute to `false` resolves this conflict and ensures the validity of the `datasource.yaml` configuration.