### PR TITLE
add 'readOnlyName' setting to settings-config.js

### DIFF
--- a/web/rootfs/defaults/settings-config.js
+++ b/web/rootfs/defaults/settings-config.js
@@ -339,7 +339,7 @@ config.chromeExtensionBanner = {{ .Env.CHROME_EXTENSION_BANNER_JSON }};
 config.disableProfile = {{ $DISABLE_PROFILE }};
 
 // When 'true', the user cannot edit the display name. Mainly used in conjunction with JWT.
-config.readOnlyName = {{ $ENABLE_READ_ONLY_NAME }}
+config.readOnlyName = {{ $ENABLE_READ_ONLY_NAME }};
 
 // Room password (false for anything, number for max digits)
 {{ if $ENABLE_JAAS_COMPONENTS -}}


### PR DESCRIPTION
Addition of the 'readOnlyName' setting to the web container.
Useful for when you use JWT authentication and don't want people to change their displayName.