### PR TITLE
Grafana on sub uri

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,6 +197,7 @@ services:
             - XMPP_RECORDER_DOMAIN
             - WHITEBOARD_COLLAB_SERVER_PUBLIC_URL
             - WHITEBOARD_COLLAB_SERVER_URL_BASE
+            - GF_SERVER_ROOT_URL
         networks:
             meet.jitsi:
         depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,7 +197,7 @@ services:
             - XMPP_RECORDER_DOMAIN
             - WHITEBOARD_COLLAB_SERVER_PUBLIC_URL
             - WHITEBOARD_COLLAB_SERVER_URL_BASE
-            - GF_SERVER_ROOT_URL
+            - GRAFANA
         networks:
             meet.jitsi:
         depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,7 +197,7 @@ services:
             - XMPP_RECORDER_DOMAIN
             - WHITEBOARD_COLLAB_SERVER_PUBLIC_URL
             - WHITEBOARD_COLLAB_SERVER_URL_BASE
-            - GRAFANA
+            - ENABLE_GRAFANA
         networks:
             meet.jitsi:
         depends_on:

--- a/env.example
+++ b/env.example
@@ -243,3 +243,19 @@ JIBRI_XMPP_PASSWORD=
 
 # Jitsi image version (useful for local development)
 #JITSI_IMAGE_VERSION=latest
+
+# Grafana
+
+# Set servers external URL
+#GF_SERVER_ROOT_URL= '${PUBLIC_URL}/monitoring'
+
+# Set defaoult admin user
+#GF_SECURITY_ADMIN_USER='admin'
+
+# Set provisioning grafana password (can be changed later)
+#GF_SECURITY_ADMIN_PASSWORD='new-admin-password'
+
+# Set security settings
+#GF_SECURITY_CONTENT_SECURITY_POLICY='true'
+#GF_SECURITY_COOKIE_SECURE='true'
+#GF_SECURITY_COOKIE_SAMESITE='true'

--- a/env.example
+++ b/env.example
@@ -249,6 +249,7 @@ JIBRI_XMPP_PASSWORD=
 # Enable Grafana configs
 #GRAFANA=1
 
+# Set Grafana sub uri
 #GRAFANA_SUB_URI="_monitoring"
 
 # Set defaoult admin user

--- a/env.example
+++ b/env.example
@@ -246,8 +246,10 @@ JIBRI_XMPP_PASSWORD=
 
 # Grafana
 
-# Set servers external URL
-#GF_SERVER_ROOT_URL= '${PUBLIC_URL}/monitoring'
+# Enable Grafana configs
+#GRAFANA=1
+
+#GRAFANA_SUB_URI="_monitoring"
 
 # Set defaoult admin user
 #GF_SECURITY_ADMIN_USER='admin'

--- a/env.example
+++ b/env.example
@@ -246,17 +246,17 @@ JIBRI_XMPP_PASSWORD=
 
 # Grafana
 
-# Enable Grafana configs
+# Enable Grafana configs if required
 #ENABLE_GRAFANA=1
 
-# Set Grafana sub uri
+# Set Grafana sub uri (required if ENABLE_GRAFANA is enabled)
 #GRAFANA_SUB_URI="_monitoring"
 
 # Set defaoult admin user
 #GF_SECURITY_ADMIN_USER='admin'
 
 # Set provisioning grafana password (can be changed later)
-#GF_SECURITY_ADMIN_PASSWORD='new-admin-password'
+#GF_SECURITY_ADMIN_PASSWORD=
 
 # Set security settings
 #GF_SECURITY_CONTENT_SECURITY_POLICY='true'

--- a/env.example
+++ b/env.example
@@ -247,7 +247,7 @@ JIBRI_XMPP_PASSWORD=
 # Grafana
 
 # Enable Grafana configs
-#GRAFANA=1
+#ENABLE_GRAFANA=1
 
 # Set Grafana sub uri
 #GRAFANA_SUB_URI="_monitoring"

--- a/grafana.yml
+++ b/grafana.yml
@@ -4,12 +4,12 @@ services:
     image: grafana/grafana:10.4.0
     environment:
       - GF_ANALYTICS_REPORTING_ENABLED=false
