### PR TITLE
fix(dial-in): point JaaS dial-in URLs to a Cloudflare-fronted host

### DIFF
--- a/web/rootfs/defaults/settings-config.js
+++ b/web/rootfs/defaults/settings-config.js
@@ -263,8 +263,8 @@ config.analytics.whiteListedEvents = [ '{{ join "','" (splitList "," .Env.ANALYT
 //
 
 {{ if $ENABLE_JAAS_COMPONENTS }}
-config.dialInConfCodeUrl = 'https://conference-mapper.jitsi.net/v1/access';
-config.dialInNumbersUrl = 'https://conference-mapper.jitsi.net/v1/access/dids';
+config.dialInConfCodeUrl = 'https://api-vo.cloudflare.jitsi.net/vmms-conference-mapper/v1/access';
+config.dialInNumbersUrl = 'https://api-vo.cloudflare.jitsi.net/vmms-conference-mapper/v1/access/dids';
 {{ else }}
 {{ if .Env.CONFCODE_URL -}}
 config.dialInConfCodeUrl = '{{ .Env.CONFCODE_URL }}';


### PR DESCRIPTION
## Summary

Swap the JaaS branch in `web/rootfs/defaults/settings-config.js` for `dialInConfCodeUrl` / `dialInNumbersUrl` from `conference-mapper.jitsi.net` to `api-vo.cloudflare.jitsi.net`.

Only the `{{ if \$ENABLE_JAAS_COMPONENTS }}` defaults are touched; the env-var override branches (`CONFCODE_URL`, `DIALIN_NUMBERS_URL`) are unchanged.

## Test plan

- [ ] Run the web container with `ENABLE_JAAS_COMPONENTS=1` and no `CONFCODE_URL` / `DIALIN_NUMBERS_URL` set; verify the rendered `settings-config.js` has the new URLs.
- [ ] Open the dial-in modal in the resulting deployment, verify the numbers list loads.