### PR TITLE
fix(log-analyser): migrate from loki exporter to otlphttp exporter

### DIFF
--- a/log-analyser.yml
+++ b/log-analyser.yml
@@ -5,7 +5,7 @@ services:
 
   loki:
     container_name: loki
-    image: grafana/loki:3.0.0
+    image: grafana/loki
     command: -config.file=/conf/loki-config.yaml
     volumes:
       - ./log-analyser/loki/data:/data
@@ -17,7 +17,7 @@ services:
 
   otel-collector:
     container_name: otel
-    image: otel/opentelemetry-collector-contrib:0.130.0
+    image: otel/opentelemetry-collector-contrib
     user: "0" # required for reading docker container logs
     volumes:
       - ./log-analyser/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml

--- a/log-analyser/grafana-provisioning/dashboards/jicofo.json
+++ b/log-analyser/grafana-provisioning/dashboards/jicofo.json
@@ -50,7 +50,7 @@
             "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
           },
           "editorMode": "code",
-          "expr": "{exporter=\"OTLP\"} | json | attributes_attrs_service=\"jitsi-jicofo\"",
+          "expr": "{service_name=\"jitsi-jicofo\"}",
           "queryType": "range",
           "refId": "A"
         }
@@ -117,8 +117,8 @@
             "uid": "b8130a28-4867-4668-917d-539c93852857"
           },
           "editorMode": "code",
-          "expr": "sum by (attributes_level) (\n  rate({exporter=\"OTLP\"} | json|attributes_attrs_service=\"jitsi-jicofo\"| line_format \"{{.log}}\" | logfmt | pattern \"[<_>] <_level>: <_>\"[5m])\n)",
-          "legendFormat": "Level: {{attributes_level}}",
+          "expr": "sum by (level) (\n  rate({service_name=\"jitsi-jicofo\"} | line_format \"{{.log}}\" | logfmt | pattern \"[<_>] <_level>: <_>\"[5m])\n)",
+          "legendFormat": "Level: {{level}}",
           "queryType": "range",
           "refId": "A"
         }
@@ -184,8 +184,8 @@
             "uid": "b8130a28-4867-4668-917d-539c93852857"
           },
           "editorMode": "code",
-          "expr": "sum by (attributes_level, attributes_attrs_service) (\n  rate({exporter=\"OTLP\"} | json|attributes_attrs_service=\"jitsi-jicofo\"| line_format \"{{.attributes_message}}\" | logfmt | pattern \"[<_>] <attributes_level>#<attributes_attrs_service>: <_>\"[5m]))",
-          "legendFormat": "Level: {{attributes_level}}",
+          "expr": "sum by (level, attrs_service) (\n  rate({service_name=\"jitsi-jicofo\"} | line_format \"{{.message}}\" | logfmt | pattern \"[<_>] <level>#<attrs_service>: <_>\"[5m]))",
+          "legendFormat": "Level: {{level}}",
           "queryType": "range",
           "refId": "A"
         }
@@ -280,7 +280,7 @@
             "uid": "P8E80F9AEF21F6940"
           },
           "editorMode": "code",
-          "expr": "sum by (attributes_codefile) (\n    rate({exporter=\"OTLP\"} | json|attributes_attrs_service=\"jitsi-jicofo\"| attributes_level=\"ERROR\" | line_format \"{{.attributes_message}}\" | logfmt | pattern \"[<_>] <attributes_level>#<attributes_attrs_service>: <_>\"[5m]))",
+          "expr": "sum by (codefile) (\n    rate({service_name=\"jitsi-jicofo\"} | level=\"ERROR\" | line_format \"{{.message}}\" | logfmt | pattern \"[<_>] <level>#<attrs_service>: <_>\"[5m]))",
           "queryType": "range",
           "refId": "A"
         }
@@ -375,7 +375,7 @@
             "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
           },
           "editorMode": "code",
