### PR TITLE
fix(jigasi): make jigasi the owner of the config folder

### DIFF
--- a/jigasi/rootfs/etc/cont-init.d/10-config
+++ b/jigasi/rootfs/etc/cont-init.d/10-config
@@ -103,3 +103,5 @@ fi
 if [[ -f /config/custom-logging.properties ]]; then
     cat /config/custom-logging.properties >> /config/logging.properties
 fi
+
+chown jigasi /config -R


### PR DESCRIPTION
See [the related topic](https://community.jitsi.org/t/jigasi-on-kubernetes-config-permission-issue/140971) in the community forum.

Jigasi cannot update permissions when it is not the owner of `/config` folder.

```
SEVERE: [17] net.java.sip.communicator.impl.configuration.ConfigurationActivator.fixPermissions: Error while fixing config file permissions
java.nio.file.FileSystemException: /config: Operation not permitted
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:100)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileAttributeViews$Posix.setMode(UnixFileAttributeViews.java:277)
	at java.base/sun.nio.fs.UnixFileAttributeViews$Posix.setPermissions(UnixFileAttributeViews.java:299)
	at java.base/java.nio.file.Files.setPosixFilePermissions(Files.java:2167)
	at net.java.sip.communicator.impl.configuration.ConfigurationActivator.fixPermissions(ConfigurationActivator.java:150)
	at net.java.sip.communicator.impl.configuration.ConfigurationActivator.startWithServices(ConfigurationActivator.java:74)
	at net.java.sip.communicator.util.osgi.DependentActivator.addingService(DependentActivator.java:103)
	at org.osgi.util.tracker.ServiceTracker$Tracked.customizerAdding(ServiceTracker.java:943)
	at org.osgi.util.tracker.ServiceTracker$Tracked.customizerAdding(ServiceTracker.java:871)
	at org.osgi.util.tracker.AbstractTracked.trackAdding(AbstractTracked.java:256)
	at org.osgi.util.tracker.AbstractTracked.trackInitial(AbstractTracked.java:183)
	at org.osgi.util.tracker.ServiceTracker.open(ServiceTracker.java:321)
	at org.osgi.util.tracker.ServiceTracker.open(ServiceTracker.java:264)
	at net.java.sip.communicator.util.osgi.DependentActivator.start(DependentActivator.java:79)
	at org.jitsi.impl.osgi.framework.BundleImpl.start(BundleImpl.java:428)
	at org.jitsi.impl.osgi.framework.launch.FrameworkImpl.startLevelChanged(FrameworkImpl.java:483)
	at org.jitsi.impl.osgi.framework.startlevel.FrameworkStartLevelImpl$Command.run(FrameworkStartLevelImpl.java:133)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1395)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
```