### PR TITLE
refactor(web): use unprivileged ports 8000 and 8443

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
             - /run:size=16M,mode=1750,exec
             - /tmp:size=16M,mode=1777,noexec
         ports:
-            - '${HTTP_PORT}:80'
-            - '${HTTPS_PORT}:443'
+            - '${HTTP_PORT}:8000'
+            - '${HTTPS_PORT}:8443'
         volumes:
             - ${CONFIG}/web:/config:Z
             - ${CONFIG}/storage/web:/storage:Z
@@ -298,8 +298,6 @@ services:
             - PROSODY_DISABLE_S2S_LIMIT
             - PROSODY_ENABLE_FILTER_MESSAGES
             - PROSODY_ENABLE_MUC_RESOURCE_VALIDATE
-            - PROSODY_MUC_RESOURCE_VALIDATE_ANONYMOUS_STRICT
-            - PROSODY_MUC_RESOURCE_VALIDATE_ANON_METHODS
             - PROSODY_ENABLE_RATE_LIMITS
             - PROSODY_ENABLE_RECORDING_METADATA
             - PROSODY_ENABLE_STANZA_COUNTS
@@ -310,6 +308,8 @@ services:
             - PROSODY_LOG_CONFIG
             - PROSODY_METRICS_ALLOWED_CIDR
             - PROSODY_MODE
+            - PROSODY_MUC_RESOURCE_VALIDATE_ANON_METHODS
+            - PROSODY_MUC_RESOURCE_VALIDATE_ANONYMOUS_STRICT
             - PROSODY_RATE_LIMIT_LOGIN_RATE
             - PROSODY_RATE_LIMIT_SESSION_RATE
             - PROSODY_RATE_LIMIT_TIMEOUT

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -33,7 +33,7 @@ RUN \
   chown s6:s6 /storage && \
   apt-cleanup
 
-EXPOSE 80 443
+EXPOSE 8000 8443
 
 VOLUME ["/config", "/usr/share/jitsi-meet/transcripts"]
 

--- a/web/rootfs/defaults/default
+++ b/web/rootfs/defaults/default
@@ -1,8 +1,8 @@
 server {
-	listen 80 default_server;
+	listen 8000 default_server;
 	
 	{{ if .Env.ENABLE_IPV6 | default "1" | toBool }}
-	listen [::]:80 default_server;
+	listen [::]:8000 default_server;
 	{{ end }}
 
 	{{ if .Env.ENABLE_HTTP_REDIRECT | default "0" | toBool }}
@@ -14,10 +14,10 @@ server {
 
 {{ if not (.Env.DISABLE_HTTPS | default "0" | toBool) }}
 server {
-	listen 443 ssl http2;
+	listen 8443 ssl http2;
 	
 	{{ if .Env.ENABLE_IPV6 | default "1" | toBool }}
-	listen [::]:443 ssl http2;
+	listen [::]:8443 ssl http2;
 	{{ end }}
 
 	include /run/web/config/nginx/ssl.conf;


### PR DESCRIPTION
PR updates the ports of the web image to run it in Kubernetes under a non-root account.

Closes https://github.com/jitsi/docker-jitsi-meet/issues/2260