### PR TITLE
web: Added LETSENCRYPT_ACME_DIRECTORY environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,6 +121,7 @@ services:
             - LETSENCRYPT_DOMAIN
             - LETSENCRYPT_EMAIL
             - LETSENCRYPT_USE_STAGING
+            - LETSENCRYPT_ACME_SERVER
             - MATOMO_ENDPOINT
             - MATOMO_SITE_ID
             - MICROSOFT_API_APP_CLIENT_ID

--- a/env.example
+++ b/env.example
@@ -69,6 +69,8 @@ TZ=UTC
 # Use the staging server (for avoiding rate limits while testing)
 #LETSENCRYPT_USE_STAGING=1
 
+# Set ACME server. Default is zerossl, you can peek one at https://github.com/acmesh-official/acme.sh/wiki/Server
+#LETSENCRYPT_ACME_SERVER="letsencrypt"
 
 #
 # Etherpad integration (for document sharing)

--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -19,10 +19,18 @@ if [[ $DISABLE_HTTPS -ne 1 ]]; then
         if [[ $LETSENCRYPT_USE_STAGING -eq 1 ]]; then
             STAGING="--staging"
         fi
+
+        ACME_SERVER=""
+        if [[ ! -z $LETSENCRYPT_ACME_SERVER ]]; then
+            ACME_SERVER="--set-default-ca --server $LETSENCRYPT_ACME_SERVER"
+            echo "Using custom ACME server: $LETSENCRYPT_ACME_SERVER"
+        fi
+
         export LE_WORKING_DIR="/config/acme.sh"
         # TODO: move away from standalone mode to webroot mode.
         /config/acme.sh/acme.sh \
             $STAGING \
+            $ACME_SERVER \
             --issue \
             --standalone \
             --pre-hook "if [[ -d /var/run/s6/services/nginx ]]; then s6-svc -d /var/run/s6/services/nginx; fi" \


### PR DESCRIPTION
* you can set it when default zerossl doesnt work for you. For example yor server located in the country blocked by ZeroSSL like described in #2022