### PR TITLE
feat: Add live audio translation wiring

### DIFF
--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -275,6 +275,18 @@ jicofo {
     sctp {
       enabled = {{ $ENABLE_SCTP }}
     }
+
+    {{ if .Env.JICOFO_TRANSLATION_URL_TEMPLATE }}
+    translation {
+      url-template = "{{ .Env.JICOFO_TRANSLATION_URL_TEMPLATE }}"
+      {{ if .Env.JICOFO_TRANSLATION_CF_ACCESS_CLIENT_ID }}
+      http-headers {
+        "CF-Access-Client-Id" = "{{ .Env.JICOFO_TRANSLATION_CF_ACCESS_CLIENT_ID }}"
+        "CF-Access-Client-Secret" = "{{ .Env.JICOFO_TRANSLATION_CF_ACCESS_CLIENT_SECRET }}"
+      }
+      {{ end }}
+    }
+    {{ end }}
 {{ if $ENABLE_VISITORS }}
     visitors {
       enabled = true

--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -2,6 +2,7 @@
 {{ $C2S_REQUIRE_ENCRYPTION := .Env.PROSODY_C2S_REQUIRE_ENCRYPTION | default "1" | toBool -}}
 {{ $DISABLE_POLLS := .Env.DISABLE_POLLS | default "false" | toBool -}}
 {{ $ENABLE_APP_SECRET := .Env.JWT_APP_SECRET | default "false" | toBool -}}
+{{ $ENABLE_AUDIO_TRANSLATION := .Env.ENABLE_AUDIO_TRANSLATION | default "0" | toBool -}}
 {{ $ENABLE_AUTH := .Env.ENABLE_AUTH | default "0" | toBool -}}
 {{ $ENABLE_AV_MODERATION := .Env.ENABLE_AV_MODERATION | default "true" | toBool -}}
 {{ $ENABLE_BREAKOUT_ROOMS := .Env.ENABLE_BREAKOUT_ROOMS | default "true" | toBool -}}
@@ -478,6 +479,10 @@ Component "metadata.{{ $XMPP_DOMAIN }}" "room_metadata_component"
     muc_component = "{{ $XMPP_MUC_DOMAIN }}"
     breakout_rooms_component = "breakout.{{ $XMPP_DOMAIN }}"
 
+{{ if $ENABLE_AUDIO_TRANSLATION }}
+Component "audiotranslation.{{ $XMPP_DOMAIN }}" "audio_translation_component"
+    muc_component = "{{ $XMPP_MUC_DOMAIN }}"
+{{ end }}
 
 {{ if $ENABLE_VISITORS }}
 Component "visitors.{{ $XMPP_DOMAIN }}" "visitors_component"


### PR DESCRIPTION
Wires up the live audio translation feature.

**prosody** (`jitsi-meet.cfg.lua`):
- New `ENABLE_AUDIO_TRANSLATION` toggle (default `0`).
- Enables the `audiotranslation.<domain>` component (`audio_translation_component`), placed after `room_metadata` which it depends on. The module ships in jitsi-meet's prosody-plugins.

**jicofo** (`jicofo.conf`):
- Adds a `translation {}` block gated on `JICOFO_TRANSLATION_URL_TEMPLATE`, with optional Cloudflare Access `http-headers` from `JICOFO_TRANSLATION_CF_ACCESS_CLIENT_ID` / `JICOFO_TRANSLATION_CF_ACCESS_CLIENT_SECRET`.

Two independent toggles (prosody component vs jicofo url), matching the split used in the ansible/infra provisioning.