-          "expr": "count_over_time({exporter=\"OTLP\"} | json | attributes_attrs_service=\"jitsi-jicofo\" |= \"Conference request\" [1m])",
+          "expr": "count_over_time({service_name=\"jitsi-jicofo\"} |= \"Conference request\" [1m])",
           "queryType": "range",
           "refId": "A"
         }
@@ -432,7 +432,7 @@
             "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
           },
           "editorMode": "code",
-          "expr": "sum(count_over_time({exporter=\"OTLP\"} | json | attributes_attrs_service=\"jitsi-jicofo\" |~ \"Member left|Terminating|Removed participant\" [1m]))",
+          "expr": "sum(count_over_time({service_name=\"jitsi-jicofo\"} |~ \"Member left|Terminating|Removed participant\" [1m]))",
           "queryType": "range",
           "refId": "A"
         }

--- a/log-analyser/grafana-provisioning/dashboards/jitsi-all.json
+++ b/log-analyser/grafana-provisioning/dashboards/jitsi-all.json
@@ -107,8 +107,8 @@
             "uid": "b8130a28-4867-4668-917d-539c93852857"
           },
           "editorMode": "code",
-          "expr": "sum by (attributes_attrs_service) (\n  rate({exporter=\"OTLP\"} | json | line_format \"{{.attributes_message}}\" | logfmt | pattern \"[<_>] <_level>: <_>\"[5m]))",
-          "legendFormat": "{{attributes_attrs_service}}",
+          "expr": "sum by (attrs_service) (\n  rate({service_name=~\"jitsi-jicofo|jitsi-jvb|jitsi-prosody|jitsi-web\"} | line_format \"{{.message}}\" | logfmt | pattern \"[<_>] <_level>: <_>\"[5m]))",
+          "legendFormat": "{{attrs_service}}",
           "queryType": "range",
           "refId": "A"
         }
@@ -145,7 +145,7 @@
             "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
           },
           "editorMode": "code",
-          "expr": "{exporter=\"OTLP\"} ",
+          "expr": "{service_name=~\"jitsi-jicofo|jitsi-jvb|jitsi-prosody|jitsi-web\"} ",
           "queryType": "range",
           "refId": "A"
         }

--- a/log-analyser/grafana-provisioning/dashboards/jitsi-web.json
+++ b/log-analyser/grafana-provisioning/dashboards/jitsi-web.json
@@ -51,7 +51,7 @@
             "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
           },
           "editorMode": "code",
-          "expr": "{exporter=\"OTLP\"} | json | attributes_attrs_service=\"jitsi-web\"",
+          "expr": "{service_name=\"jitsi-web\"}",
           "queryType": "range",
           "refId": "A"
         }
@@ -118,8 +118,8 @@
             "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
           },
           "editorMode": "code",
-          "expr": "sum by (attributes_level) (\n  rate({exporter=\"OTLP\"} | json|attributes_attrs_service=\"jitsi-web\"| line_format \"{{.log}}\" | logfmt | pattern \"[<_>] <_level>: <_>\"[5m])\n)",
-          "legendFormat": "Level: {{attributes_level}}",
+          "expr": "sum by (level) (\n  rate({service_name=\"jitsi-web\"} | line_format \"{{.log}}\" | logfmt | pattern \"[<_>] <_level>: <_>\"[5m])\n)",
+          "legendFormat": "Level: {{level}}",
           "queryType": "range",
           "refId": "A"
         }
@@ -185,8 +185,8 @@
             "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
           },
           "editorMode": "code",
-          "expr": "sum by (attributes_level, attributes_attrs_service) (\n  rate({exporter=\"OTLP\"} | json|attributes_attrs_service=\"jitsi-web\"| line_format \"{{.attributes_message}}\" | logfmt | pattern \"[<_>] <attributes_level>#<attributes_attrs_service>: <_>\"[5m]))",
-          "legendFormat": "Level: {{attributes_level}}",
+          "expr": "sum by (level, attrs_service) (\n  rate({service_name=\"jitsi-web\"} | line_format \"{{.message}}\" | logfmt | pattern \"[<_>] <level>#<attrs_service>: <_>\"[5m]))",
+          "legendFormat": "Level: {{level}}",
           "queryType": "range",
           "refId": "A"
         }
