### PR TITLE
fix(jigasi): Use /run/jigasi/tmp as Java temp folder

### DIFF
--- a/jigasi/rootfs/etc/s6-overlay/scripts/config
+++ b/jigasi/rootfs/etc/s6-overlay/scripts/config
@@ -1,5 +1,6 @@
 #!/command/with-contenv bash
 
+mkdir -p /run/jigasi/tmp
 mkdir -p /run/jigasi/config
 cp -r /config/. /run/jigasi/config
 

--- a/jigasi/rootfs/etc/s6-overlay/scripts/jigasi
+++ b/jigasi/rootfs/etc/s6-overlay/scripts/jigasi
@@ -1,6 +1,6 @@
 #!/command/with-contenv bash
 
-JAVA_SYS_PROPS="-Djava.util.logging.config.file=/run/jigasi/config/logging.properties"
+JAVA_SYS_PROPS="-Djava.util.logging.config.file=/run/jigasi/config/logging.properties -Djava.io.tmpdir=/run/jigasi/tmp -Djna.tmpdir=/run/jigasi/tmp"
 
 DAEMON=/usr/share/jigasi/jigasi.sh
 DAEMON_OPTS="--nocomponent=true --configdir=/run/jigasi --configdirname=config --min-port=${JIGASI_PORT_MIN:-20000} --max-port=${JIGASI_PORT_MAX:-20050}"


### PR DESCRIPTION
PR sets `/run/jigasi/tmp` as Java temp folder because JNA needs a folder with exec permission.

A similar issue was fixed with https://github.com/jitsi/docker-jitsi-meet/pull/2263 for JVB.