### PR TITLE
fix(grafana): enable data source provisioning to fix dashboards

### DIFF
--- a/grafana.yml
+++ b/grafana.yml
@@ -9,6 +9,7 @@ services:
     volumes:
       - ./log-analyser/grafana:/var/lib/grafana
       - ./log-analyser/grafana-provisioning/dashboards/:/etc/grafana/provisioning/dashboards/
+      - ./log-analyser/grafana-provisioning/datasources/:/etc/grafana/provisioning/datasources/
     ports:
       - "3000:3000"
     networks:

--- a/log-analyser/grafana-provisioning/dashboards/Prosody-Dashboard.json
+++ b/log-analyser/grafana-provisioning/dashboards/Prosody-Dashboard.json
@@ -18,7 +18,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 20,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -38,7 +37,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "bbb38190-2464-44ea-8080-f9ca9e3dcd61"
+        "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
       },
       "fieldConfig": {
         "defaults": {
@@ -514,7 +513,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "bbb38190-2464-44ea-8080-f9ca9e3dcd61"
+        "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
       },
       "fieldConfig": {
         "defaults": {
@@ -927,7 +926,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "bbb38190-2464-44ea-8080-f9ca9e3dcd61"
+        "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
       },
       "fieldConfig": {
         "defaults": {
@@ -971,7 +970,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1021,7 +1021,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "bbb38190-2464-44ea-8080-f9ca9e3dcd61"
+        "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
       },
       "fieldConfig": {
         "defaults": {
@@ -1030,7 +1030,8 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "orange",
@@ -1087,7 +1088,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "bbb38190-2464-44ea-8080-f9ca9e3dcd61"
+        "uid": "d301145e-8c4e-4027-bf6e-43e81f095020"
       },
       "fieldConfig": {
         "defaults": {
@@ -1131,7 +1132,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1235,7 +1237,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1326,7 +1329,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1386,7 +1390,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Prosody Dashboard",
+  "title": "Prosody Prometheus Dashboard",
   "uid": "c8b1b5f8-6b45-4fa7-92b2-01cc164e2f94asdf",
   "version": 1,
   "weekStart": ""

--- a/log-analyser/grafana-provisioning/dashboards/prosody.json
+++ b/log-analyser/grafana-provisioning/dashboards/prosody.json
@@ -401,7 +401,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Prosody Dashboard",
+  "title": "Prosody Loki Dashboard",
   "uid": "fe2d57bc-b09b-4688-8037-f642047b0cfc",
   "version": 1,
   "weekStart": ""

--- a/log-analyser/grafana-provisioning/datasources/datasource_loki.yml
+++ b/log-analyser/grafana-provisioning/datasources/datasource_loki.yml
@@ -2,8 +2,8 @@ apiVersion: 1
 
 datasources:
   - name: Loki
-    isDefault: true
     type: loki
+    uid: a4bdfb3e-762a-46e5-a79f-2e7bbe88d444
     access: proxy
     url: http://loki:3100
     editable: true
@@ -11,9 +11,9 @@ datasources:
 
   - name: Prometheus
     type: prometheus
+    uid: d301145e-8c4e-4027-bf6e-43e81f095020
     access: proxy
     url: http://prometheus:9090
-    isDefault: true
     editable: true
     jsonData:
       timeInterval: "5s"


### PR DESCRIPTION
In the current docker-compose setup, Grafana data sources were not being created automatically. This caused an issue where provisioned dashboards would fail to render graphs, showing a `Datasource <UID> was not found` error in the panels.

This PR resolves this issue by enabling Grafana's data source provisioning and updating the relevant dashboard configurations. This ensures that the Prometheus and Loki data sources are created automatically on container startup, allowing dashboards to correctly recognize them and display data reliably.

Changes
- Updated the existing `log-analyser/datasources/datasource_loki.yml` to assign static uids to the Prometheus and Loki data sources.
- Added a volume mount to `grafana.yml` to load the data source definition directory, enabling automatic data source creation.
- Updated `Prosody-Dashboard.json` and `prosody.json`.