### PR TITLE
fix(jvb): Use /run/jvb/tmp as Java temp folder

### DIFF
--- a/jvb/rootfs/etc/s6-overlay/scripts/config
+++ b/jvb/rootfs/etc/s6-overlay/scripts/config
@@ -1,5 +1,6 @@
 #!/command/with-contenv bash
 
+mkdir -p /run/jvb/tmp
 mkdir -p /run/jvb/config
 cp -r /config/. /run/jvb/config
 

--- a/jvb/rootfs/etc/s6-overlay/scripts/jvb
+++ b/jvb/rootfs/etc/s6-overlay/scripts/jvb
@@ -1,6 +1,6 @@
 #!/command/with-contenv bash
 
-export JAVA_SYS_PROPS="-Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/run/jvb -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=config -Djava.util.logging.config.file=/run/jvb/config/logging.properties -Dconfig.file=/run/jvb/config/jvb.conf"
+export JAVA_SYS_PROPS="-Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/run/jvb -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=config -Djava.util.logging.config.file=/run/jvb/config/logging.properties -Dconfig.file=/run/jvb/config/jvb.conf -Djava.io.tmpdir=/run/jvb/tmp -Djna.tmpdir=/run/jvb/tmp"
 
 DAEMON=/usr/share/jitsi-videobridge/jvb.sh
 


### PR DESCRIPTION
PR sets `/run/jvb/tmp` as Java temp folder because JNA needs a folder with `exec` permission.

The default tmp folder (`/tmp`) is set to `noexec` because of the security reasons (`mode=1777` and `exec` are not safe together). So, it cannot be used for this purpose.

Closes https://github.com/jitsi/docker-jitsi-meet/issues/2262