### PR TITLE
base: update to Debian Trixie

### DIFF
--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -28,7 +28,7 @@ jobs:
         run: echo 'APT::Key::Assert-Pubkey-Algo ">=rsa2048,ed25519,ed448,dsa1024";' | sudo tee /etc/apt/apt.conf.d/99weakkey-warning
       - name: Prosody repo
         id: prosody_repo
-        run: echo "deb [signed-by=/etc/apt/keyrings/prosody.gpg] https://packages.prosody.im/debian bookworm main" | sudo tee /etc/apt/sources.list.d/prosody.list
+        run: echo "deb [signed-by=/etc/apt/keyrings/prosody.gpg] https://packages.prosody.im/debian trixie main" | sudo tee /etc/apt/sources.list.d/prosody.list
       - name: Jitsi repo
         uses: myci-actions/add-deb-repo@43408b9f0225d1c64ba667d59e337c6140383bbe  # 11
         with:

--- a/base-java/Dockerfile
+++ b/base-java/Dockerfile
@@ -9,5 +9,5 @@ RUN mkdir -p /usr/share/man/man1 && \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
     apt-dpkg-wrap apt-get update && \
-    apt-dpkg-wrap apt-get install -y nodejs openjdk-17-jre-headless openjdk-17-jdk-headless && \
+    apt-dpkg-wrap apt-get install -y nodejs openjdk-21-jre-headless openjdk-21-jdk-headless && \
     apt-cleanup

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/debian:bookworm-slim
+FROM docker.io/library/debian:trixie-slim
 
 ARG JITSI_RELEASE=stable
 ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2
@@ -13,7 +13,7 @@ RUN \
         *) echo "unsupported architecture"; exit 1 ;; \
     esac && \
     apt-dpkg-wrap apt-get update && \
-    apt-dpkg-wrap apt-get install -y apt-transport-https apt-utils ca-certificates gnupg wget curl && \
+    apt-dpkg-wrap apt-get install -y apt-utils ca-certificates gnupg wget curl && \
     wget -qO /usr/bin/tpl https://github.com/jitsi/tpl/releases/download/v1.5.0/tpl-linux-${TPL_ARCH} && \
     # Workaround S6 bug when /bin is a symlink
     wget -qO /tmp/s6.tar.gz https://github.com/just-containers/s6-overlay/releases/download/v1.22.1.0/s6-overlay-${S6_ARCH}.tar.gz && \
@@ -25,7 +25,7 @@ RUN \
     rm -rf /tmp/s6* && \
     wget -qO - https://download.jitsi.org/jitsi-key.gpg.key | gpg --dearmour > /etc/apt/trusted.gpg.d/jitsi.gpg && \
     echo "deb https://download.jitsi.org $JITSI_RELEASE/" > /etc/apt/sources.list.d/jitsi.list && \
-    echo "deb http://ftp.debian.org/debian bookworm-backports main" > /etc/apt/sources.list.d/backports.list && \
+    echo "deb http://ftp.debian.org/debian trixie-backports main" > /etc/apt/sources.list.d/backports.list && \
     apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get dist-upgrade -y && \
     apt-cleanup && \

--- a/jibri/Dockerfile
+++ b/jibri/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.documentation="https://jitsi.github.io/handbook/"
 ARG USE_CHROMIUM=0
 #ARG CHROME_RELEASE=latest
 # https://googlechromelabs.github.io/chrome-for-testing/
-ARG CHROME_RELEASE=143.0.7499.40
+ARG CHROME_RELEASE=149.0.7827.114
 
 COPY rootfs/ /
 

--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -33,7 +33,7 @@ ARG PROSODY_PACKAGE_VERSION="13.*"
 
 RUN set -x && \
     wget -qO /etc/apt/trusted.gpg.d/prosody.gpg https://prosody.im/files/prosody-debian-packages.key && \
-    echo "deb http://packages.prosody.im/debian bookworm main" > /etc/apt/sources.list.d/prosody.list && \
+    echo "deb http://packages.prosody.im/debian trixie main" > /etc/apt/sources.list.d/prosody.list && \
     apt-dpkg-wrap apt-get update && \
     apt-dpkg-wrap apt-get install -y \
       lua5.4 \
@@ -54,8 +54,6 @@ RUN set -x && \
     apt-cleanup && \
     rm -rf /etc/prosody && \
     mv /usr/share/lua/5.3/inspect.lua /usr/share/lua/5.4/ && \
-    rm -rf /usr/lib/lua/{5.1,5.2,5.3} && \
-    rm -rf /usr/share/lua/{5.1,5.2,5.3} && \
     wget https://github.com/matrix-org/prosody-mod-auth-matrix-user-verification/archive/refs/tags/v$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN.tar.gz && \
     tar -xf v$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN.tar.gz && \
     mv prosody-mod-auth-matrix-user-verification-$VERSION_MATRIX_USER_VERIFICATION_SERVICE_PLUGIN/mod_auth_matrix_user_verification.lua /prosody-plugins && \


### PR DESCRIPTION
Migrate all Debian-based images from bookworm to trixie (Debian 13).

- base: debian:trixie-slim and trixie-backports
- base-java: openjdk-17 -> openjdk-21. Trixie dropped openjdk-17; the
  jitsi packages already declare openjdk-21 as a supported alternative.
- prosody: use the trixie suite from packages.prosody.im, and drop the
  dead 'rm -rf /usr/{lib,share}/lua/{5.1,5.2,5.3}' cleanup. The brace
  expansion never ran under /bin/sh (dash), and on trixie
  /usr/share/lua/5.4 is a symlink farm into 5.1/5.2, so actually
  deleting those trees would break the prosody install.
- base: drop apt-transport-https, a no-op transitional package in trixie.
- ci: prosody trixie suite in unstable.yml.
