### PR TITLE
fix: Patch prosody 13.0.3 to disable domain verification.

### DIFF
--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -65,7 +65,8 @@ RUN set -x && \
     tar -xf v$VERSION_JITSI_CONTRIB_PROSODY_PLUGINS.tar.gz && \
     mkdir /prosody-plugins-contrib && \
     cp -a prosody-plugins-$VERSION_JITSI_CONTRIB_PROSODY_PLUGINS/*  /prosody-plugins-contrib && \
-    rm -rf prosody-plugins-$VERSION_JITSI_CONTRIB_PROSODY_PLUGINS v$VERSION_JITSI_CONTRIB_PROSODY_PLUGINS.tar.gz
+    rm -rf prosody-plugins-$VERSION_JITSI_CONTRIB_PROSODY_PLUGINS v$VERSION_JITSI_CONTRIB_PROSODY_PLUGINS.tar.gz && \
+    (apt-cache policy prosody | grep -q "13\.0\.3" && sed -i '/idna_to_ascii/d' /usr/share/lua/5.4/prosody/util/jid.lua) || true
 
 COPY rootfs/ /
 


### PR DESCRIPTION
We allow `_` in tenant names, which get translated to
conferencename@conference.TANANT.meet.jitsi. With this change in 13.0.3
prosody throws errors as domains with "_" are not valid according to the
spec.
https://hg.prosody.im/trunk/rev/863dd118f8e8
