### PR TITLE
Update Etherpad to 2.5.3 to fix timeslider localization crash 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Look at the GH releases from now on.
 
+## unreleased
+
+* etherpad: bump image to 2.5.3 to fix timeslider breakage
+
 ## stable-10008
 
 Based on stable release 10008.

--- a/etherpad.yml
+++ b/etherpad.yml
@@ -3,7 +3,7 @@ version: '3.5'
 services:
     # Etherpad: real-time collaborative document editing
     etherpad:
-        image: etherpad/etherpad:2.0.3
+        image: etherpad/etherpad:2.5.3
         restart: ${RESTART_POLICY:-unless-stopped}
         environment:
             - TITLE=${ETHERPAD_TITLE:-""}


### PR DESCRIPTION
## Fixes: [#16797 jitsi-meet-repo](https://github.com/jitsi/jitsi-meet/issues/16797)

## What this PR does

Updates the Etherpad Docker image used by Jitsi deployments from `2.0.3` to `2.5.3`.

## Why

Self-hosted Jitsi setups using Etherpad currently experience a hard failure when opening the Etherpad timeslider, caused by invalid localization JSON triggering `html10n` `JSON.parse` errors. This breaks revision history, a core Etherpad feature.

Etherpad integration itself was confirmed in [#15010](https://github.com/jitsi/jitsi-meet/issues/15010), but the shipped Etherpad version is outdated and unstable.

## Details

- Bumps Etherpad image to `etherpad/etherpad:2.5.3`
- Pulls in upstream fixes for:
  - Timeslider stability
  - Strictly valid localization JSON
  - General reliability improvements