### PR TITLE
Fix image pull failures by defaulting to stable Jitsi image tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Tag | Description
 `unstable-YYYY-MM-DD` | Daily unstable release
 `latest` | Deprecated, no longer updated (will be removed)
 
+> ⚠️ **Note**
+>
+> Docker Hub no longer publishes or updates the `latest` Jitsi images.
+> docker-jitsi-meet defaults to a pinned `stable-*` image version to avoid
+> image pull failures. You can override this by setting
+> `JITSI_IMAGE_VERSION` in your `.env` file.
+
+
 ## Installation
 
 The installation manual is available [here](https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-docker).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
     # Frontend
     web:
-        image: jitsi/web:${JITSI_IMAGE_VERSION:-unstable}
+        image: jitsi/web:${JITSI_IMAGE_VERSION:-stable-10655}
         restart: ${RESTART_POLICY:-unless-stopped}
         ports:
             - '${HTTP_PORT}:80'
@@ -191,7 +191,7 @@ services:
 
     # XMPP server
     prosody:
-        image: jitsi/prosody:${JITSI_IMAGE_VERSION:-unstable}
+        image: jitsi/prosody:${JITSI_IMAGE_VERSION:-stable-10655}
         restart: ${RESTART_POLICY:-unless-stopped}
         expose:
             - '${XMPP_PORT:-5222}'
@@ -342,7 +342,7 @@ services:
 
     # Focus component
     jicofo:
-        image: jitsi/jicofo:${JITSI_IMAGE_VERSION:-unstable}
+        image: jitsi/jicofo:${JITSI_IMAGE_VERSION:-stable-10655}
         restart: ${RESTART_POLICY:-unless-stopped}
         ports:
             - '127.0.0.1:${JICOFO_REST_PORT:-8888}:8888'
@@ -438,7 +438,7 @@ services:
 
     # Video bridge
     jvb:
-        image: jitsi/jvb:${JITSI_IMAGE_VERSION:-unstable}
+        image: jitsi/jvb:${JITSI_IMAGE_VERSION:-stable-10655}
         restart: ${RESTART_POLICY:-unless-stopped}
         ports:
             - '${JVB_PORT:-10000}:${JVB_PORT:-10000}/udp'

--- a/env.example
+++ b/env.example
@@ -223,5 +223,7 @@ JIBRI_XMPP_PASSWORD=
 # Container restart policy
 #RESTART_POLICY=unless-stopped
 
-# Jitsi image version (useful for local development)
-#JITSI_IMAGE_VERSION=latest
+# Jitsi image version
+# Docker Hub no longer publishes `latest`
+# Use a stable-* tag or set to `unstable` for development
+JITSI_IMAGE_VERSION=stable-10655


### PR DESCRIPTION
### Problem
docker-jitsi-meet defaults to pulling Docker image tags that are no longer
published on Docker Hub, causing fresh installations to fail.

### Solution
- Default all services to a stable Jitsi image tag
- Preserve JITSI_IMAGE_VERSION override behavior
- Document the change for users

### Testing
- Clean install pulls stable-* images
- JITSI_IMAGE_VERSION override pulls unstable images
- Full docker-compose stack starts successfully
