### PR TITLE
Migrate image publishing from DockerHub to GHCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           context: ./base
           load: true
           tags: |
-            jitsi/base:latest
+            ghcr.io/jitsi/base:latest
           build-args: |
             JITSI_RELEASE=unstable
 
@@ -103,7 +103,7 @@ jobs:
           context: ./base-java
           load: true
           tags: |
-            jitsi/base-java:latest
+            ghcr.io/jitsi/base-java:latest
 
       - name: Build jibri
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
@@ -111,7 +111,7 @@ jobs:
           context: ./jibri
           load: true
           tags: |
-            jitsi/jibri:latest
+            ghcr.io/jitsi/jibri:latest
 
       - name: Build jicofo
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
@@ -119,7 +119,7 @@ jobs:
           context: ./jicofo
           load: true
           tags: |
-            jitsi/jicofo:latest
+            ghcr.io/jitsi/jicofo:latest
 
       - name: Build jigasi
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
@@ -127,7 +127,7 @@ jobs:
           context: ./jigasi
           load: true
           tags: |
-            jitsi/jigasi:latest
+            ghcr.io/jitsi/jigasi:latest
 
       - name: Build jvb
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
@@ -135,7 +135,7 @@ jobs:
           context: ./jvb
           load: true
           tags: |
-            jitsi/jvb:latest
+            ghcr.io/jitsi/jvb:latest
 
       - name: Build prosody
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
@@ -143,7 +143,7 @@ jobs:
           context: ./prosody
           load: true
           tags: |
-            jitsi/prosody:latest
+            ghcr.io/jitsi/prosody:latest
 
       - name: Build web
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
@@ -151,4 +151,4 @@ jobs:
           context: ./web
           load: true
           tags: |
-            jitsi/web:latest
+            ghcr.io/jitsi/web:latest

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -7,6 +7,14 @@ on:
         description: Version number
         required: true
         type: string
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  JITSI_REPO: ghcr.io/jitsi
+
 jobs:
   gh-release:
     runs-on: ubuntu-latest
@@ -44,19 +52,20 @@ jobs:
           platforms: linux/amd64,linux/arm64
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           push: true
           context: ./base
           tags: |
-            ${{ secrets.JITSI_REPO }}/base:stable-${{ github.event.inputs.version }}
-            ${{ secrets.JITSI_REPO }}/base:stable
+            ${{ env.JITSI_REPO }}/base:stable-${{ github.event.inputs.version }}
+            ${{ env.JITSI_REPO }}/base:stable
           build-args: |
             JITSI_RELEASE=stable
           platforms: linux/amd64,linux/arm64
@@ -75,21 +84,22 @@ jobs:
           platforms: linux/amd64,linux/arm64
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           push: true
           context: ./base-java
           tags: |
-            ${{ secrets.JITSI_REPO }}/base-java:stable-${{ github.event.inputs.version }}
-            ${{ secrets.JITSI_REPO }}/base-java:stable
+            ${{ env.JITSI_REPO }}/base-java:stable-${{ github.event.inputs.version }}
+            ${{ env.JITSI_REPO }}/base-java:stable
           build-args: |
