### PR TITLE
fix(prosody): add transcriber_prefixes to Prosody config

### DIFF
--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -76,6 +76,8 @@ muc_mapper_domain_prefix = "{{ $XMPP_MUC_DOMAIN_PREFIX }}";
 
 recorder_prefixes = { "{{ $JIBRI_RECORDER_USER }}@{{ $XMPP_HIDDEN_DOMAIN }}" };
 
+transcriber_prefixes = { "{{ $JIGASI_TRANSCRIBER_USER }}@{{ $XMPP_HIDDEN_DOMAIN }}" };
+
 http_default_host = "{{ $XMPP_DOMAIN }}"
 
 {{ if and $ENABLE_AUTH (or (eq $PROSODY_AUTH_TYPE "jwt") (eq $PROSODY_AUTH_TYPE "hybrid_matrix_token")) .Env.JWT_ACCEPTED_ISSUERS }}


### PR DESCRIPTION
Add `transcriber_prefixes` to Prosody configuration.

The transcription stopped working after the following change: https://github.com/jitsi/jitsi-meet/commit/93022b328192ddd3c97395fce5b7735d0ddfbc8b
The initial value for `transcriber_prefixes` does not include `hidden.meet.jitsi` domain: [link](https://github.com/jitsi/jitsi-meet/blob/421b21edeb365fda97b13062cb123c22178584ab/resources/prosody-plugins/util.lib.lua#L40)