### PR TITLE
fix: enable Sentry logging support for jvb, jicofo, and jigasi

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -413,7 +413,7 @@ services:
             - MAX_BRIDGE_PARTICIPANTS
             - OCTO_BRIDGE_SELECTION_STRATEGY
             - PROSODY_VISITORS_MUC_PREFIX
-            - SENTRY_DSN="${JICOFO_SENTRY_DSN:-0}"
+            - SENTRY_DSN=${JICOFO_SENTRY_DSN:-}
             - SENTRY_ENVIRONMENT
             - SENTRY_RELEASE
             - TZ
@@ -490,7 +490,7 @@ services:
             - JVB_XMPP_PORT
             - JVB_XMPP_SERVER
             - PUBLIC_URL
-            - SENTRY_DSN="${JVB_SENTRY_DSN:-0}"
+            - SENTRY_DSN=${JVB_SENTRY_DSN:-}
             - SENTRY_ENVIRONMENT
             - SENTRY_RELEASE
             - COLIBRI_REST_ENABLED

--- a/env.example
+++ b/env.example
@@ -45,6 +45,23 @@ TZ=UTC
 #VIDEOBRIDGE_MAX_MEMORY=3072m
 
 #
+# Sentry logging configuration (optional)
+# Captures WARNING+ level Java errors and sends them to your Sentry instance
+#
+
+# Sentry DSN for each Java component (leave empty to disable)
+#JVB_SENTRY_DSN=
+#JICOFO_SENTRY_DSN=
+#JIGASI_SENTRY_DSN=
+
+# Sentry environment tag (e.g. production, staging)
+#SENTRY_ENVIRONMENT=
+
+# Sentry release tag (auto-detected from package version if not set)
+#SENTRY_RELEASE=
+
+
+#
 # JaaS Components (beta)
 # https://jaas.8x8.vc
 #

--- a/jicofo/Dockerfile
+++ b/jicofo/Dockerfile
@@ -12,6 +12,11 @@ RUN apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y jicofo && \
     apt-cleanup
 
+# The jicofo package ships the Sentry core JAR but not the JUL handler needed for logging integration.
+RUN SENTRY_VERSION=$(basename /usr/share/jicofo/lib/sentry-[0-9]*.jar | grep -oP '\d+\.\d+\.\d+') && \
+    curl -sfL "https://repo1.maven.org/maven2/io/sentry/sentry-jul/${SENTRY_VERSION}/sentry-jul-${SENTRY_VERSION}.jar" \
+        -o "/usr/share/jicofo/lib/sentry-jul-${SENTRY_VERSION}.jar"
+
 COPY rootfs/ /
 
 VOLUME /config

--- a/jicofo/rootfs/defaults/logging.properties
+++ b/jicofo/rootfs/defaults/logging.properties
@@ -1,4 +1,4 @@
-{{ if .Env.SENTRY_DSN | toBool }}
+{{ if .Env.SENTRY_DSN }}
 handlers=java.util.logging.ConsoleHandler,io.sentry.jul.SentryHandler
 {{ else }}
 handlers= java.util.logging.ConsoleHandler

--- a/jigasi.yml
+++ b/jigasi.yml
@@ -57,7 +57,7 @@ services:
             - JIGASI_VISITORS_QUEUE_SERVICE_PRIVATE_KEY_PATH
             - JIGASI_VISITORS_QUEUE_SERVICE_PRIVATE_KEY_ID
             - SHUTDOWN_REST_ENABLED
-            - SENTRY_DSN="${JIGASI_SENTRY_DSN:-0}"
+            - SENTRY_DSN=${JIGASI_SENTRY_DSN:-}
             - SENTRY_ENVIRONMENT
             - SENTRY_RELEASE
             - TZ

--- a/jigasi/Dockerfile
+++ b/jigasi/Dockerfile
@@ -14,6 +14,11 @@ RUN apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y jigasi jq jitsi-autoscaler-sidecar && \
     apt-cleanup
 
