### PR TITLE
feat(jicofo): add MID RTP header extension support

### DIFF
--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -158,6 +158,9 @@ jicofo {
         video-layers-allocation {
           enabled = {{ .Env.ENABLE_VLA | default "0" | toBool }}
         }
+        mid {
+          enabled = {{ .Env.JICOFO_ENABLE_MID | default "1" | toBool }}
+        }
       }
     }
 


### PR DESCRIPTION
Add support for the MID RTP header extension in jicofo, controlled by the `JICOFO_ENABLE_MID` environment variable (defaults to enabled).

This follows the same pattern as `video-layers-allocation` / `ENABLE_VLA`.