### PR TITLE
fix(docker): remove obsolete tags

### DIFF
--- a/etherpad.yml
+++ b/etherpad.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 services:
     # Etherpad: real-time collaborative document editing
     etherpad:

--- a/grafana.yml
+++ b/grafana.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 services:
   # Grafana: used for visualization of metrics and log data through customizable dashboards.
   grafana:

--- a/jibri.yml
+++ b/jibri.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 services:
     jibri:
         image: jitsi/jibri:${JITSI_IMAGE_VERSION:-unstable}

--- a/jigasi.yml
+++ b/jigasi.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 services:
     # SIP gateway (audio)
     jigasi:

--- a/log-analyser.yml
+++ b/log-analyser.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 services:
   # Log Analyser: used for setting up a log analysis system for visualization, log collection and log processing.
 

--- a/transcriber.yml
+++ b/transcriber.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 services:
     transcriber:
         image: jitsi/jigasi:${JITSI_IMAGE_VERSION:-unstable}

--- a/whiteboard.yml
+++ b/whiteboard.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 services:
     whiteboard:
         image: jitsi/excalidraw-backend:21


### PR DESCRIPTION
`version` tags in YAML files cause this warning:
_"the attribute version is obsolete, it will be ignored, please remove it to avoid potential confusion"_

This was already done for `docker-compose.yml` with [this commit](https://github.com/jitsi/docker-jitsi-meet/commit/19e4b404adfb394c43973af8a95fd2b8c0af0923) but other YAML files still contain this tag. This PR removes these tags.