+# The jigasi package ships the Sentry core JAR but not the JUL handler needed for logging integration.
+RUN SENTRY_VERSION=$(basename /usr/share/jigasi/lib/sentry-[0-9]*.jar | grep -oP '\d+\.\d+\.\d+') && \
+    curl -sfL "https://repo1.maven.org/maven2/io/sentry/sentry-jul/${SENTRY_VERSION}/sentry-jul-${SENTRY_VERSION}.jar" \
+        -o "/usr/share/jigasi/lib/sentry-jul-${SENTRY_VERSION}.jar"
+
 COPY rootfs/ /
 
 VOLUME ["/config", "/tmp/transcripts"]

--- a/jigasi/rootfs/defaults/logging.properties
+++ b/jigasi/rootfs/defaults/logging.properties
@@ -1,4 +1,4 @@
-{{ if .Env.SENTRY_DSN | toBool }}
+{{ if .Env.SENTRY_DSN }}
 handlers=java.util.logging.ConsoleHandler,io.sentry.jul.SentryHandler
 {{ else }}
 handlers=java.util.logging.ConsoleHandler

--- a/jvb/Dockerfile
+++ b/jvb/Dockerfile
@@ -12,6 +12,11 @@ RUN apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y jitsi-videobridge2 jitsi-autoscaler-sidecar jq curl iproute2 dnsutils libpcap0.8 && \
     apt-cleanup
 
+# The jitsi-videobridge2 package ships the Sentry core JAR but not the JUL handler needed for logging integration.
+RUN SENTRY_VERSION=$(basename /usr/share/jitsi-videobridge/lib/sentry-[0-9]*.jar | grep -oP '\d+\.\d+\.\d+') && \
+    curl -sfL "https://repo1.maven.org/maven2/io/sentry/sentry-jul/${SENTRY_VERSION}/sentry-jul-${SENTRY_VERSION}.jar" \
+        -o "/usr/share/jitsi-videobridge/lib/sentry-jul-${SENTRY_VERSION}.jar"
+
 COPY rootfs/ /
 
 VOLUME /config

--- a/jvb/rootfs/defaults/logging.properties
+++ b/jvb/rootfs/defaults/logging.properties
@@ -1,4 +1,4 @@
-{{ if .Env.SENTRY_DSN | toBool }}
+{{ if .Env.SENTRY_DSN }}
 handlers=java.util.logging.ConsoleHandler,io.sentry.jul.SentryHandler
 {{ else }}
 handlers= java.util.logging.ConsoleHandler

--- a/transcriber.yml
+++ b/transcriber.yml
@@ -64,7 +64,7 @@ services:
             - GC_CLIENT_ID
             - GC_CLIENT_CERT_URL
             - SHUTDOWN_REST_ENABLED
-            - SENTRY_DSN="${JIGASI_SENTRY_DSN:-0}"
+            - SENTRY_DSN=${JIGASI_SENTRY_DSN:-}
             - SENTRY_ENVIRONMENT
             - SENTRY_RELEASE
             - TZ


### PR DESCRIPTION
The logging.properties templates used toBool on the SENTRY_DSN variable, which is a URL, making it impossible to configure Sentry properly. The SENTRY_DSN default was also set to "0" which is truthy in Go templates when toBool is removed.

Additionally, the sentry-jul JAR (containing the SentryHandler class) was missing from all three Docker images, causing a ClassNotFoundException at startup.

I believe we are not trying to move this upstream (see https://github.com/jitsi/jitsi videobridge/pull/1785) but if we wanted to make this better we should be changing upstream so that the jul jars are also included.

This won't work as-is until the docker images are built and published. An override file like this can be used to force to use local images to test it:

```yaml
services:
    jicofo:
        build:
            context: ./jicofo
            args:
                BASE_TAG: unstable
    jvb:
        build:
            context: ./jvb
            args:
                BASE_TAG: unstable
```

For: 

- https://github.com/jitsi/docker-jitsi-meet/issues/2228