-            JITSI_REPO=${{ secrets.JITSI_REPO }}
+            JITSI_REPO=${{ env.JITSI_REPO }}
             BASE_TAG=stable-${{ github.event.inputs.version }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
@@ -107,21 +117,22 @@ jobs:
           platforms: linux/amd64,linux/arm64
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           push: true
           context: ./jibri
           tags: |
-            ${{ secrets.JITSI_REPO }}/jibri:stable-${{ github.event.inputs.version }}
-            ${{ secrets.JITSI_REPO }}/jibri:stable
+            ${{ env.JITSI_REPO }}/jibri:stable-${{ github.event.inputs.version }}
+            ${{ env.JITSI_REPO }}/jibri:stable
           build-args: |
-            JITSI_REPO=${{ secrets.JITSI_REPO }}
+            JITSI_REPO=${{ env.JITSI_REPO }}
             BASE_TAG=stable-${{ github.event.inputs.version }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
@@ -139,21 +150,22 @@ jobs:
           platforms: linux/amd64,linux/arm64
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           push: true
           context: ./jicofo
           tags: |
-            ${{ secrets.JITSI_REPO }}/jicofo:stable-${{ github.event.inputs.version }}
-            ${{ secrets.JITSI_REPO }}/jicofo:stable
+            ${{ env.JITSI_REPO }}/jicofo:stable-${{ github.event.inputs.version }}
+            ${{ env.JITSI_REPO }}/jicofo:stable
           build-args: |
-            JITSI_REPO=${{ secrets.JITSI_REPO }}
+            JITSI_REPO=${{ env.JITSI_REPO }}
             BASE_TAG=stable-${{ github.event.inputs.version }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
@@ -171,21 +183,22 @@ jobs:
           platforms: linux/amd64,linux/arm64
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           push: true
           context: ./jigasi
           tags: |
-            ${{ secrets.JITSI_REPO }}/jigasi:stable-${{ github.event.inputs.version }}
-            ${{ secrets.JITSI_REPO }}/jigasi:stable
+            ${{ env.JITSI_REPO }}/jigasi:stable-${{ github.event.inputs.version }}
+            ${{ env.JITSI_REPO }}/jigasi:stable
           build-args: |
-            JITSI_REPO=${{ secrets.JITSI_REPO }}
+            JITSI_REPO=${{ env.JITSI_REPO }}
             BASE_TAG=stable-${{ github.event.inputs.version }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
@@ -203,21 +216,22 @@ jobs:
           platforms: linux/amd64,linux/arm64
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           push: true
           context: ./jvb
           tags: |
-            ${{ secrets.JITSI_REPO }}/jvb:stable-${{ github.event.inputs.version }}
-            ${{ secrets.JITSI_REPO }}/jvb:stable
+            ${{ env.JITSI_REPO }}/jvb:stable-${{ github.event.inputs.version }}
+            ${{ env.JITSI_REPO }}/jvb:stable
           build-args: |
-            JITSI_REPO=${{ secrets.JITSI_REPO }}
+            JITSI_REPO=${{ env.JITSI_REPO }}
             BASE_TAG=stable-${{ github.event.inputs.version }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
@@ -235,21 +249,22 @@ jobs:
           platforms: linux/amd64,linux/arm64
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           push: true
           context: ./prosody
           tags: |
-            ${{ secrets.JITSI_REPO }}/prosody:stable-${{ github.event.inputs.version }}
-            ${{ secrets.JITSI_REPO }}/prosody:stable
+            ${{ env.JITSI_REPO }}/prosody:stable-${{ github.event.inputs.version }}
+            ${{ env.JITSI_REPO }}/prosody:stable
           build-args: |
-            JITSI_REPO=${{ secrets.JITSI_REPO }}
+            JITSI_REPO=${{ env.JITSI_REPO }}
             BASE_TAG=stable-${{ github.event.inputs.version }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
@@ -267,21 +282,22 @@ jobs:
           platforms: linux/amd64,linux/arm64
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           push: true
           context: ./web
           tags: |
-            ${{ secrets.JITSI_REPO }}/web:stable-${{ github.event.inputs.version }}
-            ${{ secrets.JITSI_REPO }}/web:stable
+            ${{ env.JITSI_REPO }}/web:stable-${{ github.event.inputs.version }}
+            ${{ env.JITSI_REPO }}/web:stable
           build-args: |
-            JITSI_REPO=${{ secrets.JITSI_REPO }}
+            JITSI_REPO=${{ env.JITSI_REPO }}
             BASE_TAG=stable-${{ github.event.inputs.version }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -5,6 +5,14 @@ on:
     - cron: "0 5 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  JITSI_REPO: ghcr.io/jitsi
+
 jobs:
   version:
     runs-on: ubuntu-latest
@@ -70,19 +78,20 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
         with:
           driver: docker
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           push: true
           context: ./base
           tags: |
-            ${{ secrets.JITSI_REPO }}/base:${{ needs.version.outputs.base }}-${{ matrix.config.arch }}
-            ${{ secrets.JITSI_REPO }}/base:${{ needs.version.outputs.date }}-${{ matrix.config.arch }}
+            ${{ env.JITSI_REPO }}/base:${{ needs.version.outputs.base }}-${{ matrix.config.arch }}
+            ${{ env.JITSI_REPO }}/base:${{ needs.version.outputs.date }}-${{ matrix.config.arch }}
           build-args: |
             JITSI_RELEASE=unstable
 
@@ -90,20 +99,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: [version, base-arch]
     steps:
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Docker Manifest
         uses: int128/docker-manifest-create-action@44422a4b046d55dc036df622039ed3aec43c613c  # v2
         with:
           tags: |
-            ${{ secrets.JITSI_REPO }}/base:${{ needs.version.outputs.base }}
-            ${{ secrets.JITSI_REPO }}/base:${{ needs.version.outputs.date }}
+            ${{ env.JITSI_REPO }}/base:${{ needs.version.outputs.base }}
+            ${{ env.JITSI_REPO }}/base:${{ needs.version.outputs.date }}
           sources: |
-            ${{ secrets.JITSI_REPO }}/base:${{ needs.version.outputs.base }}-amd64
-            ${{ secrets.JITSI_REPO }}/base:${{ needs.version.outputs.base }}-arm64
+            ${{ env.JITSI_REPO }}/base:${{ needs.version.outputs.base }}-amd64
+            ${{ env.JITSI_REPO }}/base:${{ needs.version.outputs.base }}-arm64
 
   base-java-arch:
     runs-on: ${{ matrix.config.os }}
@@ -121,41 +131,43 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
         with:
           driver: docker
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           push: true
           context: ./base-java
           tags: |
-            ${{ secrets.JITSI_REPO }}/base-java:${{ needs.version.outputs.base }}-${{ matrix.config.arch }}
-            ${{ secrets.JITSI_REPO }}/base-java:${{ needs.version.outputs.date }}-${{ matrix.config.arch }}
+            ${{ env.JITSI_REPO }}/base-java:${{ needs.version.outputs.base }}-${{ matrix.config.arch }}
+            ${{ env.JITSI_REPO }}/base-java:${{ needs.version.outputs.date }}-${{ matrix.config.arch }}
           build-args: |
-            JITSI_REPO=${{ secrets.JITSI_REPO }}
+            JITSI_REPO=${{ env.JITSI_REPO }}
             BASE_TAG=${{ needs.version.outputs.base }}
 
   base-java:
     runs-on: ubuntu-latest
     needs: [version, base-java-arch]
     steps:
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Docker Manifest
         uses: int128/docker-manifest-create-action@44422a4b046d55dc036df622039ed3aec43c613c  # v2
         with:
           tags: |
-            ${{ secrets.JITSI_REPO }}/base-java:${{ needs.version.outputs.base }}
-            ${{ secrets.JITSI_REPO }}/base-java:${{ needs.version.outputs.date }}
+            ${{ env.JITSI_REPO }}/base-java:${{ needs.version.outputs.base }}
+            ${{ env.JITSI_REPO }}/base-java:${{ needs.version.outputs.date }}
           sources: |
-            ${{ secrets.JITSI_REPO }}/base-java:${{ needs.version.outputs.base }}-amd64
-            ${{ secrets.JITSI_REPO }}/base-java:${{ needs.version.outputs.base }}-arm64
+            ${{ env.JITSI_REPO }}/base-java:${{ needs.version.outputs.base }}-amd64
+            ${{ env.JITSI_REPO }}/base-java:${{ needs.version.outputs.base }}-arm64
 
   jibri-arch:
     runs-on: ${{ matrix.config.os }}
@@ -173,43 +185,45 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
         with:
           driver: docker
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           push: true
           context: ./jibri
           tags: |
-            ${{ secrets.JITSI_REPO }}/jibri:${{ needs.version.outputs.base }}-${{ matrix.config.arch }}
-            ${{ secrets.JITSI_REPO }}/jibri:${{ needs.version.outputs.date }}-${{ matrix.config.arch }}
-            ${{ secrets.JITSI_REPO }}/jibri:${{ needs.version.outputs.jibri_version }}-${{ matrix.config.arch }}
+            ${{ env.JITSI_REPO }}/jibri:${{ needs.version.outputs.base }}-${{ matrix.config.arch }}
+            ${{ env.JITSI_REPO }}/jibri:${{ needs.version.outputs.date }}-${{ matrix.config.arch }}
+            ${{ env.JITSI_REPO }}/jibri:${{ needs.version.outputs.jibri_version }}-${{ matrix.config.arch }}
           build-args: |
-            JITSI_REPO=${{ secrets.JITSI_REPO }}
+            JITSI_REPO=${{ env.JITSI_REPO }}
             BASE_TAG=${{ needs.version.outputs.base }}
 
   jibri:
     runs-on: ubuntu-latest
     needs: [version, jibri-arch]
     steps:
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Docker Manifest
         uses: int128/docker-manifest-create-action@44422a4b046d55dc036df622039ed3aec43c613c  # v2
         with:
           tags: |
-            ${{ secrets.JITSI_REPO }}/jibri:${{ needs.version.outputs.base }}
-            ${{ secrets.JITSI_REPO }}/jibri:${{ needs.version.outputs.date }}
-            ${{ secrets.JITSI_REPO }}/jibri:${{ needs.version.outputs.jibri_version }}
+            ${{ env.JITSI_REPO }}/jibri:${{ needs.version.outputs.base }}
+            ${{ env.JITSI_REPO }}/jibri:${{ needs.version.outputs.date }}
+            ${{ env.JITSI_REPO }}/jibri:${{ needs.version.outputs.jibri_version }}
           sources: |
-            ${{ secrets.JITSI_REPO }}/jibri:${{ needs.version.outputs.base }}-amd64
-            ${{ secrets.JITSI_REPO }}/jibri:${{ needs.version.outputs.base }}-arm64
+            ${{ env.JITSI_REPO }}/jibri:${{ needs.version.outputs.base }}-amd64
+            ${{ env.JITSI_REPO }}/jibri:${{ needs.version.outputs.base }}-arm64
 
   jicofo-arch:
     runs-on: ${{ matrix.config.os }}
@@ -227,43 +241,45 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
         with:
           driver: docker
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           push: true
           context: ./jicofo
           tags: |
-            ${{ secrets.JITSI_REPO }}/jicofo:${{ needs.version.outputs.base }}-${{ matrix.config.arch }}
-            ${{ secrets.JITSI_REPO }}/jicofo:${{ needs.version.outputs.date }}-${{ matrix.config.arch }}
-            ${{ secrets.JITSI_REPO }}/jicofo:${{ needs.version.outputs.jicofo_version }}-${{ matrix.config.arch }}
+            ${{ env.JITSI_REPO }}/jicofo:${{ needs.version.outputs.base }}-${{ matrix.config.arch }}
+            ${{ env.JITSI_REPO }}/jicofo:${{ needs.version.outputs.date }}-${{ matrix.config.arch }}
+            ${{ env.JITSI_REPO }}/jicofo:${{ needs.version.outputs.jicofo_version }}-${{ matrix.config.arch }}
           build-args: |
-            JITSI_REPO=${{ secrets.JITSI_REPO }}
+            JITSI_REPO=${{ env.JITSI_REPO }}
             BASE_TAG=${{ needs.version.outputs.base }}
 
   jicofo:
     runs-on: ubuntu-latest
     needs: [version, jicofo-arch]
     steps:
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Docker Manifest
         uses: int128/docker-manifest-create-action@44422a4b046d55dc036df622039ed3aec43c613c  # v2
         with:
           tags: |
-            ${{ secrets.JITSI_REPO }}/jicofo:${{ needs.version.outputs.base }}
-            ${{ secrets.JITSI_REPO }}/jicofo:${{ needs.version.outputs.date }}
-            ${{ secrets.JITSI_REPO }}/jicofo:${{ needs.version.outputs.jicofo_version }}
+            ${{ env.JITSI_REPO }}/jicofo:${{ needs.version.outputs.base }}
+            ${{ env.JITSI_REPO }}/jicofo:${{ needs.version.outputs.date }}
+            ${{ env.JITSI_REPO }}/jicofo:${{ needs.version.outputs.jicofo_version }}
           sources: |
-            ${{ secrets.JITSI_REPO }}/jicofo:${{ needs.version.outputs.base }}-amd64
-            ${{ secrets.JITSI_REPO }}/jicofo:${{ needs.version.outputs.base }}-arm64
+            ${{ env.JITSI_REPO }}/jicofo:${{ needs.version.outputs.base }}-amd64
+            ${{ env.JITSI_REPO }}/jicofo:${{ needs.version.outputs.base }}-arm64
 
   jigasi-arch:
     runs-on: ${{ matrix.config.os }}
@@ -281,43 +297,45 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
         with:
           driver: docker
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           push: true
           context: ./jigasi
           tags: |
-            ${{ secrets.JITSI_REPO }}/jigasi:${{ needs.version.outputs.base }}-${{ matrix.config.arch }}
-            ${{ secrets.JITSI_REPO }}/jigasi:${{ needs.version.outputs.date }}-${{ matrix.config.arch }}
-            ${{ secrets.JITSI_REPO }}/jigasi:${{ needs.version.outputs.jigasi_version }}-${{ matrix.config.arch }}
+            ${{ env.JITSI_REPO }}/jigasi:${{ needs.version.outputs.base }}-${{ matrix.config.arch }}
+            ${{ env.JITSI_REPO }}/jigasi:${{ needs.version.outputs.date }}-${{ matrix.config.arch }}
+            ${{ env.JITSI_REPO }}/jigasi:${{ needs.version.outputs.jigasi_version }}-${{ matrix.config.arch }}
           build-args: |
-            JITSI_REPO=${{ secrets.JITSI_REPO }}
+            JITSI_REPO=${{ env.JITSI_REPO }}
             BASE_TAG=${{ needs.version.outputs.base }}
 
   jigasi:
     runs-on: ubuntu-latest
     needs: [version, jigasi-arch]
     steps:
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Docker Manifest
         uses: int128/docker-manifest-create-action@44422a4b046d55dc036df622039ed3aec43c613c  # v2
         with:
           tags: |
-            ${{ secrets.JITSI_REPO }}/jigasi:${{ needs.version.outputs.base }}
-            ${{ secrets.JITSI_REPO }}/jigasi:${{ needs.version.outputs.date }}
-            ${{ secrets.JITSI_REPO }}/jigasi:${{ needs.version.outputs.jigasi_version }}
+            ${{ env.JITSI_REPO }}/jigasi:${{ needs.version.outputs.base }}
+            ${{ env.JITSI_REPO }}/jigasi:${{ needs.version.outputs.date }}
+            ${{ env.JITSI_REPO }}/jigasi:${{ needs.version.outputs.jigasi_version }}
           sources: |
-            ${{ secrets.JITSI_REPO }}/jigasi:${{ needs.version.outputs.base }}-amd64
-            ${{ secrets.JITSI_REPO }}/jigasi:${{ needs.version.outputs.base }}-arm64
+            ${{ env.JITSI_REPO }}/jigasi:${{ needs.version.outputs.base }}-amd64
+            ${{ env.JITSI_REPO }}/jigasi:${{ needs.version.outputs.base }}-arm64
 
   jvb-arch:
     runs-on: ${{ matrix.config.os }}
@@ -335,43 +353,45 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
         with:
           driver: docker
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           push: true
           context: ./jvb
           tags: |
-            ${{ secrets.JITSI_REPO }}/jvb:${{ needs.version.outputs.base }}-${{ matrix.config.arch }}
-            ${{ secrets.JITSI_REPO }}/jvb:${{ needs.version.outputs.date }}-${{ matrix.config.arch }}
-            ${{ secrets.JITSI_REPO }}/jvb:${{ needs.version.outputs.jvb_version }}-${{ matrix.config.arch }}
+            ${{ env.JITSI_REPO }}/jvb:${{ needs.version.outputs.base }}-${{ matrix.config.arch }}
+            ${{ env.JITSI_REPO }}/jvb:${{ needs.version.outputs.date }}-${{ matrix.config.arch }}
+            ${{ env.JITSI_REPO }}/jvb:${{ needs.version.outputs.jvb_version }}-${{ matrix.config.arch }}
           build-args: |
-            JITSI_REPO=${{ secrets.JITSI_REPO }}
+            JITSI_REPO=${{ env.JITSI_REPO }}
             BASE_TAG=${{ needs.version.outputs.base }}
 
   jvb:
     runs-on: ubuntu-latest
     needs: [version, jvb-arch]
     steps:
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Docker Manifest
         uses: int128/docker-manifest-create-action@44422a4b046d55dc036df622039ed3aec43c613c  # v2
         with:
           tags: |
-            ${{ secrets.JITSI_REPO }}/jvb:${{ needs.version.outputs.base }}
-            ${{ secrets.JITSI_REPO }}/jvb:${{ needs.version.outputs.date }}
-            ${{ secrets.JITSI_REPO }}/jvb:${{ needs.version.outputs.jvb_version }}
+            ${{ env.JITSI_REPO }}/jvb:${{ needs.version.outputs.base }}
+            ${{ env.JITSI_REPO }}/jvb:${{ needs.version.outputs.date }}
+            ${{ env.JITSI_REPO }}/jvb:${{ needs.version.outputs.jvb_version }}
           sources: |
-            ${{ secrets.JITSI_REPO }}/jvb:${{ needs.version.outputs.base }}-amd64
-            ${{ secrets.JITSI_REPO }}/jvb:${{ needs.version.outputs.base }}-arm64
+            ${{ env.JITSI_REPO }}/jvb:${{ needs.version.outputs.base }}-amd64
+            ${{ env.JITSI_REPO }}/jvb:${{ needs.version.outputs.base }}-arm64
 
   prosody-arch:
     runs-on: ${{ matrix.config.os }}
@@ -389,43 +409,45 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
         with:
           driver: docker
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           push: true
           context: ./prosody
           tags: |
-            ${{ secrets.JITSI_REPO }}/prosody:${{ needs.version.outputs.base }}-${{ matrix.config.arch }}
-            ${{ secrets.JITSI_REPO }}/prosody:${{ needs.version.outputs.date }}-${{ matrix.config.arch }}
-            ${{ secrets.JITSI_REPO }}/prosody:${{ needs.version.outputs.prosody_version }}-${{ matrix.config.arch }}
+            ${{ env.JITSI_REPO }}/prosody:${{ needs.version.outputs.base }}-${{ matrix.config.arch }}
+            ${{ env.JITSI_REPO }}/prosody:${{ needs.version.outputs.date }}-${{ matrix.config.arch }}
+            ${{ env.JITSI_REPO }}/prosody:${{ needs.version.outputs.prosody_version }}-${{ matrix.config.arch }}
           build-args: |
-            JITSI_REPO=${{ secrets.JITSI_REPO }}
+            JITSI_REPO=${{ env.JITSI_REPO }}
             BASE_TAG=${{ needs.version.outputs.base }}
 
   prosody:
     runs-on: ubuntu-latest
     needs: [version, prosody-arch]
     steps:
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Docker Manifest
         uses: int128/docker-manifest-create-action@44422a4b046d55dc036df622039ed3aec43c613c  # v2
         with:
           tags: |
-            ${{ secrets.JITSI_REPO }}/prosody:${{ needs.version.outputs.base }}
-            ${{ secrets.JITSI_REPO }}/prosody:${{ needs.version.outputs.date }}
-            ${{ secrets.JITSI_REPO }}/prosody:${{ needs.version.outputs.prosody_version }}
+            ${{ env.JITSI_REPO }}/prosody:${{ needs.version.outputs.base }}
+            ${{ env.JITSI_REPO }}/prosody:${{ needs.version.outputs.date }}
+            ${{ env.JITSI_REPO }}/prosody:${{ needs.version.outputs.prosody_version }}
           sources: |
-            ${{ secrets.JITSI_REPO }}/prosody:${{ needs.version.outputs.base }}-amd64
-            ${{ secrets.JITSI_REPO }}/prosody:${{ needs.version.outputs.base }}-arm64
+            ${{ env.JITSI_REPO }}/prosody:${{ needs.version.outputs.base }}-amd64
+            ${{ env.JITSI_REPO }}/prosody:${{ needs.version.outputs.base }}-arm64
 
   web-arch:
     runs-on: ${{ matrix.config.os }}
@@ -443,40 +465,42 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
         with:
           driver: docker
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           push: true
           context: ./web
           tags: |
-            ${{ secrets.JITSI_REPO }}/web:${{ needs.version.outputs.base }}-${{ matrix.config.arch }}
-            ${{ secrets.JITSI_REPO }}/web:${{ needs.version.outputs.date }}-${{ matrix.config.arch }}
-            ${{ secrets.JITSI_REPO }}/web:${{ needs.version.outputs.web_version }}-${{ matrix.config.arch }}
+            ${{ env.JITSI_REPO }}/web:${{ needs.version.outputs.base }}-${{ matrix.config.arch }}
+            ${{ env.JITSI_REPO }}/web:${{ needs.version.outputs.date }}-${{ matrix.config.arch }}
+            ${{ env.JITSI_REPO }}/web:${{ needs.version.outputs.web_version }}-${{ matrix.config.arch }}
           build-args: |
-            JITSI_REPO=${{ secrets.JITSI_REPO }}
+            JITSI_REPO=${{ env.JITSI_REPO }}
             BASE_TAG=${{ needs.version.outputs.base }}
 
   web:
     runs-on: ubuntu-latest
     needs: [version, web-arch]
     steps:
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Docker Manifest
         uses: int128/docker-manifest-create-action@44422a4b046d55dc036df622039ed3aec43c613c  # v2
         with:
           tags: |
-            ${{ secrets.JITSI_REPO }}/web:${{ needs.version.outputs.base }}
-            ${{ secrets.JITSI_REPO }}/web:${{ needs.version.outputs.date }}
-            ${{ secrets.JITSI_REPO }}/web:${{ needs.version.outputs.web_version }}
+            ${{ env.JITSI_REPO }}/web:${{ needs.version.outputs.base }}
+            ${{ env.JITSI_REPO }}/web:${{ needs.version.outputs.date }}
+            ${{ env.JITSI_REPO }}/web:${{ needs.version.outputs.web_version }}
           sources: |
-            ${{ secrets.JITSI_REPO }}/web:${{ needs.version.outputs.base }}-amd64
-            ${{ secrets.JITSI_REPO }}/web:${{ needs.version.outputs.base }}-arm64
+            ${{ env.JITSI_REPO }}/web:${{ needs.version.outputs.base }}-amd64
+            ${{ env.JITSI_REPO }}/web:${{ needs.version.outputs.base }}-arm64

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 FORCE_REBUILD ?= 0
 JITSI_RELEASE ?= stable
 JITSI_BUILD ?= unstable
-JITSI_REPO ?= jitsi
+JITSI_REPO ?= ghcr.io/jitsi
 
 JITSI_SERVICES := base base-java web prosody jicofo jvb jigasi jibri
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This repository contains the necessary tools to run a Jitsi Meet stack on [Docker](https://www.docker.com) using [Docker Compose](https://docs.docker.com/compose/).
 
-All our images are published on [DockerHub](https://hub.docker.com/u/jitsi/).
+All our images are published on the [GitHub Container Registry (GHCR)](https://github.com/orgs/jitsi/packages).
 
 ## Supported architectures
 

--- a/base-java/Dockerfile
+++ b/base-java/Dockerfile
@@ -1,4 +1,4 @@
-ARG JITSI_REPO=jitsi
+ARG JITSI_REPO=ghcr.io/jitsi
 ARG BASE_TAG=latest
 FROM ${JITSI_REPO}/base:${BASE_TAG}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
     # Frontend
     web:
-        image: jitsi/web:${JITSI_IMAGE_VERSION:-unstable}
+        image: ${JITSI_IMAGE_REPO:-ghcr.io/jitsi}/web:${JITSI_IMAGE_VERSION:-unstable}
         restart: ${RESTART_POLICY:-unless-stopped}
         read_only: true
         tmpfs:
@@ -204,7 +204,7 @@ services:
 
     # XMPP server
     prosody:
-        image: jitsi/prosody:${JITSI_IMAGE_VERSION:-unstable}
+        image: ${JITSI_IMAGE_REPO:-ghcr.io/jitsi}/prosody:${JITSI_IMAGE_VERSION:-unstable}
         restart: ${RESTART_POLICY:-unless-stopped}
         read_only: true
         tmpfs:
@@ -363,7 +363,7 @@ services:
 
     # Focus component
     jicofo:
-        image: jitsi/jicofo:${JITSI_IMAGE_VERSION:-unstable}
+        image: ${JITSI_IMAGE_REPO:-ghcr.io/jitsi}/jicofo:${JITSI_IMAGE_VERSION:-unstable}
         restart: ${RESTART_POLICY:-unless-stopped}
         read_only: true
         tmpfs:
@@ -463,7 +463,7 @@ services:
 
     # Video bridge
     jvb:
-        image: jitsi/jvb:${JITSI_IMAGE_VERSION:-unstable}
+        image: ${JITSI_IMAGE_REPO:-ghcr.io/jitsi}/jvb:${JITSI_IMAGE_VERSION:-unstable}
         restart: ${RESTART_POLICY:-unless-stopped}
         read_only: true
         tmpfs:

--- a/env.example
+++ b/env.example
@@ -238,5 +238,8 @@ JIBRI_XMPP_PASSWORD=
 # Container restart policy
 #RESTART_POLICY=unless-stopped
 
+# Jitsi image registry/namespace (defaults to ghcr.io/jitsi)
+#JITSI_IMAGE_REPO=ghcr.io/jitsi
+
 # Jitsi image version (useful for local development)
 #JITSI_IMAGE_VERSION=latest

--- a/jibri.yml
+++ b/jibri.yml
@@ -1,6 +1,6 @@
 services:
     jibri:
-        image: jitsi/jibri:${JITSI_IMAGE_VERSION:-unstable}
+        image: ${JITSI_IMAGE_REPO:-ghcr.io/jitsi}/jibri:${JITSI_IMAGE_VERSION:-unstable}
         restart: ${RESTART_POLICY:-unless-stopped}
         read_only: true
         tmpfs:

--- a/jibri/Dockerfile
+++ b/jibri/Dockerfile
@@ -1,4 +1,4 @@
-ARG JITSI_REPO=jitsi
+ARG JITSI_REPO=ghcr.io/jitsi
 ARG BASE_TAG=latest
 FROM ${JITSI_REPO}/base-java:${BASE_TAG}
 

--- a/jicofo/Dockerfile
+++ b/jicofo/Dockerfile
@@ -1,4 +1,4 @@
-ARG JITSI_REPO=jitsi
+ARG JITSI_REPO=ghcr.io/jitsi
 ARG BASE_TAG=latest
 FROM ${JITSI_REPO}/base-java:${BASE_TAG}
 

--- a/jigasi.yml
+++ b/jigasi.yml
@@ -1,7 +1,7 @@
 services:
     # SIP gateway (audio)
     jigasi:
-        image: jitsi/jigasi:${JITSI_IMAGE_VERSION:-unstable}
+        image: ${JITSI_IMAGE_REPO:-ghcr.io/jitsi}/jigasi:${JITSI_IMAGE_VERSION:-unstable}
         restart: ${RESTART_POLICY:-unless-stopped}
         read_only: true
         tmpfs:

--- a/jigasi/Dockerfile
+++ b/jigasi/Dockerfile
@@ -1,4 +1,4 @@
-ARG JITSI_REPO=jitsi
+ARG JITSI_REPO=ghcr.io/jitsi
 ARG BASE_TAG=latest
 FROM ${JITSI_REPO}/base-java:${BASE_TAG}
 

--- a/jvb/Dockerfile
+++ b/jvb/Dockerfile
@@ -1,4 +1,4 @@
-ARG JITSI_REPO=jitsi
+ARG JITSI_REPO=ghcr.io/jitsi
 ARG BASE_TAG=latest
 FROM ${JITSI_REPO}/base-java:${BASE_TAG}
 

--- a/prosody/Dockerfile
+++ b/prosody/Dockerfile
@@ -1,4 +1,4 @@
-ARG JITSI_REPO=jitsi
+ARG JITSI_REPO=ghcr.io/jitsi
 ARG BASE_TAG=latest
 
 FROM ${JITSI_REPO}/base:${BASE_TAG} AS builder

--- a/transcriber.yml
+++ b/transcriber.yml
@@ -1,6 +1,6 @@
 services:
     transcriber:
-        image: jitsi/jigasi:${JITSI_IMAGE_VERSION:-unstable}
+        image: ${JITSI_IMAGE_REPO:-ghcr.io/jitsi}/jigasi:${JITSI_IMAGE_VERSION:-unstable}
         restart: ${RESTART_POLICY:-unless-stopped}
         read_only: true
         tmpfs:

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-ARG JITSI_REPO=jitsi
+ARG JITSI_REPO=ghcr.io/jitsi
 ARG BASE_TAG=latest
 FROM ${JITSI_REPO}/base:${BASE_TAG}
 


### PR DESCRIPTION
Migrates all image building, publishing, and pulling from DockerHub (`docker.io/jitsi`) to the GitHub Container Registry (`ghcr.io/jitsi`). No dual-publish — images go straight to GHCR.

## What changed

**Publish pipelines** (`release-stable.yml`, `unstable.yml`)
- Replaced every `Login to DockerHub` step with a GHCR login using the built-in `GITHUB_TOKEN`.
- Added workflow-level `permissions: packages: write`.
- Introduced workflow-level `env` (`REGISTRY=ghcr.io`, `JITSI_REPO=ghcr.io/jitsi`), replacing the `secrets.JITSI_REPO` references in tags and build-args.
- Dropped all use of `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` / `JITSI_REPO` secrets.

**Source-side references**
- Dockerfiles: `ARG JITSI_REPO` default `jitsi` → `ghcr.io/jitsi` (GHCR does not infer a registry prefix, so refs must be fully qualified).
- `Makefile`: `JITSI_REPO ?= ghcr.io/jitsi`.
- `docker-compose.yml` + service `.yml`: introduced `${JITSI_IMAGE_REPO:-ghcr.io/jitsi}/...`; documented `JITSI_IMAGE_REPO` in `env.example`.
- `ci.yml`: retagged local test-build images to `ghcr.io/jitsi/*` so derived images resolve against the new Dockerfile `FROM` default.
- `README.md`: points to GHCR.

## Validation

- **Auth + push + cross-job pull-during-build validated** on a throwaway branch: `GITHUB_TOKEN` can publish under `ghcr.io/jitsi` (no PAT needed), packages were flipped public, and an unauthenticated `docker pull` succeeded.
- All three workflow YAMLs parse; `docker compose config` resolves core services to `ghcr.io/jitsi/...`.

## Out of scope / follow-ups

- **External images** (`excalidraw-backend`, `rtcstats-server`, `rtcstats-visualizer`) come from other repos and remain on DockerHub until they're published to GHCR.
- The **handbook** (`jitsi.github.io/handbook`, separate repo) documents pull commands and needs a companion update.
- CI flags a **Node 20 deprecation** on the pinned action SHAs — worth a separate bump, unrelated to GHCR.
- New GHCR packages default to **private** — each must be set **public** in org package settings after its first publish.