@@ -247,7 +247,7 @@
             "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
           },
           "editorMode": "code",
-          "expr": "sum(count_over_time({exporter=\"OTLP\"} | json | attributes_attrs_service=\"jitsi-web\" |= \"GET\" [5m])) by (instance)",
+          "expr": "sum(count_over_time({service_name=\"jitsi-web\"} |= \"GET\" [5m])) by (instance)",
           "queryType": "range",
           "refId": "A"
         }

--- a/log-analyser/grafana-provisioning/dashboards/jvb.json
+++ b/log-analyser/grafana-provisioning/dashboards/jvb.json
@@ -50,7 +50,7 @@
             "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
           },
           "editorMode": "code",
-          "expr": "{exporter=\"OTLP\"} | json | attributes_attrs_service=\"jitsi-jvb\"",
+          "expr": "{service_name=\"jitsi-jvb\"}",
           "queryType": "range",
           "refId": "A"
         }
@@ -116,8 +116,8 @@
             "uid": "b8130a28-4867-4668-917d-539c93852857"
           },
           "editorMode": "code",
-          "expr": "sum by (attributes_level) (\n  rate({exporter=\"OTLP\"} | json|attributes_attrs_service=\"jitsi-jvb\"| line_format \"{{.log}}\" | logfmt | pattern \"[<_>] <_level>: <_>\"[5m])\n)",
-          "legendFormat": "Level: {{attributes_level}}",
+          "expr": "sum by (level) (\n  rate({service_name=\"jitsi-jvb\"} | line_format \"{{.log}}\" | logfmt | pattern \"[<_>] <_level>: <_>\"[5m])\n)",
+          "legendFormat": "Level: {{level}}",
           "queryType": "range",
           "refId": "A"
         }
@@ -184,8 +184,8 @@
             "uid": "b8130a28-4867-4668-917d-539c93852857"
           },
           "editorMode": "code",
-          "expr": "sum by (attributes_level, attributes_attrs_service) (\n  rate({exporter=\"OTLP\"} | json|attributes_attrs_service=\"jitsi-jvb\" | line_format \"{{.attributes_message}}\" | logfmt | pattern \"[<_>] <attributes_level>#<attributes_attrs_service>: <_>\"[5m]))",
-          "legendFormat": "Level: {{attributes_level}}",
+          "expr": "sum by (level, attrs_service) (\n  rate({service_name=\"jitsi-jvb\"} | line_format \"{{.message}}\" | logfmt | pattern \"[<_>] <level>#<attrs_service>: <_>\"[5m]))",
+          "legendFormat": "Level: {{level}}",
           "queryType": "range",
           "refId": "A"
         }

--- a/log-analyser/grafana-provisioning/dashboards/prosody.json
+++ b/log-analyser/grafana-provisioning/dashboards/prosody.json
@@ -50,7 +50,7 @@
             "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
           },
           "editorMode": "code",
-          "expr": "{exporter=\"OTLP\"} | json | attributes_attrs_service=\"jitsi-prosody\"",
+          "expr": "{service_name=\"jitsi-prosody\"}",
           "queryType": "range",
           "refId": "A"
         }
@@ -117,8 +117,8 @@
             "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
           },
           "editorMode": "code",
-          "expr": "sum by (attributes_level) (\n  rate({exporter=\"OTLP\"} | json|attributes_attrs_service=\"jitsi-prosody\"| line_format \"{{.log}}\" | logfmt | pattern \"[<_>] <_level>: <_>\"[5m])\n)",
-          "legendFormat": "Level: {{attributes_level}}",
+          "expr": "sum by (level) (\n  rate({service_name=\"jitsi-prosody\"} | line_format \"{{.log}}\" | logfmt | pattern \"[<_>] <_level>: <_>\"[5m])\n)",
+          "legendFormat": "Level: {{level}}",
           "queryType": "range",
           "refId": "A"
         }
