### PR TITLE
fix(web): noprofile for acme.sh

### DIFF
--- a/web/rootfs/etc/s6-overlay/scripts/config
+++ b/web/rootfs/etc/s6-overlay/scripts/config
@@ -29,7 +29,11 @@ if [[ $DISABLE_HTTPS -ne 1 ]]; then
         check-writable /var/spool/cron/crontabs '${CONFIG}/tmp/web-crontabs' || exit 1
         mkdir -p /storage/acme.sh
         pushd /opt
-        sh ./acme.sh --install --home /storage/acme.sh --accountemail $LETSENCRYPT_EMAIL
+        # --noprofile: skip writing the shell alias into $HOME/.profile, which
+        # lives on the read-only root filesystem. It is only an interactive
+        # convenience; this script always calls acme.sh by full path with
+        # LE_WORKING_DIR exported, so nothing here needs it.
+        sh ./acme.sh --install --noprofile --home /storage/acme.sh --accountemail $LETSENCRYPT_EMAIL
         popd
 
         STAGING=""


### PR DESCRIPTION
With Let's Encrypt enabled, the read-only web container crashes on startup:
  `cannot create /home/s6/.profile: Read-only file system`

PR adds `--noprofile` to skip that write. The alias is only an interactive convenience, this container calls `acme.sh` by full path, and everything it actually writes (certs,  cron) already lives on writable volumes. No new volume needed.

https://github.com/jitsi/docker-jitsi-meet/issues/2275#issuecomment-4832600771