### PR TITLE
refactor(prosody): update JITSI_CONTRIB_PROSODY_PLUGINS to 20250808

### DIFF
--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -27,7 +27,7 @@ LABEL org.opencontainers.image.url="https://prosody.im/"
 LABEL org.opencontainers.image.source="https://github.com/jitsi/docker-jitsi-meet"
 LABEL org.opencontainers.image.documentation="https://jitsi.github.io/handbook/"
 
-ARG VERSION_JITSI_CONTRIB_PROSODY_PLUGINS="20250729"
+ARG VERSION_JITSI_CONTRIB_PROSODY_PLUGINS="20250808"
 ARG VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN="1.8.0"
 ARG PROSODY_PACKAGE="prosody"
 


### PR DESCRIPTION
Install the new release (v20250808) from [jitsi-contrib/prosody-plugins](https://github.com/jitsi-contrib/prosody-plugins)