### PR TITLE
feat(prosody): use in-memory storage for mod_smacks smacks_h store (JIT-16012)

### DIFF
--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -103,6 +103,10 @@ smacks_hibernation_time = 60;
 smacks_max_old_sessions = 1;
 {{ end }}
 
+-- Keep the mod_smacks hibernation queue store in memory; all other stores
+-- fall back to the default "internal" backend.
+storage = { smacks_h = "memory" }
+
 {{ if $ENABLE_JAAS_COMPONENTS }}
 VirtualHost "jigasi.meet.jitsi"
     modules_enabled = {


### PR DESCRIPTION
## Summary
Keep the mod_smacks hibernation queue store (`smacks_h`) in the `memory` backend instead of the disk-based `internal` storage.

## Change
In `prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua`, alongside the existing global smacks settings, add:

```lua
storage = { smacks_h = "memory" }
```

Only the `smacks_h` store is redirected; all other stores fall back to the default `internal` backend. Applied unconditionally (outside the `ENABLE_XMPP_WEBSOCKET` gate) — harmless when mod_smacks is not loaded.

## Rationale
mod_smacks uses the `smacks_h` store for hibernated (resumable) session queues. Keeping this transient state in memory avoids unnecessary disk I/O.

This mirrors the equivalent change in the Ansible-managed prosody template (jitsi/infra-configuration#934). The nomad pack (`infra-provisioning`) only emits per-host VirtualHost fragments and has no global storage declaration, so this Docker-image default is the correct place for the global setting.

Ref: JIT-16012