### PR TITLE
feat(jvb): add ports to advertised ips

### DIFF
--- a/jvb/rootfs/defaults/jvb.conf
+++ b/jvb/rootfs/defaults/jvb.conf
@@ -138,11 +138,22 @@ ice4j {
             }
             static-mappings = [
 {{ range $index, $element := $JVB_IPS -}}
+{{ if contains ":" $element -}}
+{{ $element_ip_port := splitn ":" 2 $element -}}
+                {
+                    local-address = "{{ $ENV.LOCAL_ADDRESS }}"
+                    public-address = "{{ $element_ip_port._0 }}"
+                    local-port = {{ $ENV.JVB_PORT | default 10000 }}
+                    public-port = {{ $element_ip_port._1 }}
+                    name = "ip-{{ $index }}"
+                },
+{{ else -}}
                 {
                     local-address = "{{ $ENV.LOCAL_ADDRESS }}"
                     public-address = "{{ $element }}"
                     name = "ip-{{ $index }}"
                 },
+{{ end -}}
 {{ end -}}
             ]
         }


### PR DESCRIPTION
I initially described my problem [here](https://github.com/jitsi/jitsi-videobridge/issues/2305)
>We are using a Kubernetes StatefulSet to host Jitsi video bridges. A load balancer acts as the ingress to the video bridges.
>
>From my perspective, it would be ideal if all video bridges could use the same UDP port internally, with the load balancer differentiating them by using different external ports. This approach would save me from having to allow all possible UDP port values in the video bridges' pod template.

This is my solution to this problem, it ensures old advertised IPs also remain functional.

I welcome any comments or suggestions.

Thanks in advance.

Best regards,
Fabian