-      - GF_SERVER_ROOT_URL='${PUBLIC_URL}/monitoring'
-      - GF_SECURITY_ADMIN_USER: gadmin
-      - GF_SECURITY_ADMIN_PASSWORD: new-admin-password
-      - GF_SECURITY_CONTENT_SECURITY_POLICY: 'true'
-      - GF_SECURITY_COOKIE_SECURE: 'true'
-      - GF_SECURITY_COOKIE_SAMESITE: 'true'
+      - GF_SERVER_ROOT_URL
+      - GF_SECURITY_ADMIN_USER
+      - GF_SECURITY_ADMIN_PASSWORD
+      - GF_SECURITY_CONTENT_SECURITY_POLICY
+      - GF_SECURITY_COOKIE_SECURE
+      - GF_SECURITY_COOKIE_SAMESITE
       
     volumes:
       - ./log-analyser/grafana:/var/lib/grafana

--- a/grafana.yml
+++ b/grafana.yml
@@ -1,7 +1,7 @@
 services:
   # Grafana: used for visualization of metrics and log data through customizable dashboards.
   grafana:
-    image: grafana/grafana:10.4.0
+    image: grafana/grafana:10.4.19
     environment:
       - GF_ANALYTICS_REPORTING_ENABLED=false
       - GF_SERVER_ROOT_URL

--- a/grafana.yml
+++ b/grafana.yml
@@ -1,7 +1,7 @@
 services:
   # Grafana: used for visualization of metrics and log data through customizable dashboards.
   grafana:
-    image: grafana/grafana:10.4.19
+    image: grafana/grafana:11.6.16
     environment:
       - GF_ANALYTICS_REPORTING_ENABLED=false
       - GF_SERVER_ROOT_URL

--- a/grafana.yml
+++ b/grafana.yml
@@ -1,9 +1,16 @@
 services:
   # Grafana: used for visualization of metrics and log data through customizable dashboards.
   grafana:
-    image: grafana/grafana:10.2.0
+    image: grafana/grafana:10.4.0
     environment:
       - GF_ANALYTICS_REPORTING_ENABLED=false
+      - GF_SERVER_ROOT_URL='${PUBLIC_URL}/monitoring'
+      - GF_SECURITY_ADMIN_USER: gadmin
+      - GF_SECURITY_ADMIN_PASSWORD: new-admin-password
+      - GF_SECURITY_CONTENT_SECURITY_POLICY: 'true'
+      - GF_SECURITY_COOKIE_SECURE: 'true'
+      - GF_SECURITY_COOKIE_SAMESITE: 'true'
+      
     volumes:
       - ./log-analyser/grafana:/var/lib/grafana
       - ./log-analyser/grafana-provisioning/dashboards/:/etc/grafana/provisioning/dashboards/

--- a/grafana.yml
+++ b/grafana.yml
@@ -1,7 +1,7 @@
 services:
   # Grafana: used for visualization of metrics and log data through customizable dashboards.
   grafana:
-    image: grafana/grafana:11.6.16
+    image: grafana/grafana:10.2.0
     environment:
       - GF_ANALYTICS_REPORTING_ENABLED=false
       - GF_SERVER_ROOT_URL

--- a/grafana.yml
+++ b/grafana.yml
@@ -12,7 +12,7 @@ services:
       - GF_SECURITY_COOKIE_SAMESITE
       
     volumes:
-      - ./log-analyser/grafana:/var/lib/grafana
+      - ${CONFIG}/grafana:/var/lib/grafana
       - ./log-analyser/grafana-provisioning/dashboards/:/etc/grafana/provisioning/dashboards/
       - ./log-analyser/grafana-provisioning/datasources/:/etc/grafana/provisioning/datasources/
     ports:

--- a/grafana.yml
+++ b/grafana.yml
@@ -9,8 +9,7 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD
       - GF_SECURITY_CONTENT_SECURITY_POLICY
       - GF_SECURITY_COOKIE_SECURE
