### PR TITLE
Preventing default GC setting from eating all node RAM

### DIFF
--- a/prosody/rootfs/defaults/prosody.cfg.lua
+++ b/prosody/rootfs/defaults/prosody.cfg.lua
@@ -10,7 +10,7 @@
 {{ $ENABLE_VISITORS := .Env.ENABLE_VISITORS | default "0" | toBool -}}
 {{ $ENABLE_S2S := or $ENABLE_VISITORS ( .Env.PROSODY_ENABLE_S2S | default "0" | toBool ) }}
 {{ $GC_TYPE := .Env.GC_TYPE | default "incremental" -}}
-{{ $GC_INC_TH := .Env.GC_INC_TH | default 400 -}}
+{{ $GC_INC_TH := .Env.GC_INC_TH | default 200 -}}
 {{ $GC_INC_SPEED := .Env.GC_INC_SPEED | default 250 -}}
 {{ $GC_INC_STEP_SIZE := .Env.GC_INC_STEP_SIZE | default 13 -}}
 {{ $GC_GEN_MIN_TH := .Env.GC_GEN_MIN_TH | default 20 -}}


### PR DESCRIPTION
Having 400 as a default GC threshold ( in combination with speed equal 250 as a second default ) makes lua anable to recover memory at all! Eating out every single byte on node cluster:

<img width="1080" height="242" alt="image" src="https://github.com/user-attachments/assets/8aaaa0d0-fbe6-4c17-b28e-b11d5e99b8b8" />
