### PR TITLE
fix(jicofo,jvb,jigasi): append to *_LOG_FILE so it can be rotated

### DIFF
--- a/jicofo/rootfs/etc/s6-overlay/scripts/jicofo
+++ b/jicofo/rootfs/etc/s6-overlay/scripts/jicofo
@@ -6,6 +6,6 @@ DAEMON_DIR=/usr/share/jicofo/
 
 JICOFO_CMD="exec $DAEMON"
 
-[ -n "$JICOFO_LOG_FILE" ] && JICOFO_CMD="$JICOFO_CMD 2>&1 | tee $JICOFO_LOG_FILE"
+[ -n "$JICOFO_LOG_FILE" ] && JICOFO_CMD="$JICOFO_CMD 2>&1 | tee -a $JICOFO_LOG_FILE"
 
 exec /bin/bash -c "cd $DAEMON_DIR; JAVA_SYS_PROPS=\"$JAVA_SYS_PROPS\" $JICOFO_CMD"

--- a/jigasi/rootfs/etc/s6-overlay/scripts/jigasi
+++ b/jigasi/rootfs/etc/s6-overlay/scripts/jigasi
@@ -6,6 +6,6 @@ DAEMON=/usr/share/jigasi/jigasi.sh
 DAEMON_OPTS="--nocomponent=true --configdir=/run/jigasi --configdirname=config --min-port=${JIGASI_PORT_MIN:-20000} --max-port=${JIGASI_PORT_MAX:-20050}"
 
 JIGASI_CMD="JAVA_SYS_PROPS=\"$JAVA_SYS_PROPS\" exec $DAEMON $DAEMON_OPTS"
-[ -n "$JIGASI_LOG_FILE" ] && JIGASI_CMD="$JIGASI_CMD 2>&1 | tee $JIGASI_LOG_FILE"
+[ -n "$JIGASI_LOG_FILE" ] && JIGASI_CMD="$JIGASI_CMD 2>&1 | tee -a $JIGASI_LOG_FILE"
 
 exec /bin/bash -c "$JIGASI_CMD"

--- a/jvb/rootfs/etc/s6-overlay/scripts/jvb
+++ b/jvb/rootfs/etc/s6-overlay/scripts/jvb
@@ -5,6 +5,6 @@ export JAVA_SYS_PROPS="-Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/run/jvb
 DAEMON=/usr/share/jitsi-videobridge/jvb.sh
 
 JVB_CMD="exec $DAEMON"
-[ -n "$JVB_LOG_FILE" ] && JVB_CMD="$JVB_CMD 2>&1 | tee $JVB_LOG_FILE"
+[ -n "$JVB_LOG_FILE" ] && JVB_CMD="$JVB_CMD 2>&1 | tee -a $JVB_LOG_FILE"
 
 exec /bin/bash -c "$JVB_CMD"


### PR DESCRIPTION
## Problem

The `jicofo`, `jvb`, and `jigasi` s6 service run scripts tee the process output to `$*_LOG_FILE` **without** `-a`:

```bash
[ -n "$JICOFO_LOG_FILE" ] && JICOFO_CMD="$JICOFO_CMD 2>&1 | tee $JICOFO_LOG_FILE"
```

Because `tee` opens the file with `O_TRUNC` (truncate-at-open) and then writes at a monotonically growing offset, the log file **cannot be rotated or truncated while the service runs**. An in-place truncate — `logrotate` `copytruncate`, or a simple `echo > file` / `truncate -s0` — does not move tee's file offset, so the next write lands past the old end of file and the kernel zero-fills the gap. The result is a **sparse file back at its previous logical size**, and any process tailing the file (e.g. [`jicofo-rtcstats-push`](https://github.com/jitsi/jicofo-rtcstats-push), which follows `JICOFO_LOG_FILE`) has its read offset desynced.

The only way to bound the file today is to restart the service, which is disruptive.

## Fix

Open the log file in append mode (`tee -a`) so every write goes to the current end of file. In-place truncation then actually shrinks the file, and tail followers pick up correctly from offset 0.

Applied consistently to the three services that support an optional log file:
- `jicofo/rootfs/etc/s6-overlay/scripts/jicofo`
- `jvb/rootfs/etc/s6-overlay/scripts/jvb`
- `jigasi/rootfs/etc/s6-overlay/scripts/jigasi`

## Behaviour change

On a fresh container the file does not exist, so `tee` still creates it. The only difference is that a **service restart within a running container** now appends instead of truncating — which is the desired behaviour for a rotatable log, and enables external rotation/truncation without a restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
