### PR TITLE
Add support for custom transcription languages config option

### DIFF
--- a/env.example
+++ b/env.example
@@ -115,6 +115,21 @@ TZ=UTC
 
 
 #
+# Transcription configuration
+#
+
+# Enable transcription (requires Jigasi)
+#ENABLE_TRANSCRIPTIONS=0
+
+# Custom transcription languages in JSON format
+# Allows extending the list of supported transcription languages for custom speech recognition systems
+# Example format: {"language-code": "Language Name"}
+# For use with Vosk or other custom speech recognition engines
+# Example: TRANSCRIPTION_CUSTOM_LANGUAGES={"hi":"Hindi","ta":"Tamil","bn":"Bengali"}
+#TRANSCRIPTION_CUSTOM_LANGUAGES=
+
+
+#
 # Authentication configuration (see handbook for details)
 #
 

--- a/web/rootfs/defaults/settings-config.js
+++ b/web/rootfs/defaults/settings-config.js
@@ -30,6 +30,7 @@
 {{ $PREFERRED_LANGUAGE := .Env.PREFERRED_LANGUAGE | default "en-US" -}}
 {{ $DISABLE_START_FOR_ALL := .Env.DISABLE_START_FOR_ALL | default "false" | toBool -}}
 {{ $AUTO_CAPTION_ON_RECORD := .Env.AUTO_CAPTION_ON_RECORD | default "false" | toBool -}}
+{{ $TRANSCRIPTION_CUSTOM_LANGUAGES := .Env.TRANSCRIPTION_CUSTOM_LANGUAGES | default "" -}}
 {{ $ENABLE_JAAS_COMPONENTS := .Env.ENABLE_JAAS_COMPONENTS | default "0" | toBool }}
 {{ $HIDE_PREJOIN_DISPLAY_NAME := .Env.HIDE_PREJOIN_DISPLAY_NAME | default "false" | toBool -}}
 {{ $PUBLIC_URL := .Env.PUBLIC_URL | default "https://localhost:8443" -}}
@@ -364,6 +365,9 @@ config.transcription = {
     preferredLanguage: '{{ $PREFERRED_LANGUAGE }}',
     disableStartForAll: {{ $DISABLE_START_FOR_ALL }},
     autoCaptionOnRecord: {{ $AUTO_CAPTION_ON_RECORD }},
+{{ if $TRANSCRIPTION_CUSTOM_LANGUAGES -}}
+    customLanguages: {{ $TRANSCRIPTION_CUSTOM_LANGUAGES }},
+{{ end -}}
 };
 
 // Dynamic branding


### PR DESCRIPTION
Added support for the [customLanguages](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) configuration option in the transcription settings, enabling Docker deployments to extend the list of supported transcription languages.