### PR TITLE
fix(jibri): add the missing /home/s6/.cache

### DIFF
--- a/jibri/Dockerfile
+++ b/jibri/Dockerfile
@@ -51,10 +51,11 @@ RUN \
   usermod -a -G audio,jibri,jitsi,rtkit,video s6 && \
   cp -r /home/jibri/. /home/s6 && \
   rm -rf /home/jibri && \
-  rm -rf /home/s6/.config /home/s6/.local && \
+  rm -rf /home/s6/.cache /home/s6/.config /home/s6/.local && \
+  ln -s /run/tmp/s6-cache /home/s6/.cache && \
   ln -s /run/tmp/s6-config /home/s6/.config && \
   ln -s /run/tmp/s6-local /home/s6/.local && \
-  chown -h s6:s6 /home/s6/.config /home/s6/.local && \
+  chown -h s6:s6 /home/s6/.cache /home/s6/.config /home/s6/.local && \
   chown s6:s6 /home/s6 -R && \
 \
   dpkgArch="$(dpkg --print-architecture)" && \

--- a/jibri/rootfs/etc/s6-overlay/scripts/config
+++ b/jibri/rootfs/etc/s6-overlay/scripts/config
@@ -80,8 +80,9 @@ JIBRI_LOGS_DIR=/storage/logs
 mkdir -p ${JIBRI_LOGS_DIR}
 chown -R s6 ${JIBRI_LOGS_DIR}
 
-# make .config and .local dirs
-# these are temporary folders linked to /home/s6/.config and /home/s6/.local
-mkdir -p /run/tmp/s6-local
+# make .cache, .config and .local dirs
+# these are temporary folders linked to /home/s6/.cache, /home/s6/.config and /home/s6/.local
+mkdir -p /run/tmp/s6-cache
 mkdir -p /run/tmp/s6-config
+mkdir -p /run/tmp/s6-local
 cp -r /home/s6/config/. /run/tmp/s6-config


### PR DESCRIPTION
Add the missing cache folder and its symbolic link

Closes https://github.com/jitsi/docker-jitsi-meet/issues/2264