### PR TITLE
fix(prosody): replace the failing mv with cp

### DIFF
--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -55,7 +55,7 @@ RUN set -x && \
       lua-unbound && \
     apt-dpkg-wrap apt-get -d install -y jitsi-meet-prosody && \
     dpkg -x /var/cache/apt/archives/jitsi-meet-prosody*.deb /tmp/pkg && \
-    mv /tmp/pkg/usr/share/jitsi-meet/prosody-plugins /prosody-plugins && \
+    cp -a /tmp/pkg/usr/share/jitsi-meet/prosody-plugins/* /prosody-plugins && \
     rm -rf /tmp/pkg /var/cache/apt && \
     apt-cleanup && \
     rm -rf /etc/prosody && \


### PR DESCRIPTION
Move the files with copy. Otherwise it create a new folder inside `prosody-plugins`.

Closes https://github.com/jitsi/docker-jitsi-meet/issues/2267