### PR TITLE
feat: Configure jvb LastN values using ENV

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -466,12 +466,15 @@ services:
             - JVB_AUTH_PASSWORD
             - JVB_BREWERY_MUC
             - JVB_CC_TRUST_BWE
+            - JVB_CONFERENCE_LAST_N_LIMITS
             - JVB_DISABLE_STUN
             - JVB_DISABLE_XMPP
+            - JVB_INITIAL_LAST_N
             - JVB_INSTANCE_ID
             - JVB_PORT
             - JVB_MUC_NICKNAME
             - JVB_STUN_SERVERS
+            - JVB_LAST_N
             - JVB_LOG_FILE
             - JVB_OCTO_BIND_ADDRESS
             - JVB_OCTO_REGION

--- a/jvb/rootfs/defaults/jvb.conf
+++ b/jvb/rootfs/defaults/jvb.conf
@@ -19,6 +19,9 @@
 {{ $JVB_XMPP_PORT := .Env.JVB_XMPP_PORT | default "6222" -}}
 {{ $JVB_XMPP_SERVER := .Env.JVB_XMPP_SERVER | default "xmpp.jvb.meet.jitsi" -}}
 {{ $JVB_XMPP_SERVERS := splitList "," $JVB_XMPP_SERVER | compact -}}
+{{ $JVB_LAST_N := .Env.JVB_LAST_N | default "-1" -}}
+{{ $JVB_INITIAL_LAST_N := .Env.JVB_INITIAL_LAST_N | default "-1" -}}
+{{ $JVB_CONFERENCE_LAST_N_LIMITS := splitList "," .Env.JVB_CONFERENCE_LAST_N_LIMITS | compact -}}
 {{ $PUBLIC_URL_DOMAIN := .Env.PUBLIC_URL | default "https://localhost:8443" | trimPrefix "https://" | trimSuffix "/" -}}
 {{ $SHUTDOWN_REST_ENABLED := .Env.SHUTDOWN_REST_ENABLED | default "false" | toBool -}}
 {{ $USE_USRSCTP := .Env.JVB_USE_USRSCTP | default "false" | toBool -}}
@@ -37,6 +40,8 @@ videobridge {
     cc {
         use-vla-target-bitrate = {{ .Env.ENABLE_VLA | default "0" | toBool }}
         trust-bwe = {{ $JVB_CC_TRUST_BWE }}
+        jvb-last-n = {{ $JVB_LAST_N }}
+        initial-last-n = {{ $JVB_INITIAL_LAST_N }}
     }
     ice {
         udp {
@@ -124,6 +129,17 @@ videobridge {
         relay-id = "{{ .Env.JVB_OCTO_RELAY_ID | default .Env.JVB_OCTO_BIND_ADDRESS }}"
     }
     {{ end -}}
+
+{{ if $JVB_CONFERENCE_LAST_N_LIMITS }}
+    load-management {
+        conference-last-n-limits {
+{{- range $index, $element := $JVB_CONFERENCE_LAST_N_LIMITS -}}
+{{ $LIMIT := splitn "=" 2 $element }}
+            {{ $LIMIT._0 }} = {{ $LIMIT._1 }},
+{{- end }}
+        }
+    }
+{{ end -}}
 }
 
 ice4j {


### PR DESCRIPTION
This PR allows to configure LastN values in `jvb.conf` using environment variables. I haven't added `videobridge.load-management.load-reducers.last-n` values as I think, in comparison with the other LastN values, there's no real reason to edit the default values and if anybody really wants to, it can be done using the `custom_jvb.conf` file.

- Add `$JVB_LAST_N` to control `videobridge.cc.jvb-last-n` value
- Add `$JVB_INITIAL_LAST_N` to control `videobridge.cc.initial-last-n` value
- Add `$JVB_CONFERENCE_LAST_N_LIMITS` to create and control `videobridge.load-management.conference-last-n-limits` list
  - Meant to be defined as `key1=value1,key2=value2`
  - Will probably need more refactoring as I don't know if trailing comma is allowed