### PR TITLE
feat(prosody): prioritize custom plugin path

### DIFF
--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -69,7 +69,7 @@ unlimited_jids = {
     "{{ $JVB_AUTH_USER }}@{{ $XMPP_AUTH_DOMAIN }}"
 }
 
-plugin_paths = { "/prosody-plugins/", "/prosody-plugins-custom", "/prosody-plugins-contrib" }
+plugin_paths = { "/prosody-plugins-custom", "/prosody-plugins/", "/prosody-plugins-contrib" }
 
 muc_mapper_domain_base = "{{ $XMPP_DOMAIN }}";
 muc_mapper_domain_prefix = "{{ $XMPP_MUC_DOMAIN_PREFIX }}";


### PR DESCRIPTION
This change modifies the plugin search order in the Prosody configuration to allow custom plugins to override default ones.

By placing `/prosody-plugins-custom` before `/prosody-plugins/`, users can now easily customize their Jitsi Meet deployment by mounting their own plugins, without needing to rebuild the Docker image.