### PR TITLE
fix(prosody): Fixes auth type internal with prosody 13.

### DIFF
--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -154,6 +154,7 @@ VirtualHost "{{ $XMPP_DOMAIN }}"
     {{ end }}
   {{ else if eq $PROSODY_AUTH_TYPE "internal" }}
     authentication = "internal_hashed"
+    disable_sasl_mechanisms={ "DIGEST-MD5", "OAUTHBEARER" }
   {{ end }}
 {{ else }}
     authentication = "jitsi-anonymous"


### PR DESCRIPTION
When that mechanism is enabled we end up in endless loop:
```
prosody-1  | 2025-03-22T21:01:26.925692034Z 2025-03-22 21:01:26 meet.jitsi:tokenauth                                         warn	Failed to verify access token: (nil)
prosody-1  | 2025-03-22T21:01:27.043438860Z 2025-03-22 21:01:27 meet.jitsi:tokenauth                                         warn	Failed to verify access token: (nil)
.....
```