@@ -184,8 +184,8 @@
             "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
           },
           "editorMode": "code",
-          "expr": "sum by (attributes_level, attributes_attrs_service) (\n  rate({exporter=\"OTLP\"} | json|attributes_attrs_service=\"jitsi-prosody\"| line_format \"{{.attributes_message}}\" | logfmt | pattern \"[<_>] <attributes_level>#<attributes_attrs_service>: <_>\"[5m]))",
-          "legendFormat": "Level: {{attributes_level}}",
+          "expr": "sum by (level, attrs_service) (\n  rate({service_name=\"jitsi-prosody\"} | line_format \"{{.message}}\" | logfmt | pattern \"[<_>] <level>#<attrs_service>: <_>\"[5m]))",
+          "legendFormat": "Level: {{level}}",
           "queryType": "range",
           "refId": "A"
         }
@@ -250,7 +250,7 @@
             "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
           },
           "editorMode": "code",
-          "expr": "sum(count_over_time({exporter=\"OTLP\"} | json | attributes_attrs_service=\"jitsi-prosody\" |~ \"Starting room\" [1m]))",
+          "expr": "sum(count_over_time({service_name=\"jitsi-prosody\"} |~ \"Starting room\" [1m]))",
           "queryType": "range",
           "refId": "A"
         }
@@ -315,7 +315,7 @@
             "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
           },
           "editorMode": "code",
-          "expr": "sum(count_over_time({exporter=\"OTLP\"} | json | attributes_attrs_service=\"jitsi-prosody\" |~ \"Client disconnected\" [1m]))",
+          "expr": "sum(count_over_time({service_name=\"jitsi-prosody\"} |~ \"Client disconnected\" [1m]))",
           "queryType": "range",
           "refId": "A"
         }
@@ -380,7 +380,7 @@
             "uid": "a4bdfb3e-762a-46e5-a79f-2e7bbe88d444"
           },
           "editorMode": "code",
-          "expr": "sum(count_over_time({exporter=\"OTLP\"} | json |attributes_attrs_service=\"jitsi-prosody\" |~ \"Client connected\" [1m]))",
+          "expr": "sum(count_over_time({service_name=\"jitsi-prosody\"} |~ \"Client connected\" [1m]))",
           "queryType": "range",
           "refId": "A"
         }

--- a/log-analyser/otel-collector-config.yaml
+++ b/log-analyser/otel-collector-config.yaml
@@ -21,6 +21,11 @@ receivers:
           attributes?.attrs?.service != "jitsi-jicofo" and 
           attributes?.attrs?.service != "jitsi-jvb" and
           attributes?.attrs?.service != "jitsi-prosody")
+        output: add_service_name
+      - type: add
+        id: add_service_name
+        field: resource["service.name"]
+        value: EXPR(attributes.attrs.service)
         output: regex_parser_choice
       - type: router
         id: regex_parser_choice
@@ -70,8 +75,8 @@ processors:
 exporters:
   debug:
     verbosity: detailed
-  loki:
-    endpoint: "http://loki:3100/loki/api/v1/push"
+  otlphttp:
+    endpoint: "http://loki:3100/otlp"
   prometheus:
     endpoint: "0.0.0.0:9464"
 
@@ -80,7 +85,7 @@ service:
     logs:
       receivers: [otlp, filelog/jitsi-containers]
       processors: [batch]
-      exporters: [loki]
+      exporters: [otlphttp]
     metrics:
       receivers: [docker_stats]
       processors: [batch]


### PR DESCRIPTION
This PR provides a permanent solution to the issue temporarily addressed in #2137. It migrates the log-analyser from the deprecated loki exporter to the recommended otlphttp exporter, ensuring it works with the latest `otel/opentelemetry-collector-contrib` images.

Changes:
-   Updated `otel-collector-config.yaml` to use the `otlphttp` exporter and added the `service.name` resource attribute for better indexing.
-   Updated Grafana dashboard JSON files with queries compatible with the OTLP log format.
-   Removed the pinned image version in `log-analyser.yml`.