-      - GF_SECURITY_COOKIE_SAMESITE
-      
+      - GF_SECURITY_COOKIE_SAMESITE    
     volumes:
       - ${CONFIG}/grafana:/var/lib/grafana
       - ./log-analyser/grafana-provisioning/dashboards/:/etc/grafana/provisioning/dashboards/
@@ -19,3 +18,5 @@ services:
       - "3000:3000"
     networks:
       meet.jitsi:
+        aliases:
+          - grafana.meet.jitsi

--- a/grafana.yml
+++ b/grafana.yml
@@ -4,7 +4,7 @@ services:
     image: grafana/grafana:10.2.0
     environment:
       - GF_ANALYTICS_REPORTING_ENABLED=false
-      - GF_SERVER_ROOT_URL
+      - GF_SERVER_ROOT_URL='${PUBLIC_URL}/${GRAFANA_SUB_URI}'
       - GF_SECURITY_ADMIN_USER
       - GF_SECURITY_ADMIN_PASSWORD
       - GF_SECURITY_CONTENT_SECURITY_POLICY

--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -280,18 +280,18 @@ location @root_path {
 
 {{ if .Env.GF_SERVER_ROOT_URL }}
 # Grafana settings
-location /monitoring/ {
+location ^~ /monitoring/ {
     proxy_set_header Host $http_host; 
-    proxy_pass http://localhost:3000/;
+    proxy_pass http://grafana.meet.jitsi:3000/;
   }
 
   # Proxy Grafana Live WebSocket connections.
-location /monitoring/api/live {
+location ^~ /monitoring/api/live {
     rewrite  ^/monitoring/(.*)  /$1 break;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "Upgrade";
     proxy_set_header Host $http_host;
-    proxy_pass http://localhost:3000/;
+    proxy_pass http://grafana.meet.jitsi:3000/;
   }
 {{ end }}

--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -277,3 +277,21 @@ location @root_path {
         rewrite ^/([^/?&:'"]+)/(.*)$ /$2;
     }
 {{ end }}
+
+{{ if .Env.GF_SERVER_ROOT_URL }}
+# Grafana settings
+location /monitoring/ {
+    proxy_set_header Host $http_host; 
+    proxy_pass http://localhost:3000/;
+  }
+
+  # Proxy Grafana Live WebSocket connections.
+location /monitoring/api/live {
+    rewrite  ^/monitoring/(.*)  /$1 break;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $http_host;
+    proxy_pass http://localhost:3000/;
+  }
+{{ end }}

--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -278,16 +278,16 @@ location @root_path {
     }
 {{ end }}
 
-{{ if .Env.GF_SERVER_ROOT_URL }}
+{{ if .Env.GRAFANA }}
 # Grafana settings
-location ^~ /monitoring/ {
+location ^~ /{{ .Env.GRAFANA_SUB_URI }}/ {
     proxy_set_header Host $http_host; 
     proxy_pass http://grafana.meet.jitsi:3000/;
   }
 
   # Proxy Grafana Live WebSocket connections.
-location ^~ /monitoring/api/live {
-    rewrite  ^/monitoring/(.*)  /$1 break;
+location ^~ /{{ .Env.GRAFANA_SUB_URI }}/api/live {
+    rewrite  ^/{{ .Env.GRAFANA_SUB_URI }}/(.*)  /$1 break;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "Upgrade";

--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -278,7 +278,7 @@ location @root_path {
     }
 {{ end }}
 
-{{ if .Env.GRAFANA }}
+{{ if .Env.ENABLE_GRAFANA | default "0" | toBool }}
 # Grafana settings
 location ^~ /{{ .Env.GRAFANA_SUB_URI }}/ {
     proxy_set_header Host $http_host; 


### PR DESCRIPTION
This PR is to allow running Grafana on `/monitoring` suburi
extra die is required: ${CONFIG}/grafana
Grafana should be able to write to
`chmod 777 ${CONFIG}/grafana`
or 
`chown -R 472:472 ${CONFIG}/grafana `
472 is grafana pid

Also need to activate the respective vars in configs

Grafana version is 116.16, as newer version should have some fixes in dashboards