### PR TITLE
fix(log-analyser): pin otel/opentelemetry-collector-contrib image version

### DIFF
--- a/log-analyser.yml
+++ b/log-analyser.yml
@@ -17,7 +17,7 @@ services:
 
   otel-collector:
     container_name: otel
-    image: otel/opentelemetry-collector-contrib
+    image: otel/opentelemetry-collector-contrib:0.130.0
     user: "0" # required for reading docker container logs
     volumes:
       - ./log-analyser/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml

--- a/log-analyser/otel-collector-config.yaml
+++ b/log-analyser/otel-collector-config.yaml
@@ -68,8 +68,8 @@ processors:
   batch:
 
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
   loki:
     endpoint: "http://loki:3100/loki/api/v1/push"
   prometheus:


### PR DESCRIPTION
The Loki exporter, which is used by the log-analyser, has been removed from recent versions of the `otel/opentelemetry-collector-contrib` image. Using the `latest` tag breaks the logging functionality.

This PR pins the image to `otel/opentelemetry-collector-contrib:0.130.0` to ensure that a version with the Loki exporter is used.

Reference: 
- https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.131.0
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/41413