### PR TITLE
feat(jibri): add rclone

### DIFF
--- a/jibri/Dockerfile
+++ b/jibri/Dockerfile
@@ -30,7 +30,8 @@ RUN apt-dpkg-wrap apt-get update && \
         unzip \
         fonts-noto \
         fonts-noto-cjk \
-        libcap2-bin && \
+        libcap2-bin \
+        rclone && \
     /usr/bin/install-chrome.sh && \
     apt-cleanup && \
     adduser jibri rtkit && \


### PR DESCRIPTION
This PR adds [rclone](https://github.com/rclone/rclone) into Jibri from the official Debian repository. It contains only a single executable without any dependencies.

[rclone](https://github.com/rclone/rclone) allows to upload the recorded files from the container to cloud storage providers such as Amazon S3, Google Drive, Microsoft One Drive, etc. Useful for the finalize script.