### PR TITLE
Use HTTPS for pinned Chrome downloads

### DIFF
--- a/jibri/rootfs/usr/bin/install-chrome.sh
+++ b/jibri/rootfs/usr/bin/install-chrome.sh
@@ -16,7 +16,7 @@ else
         apt-dpkg-wrap apt-get install -y google-chrome-stable
     else
         CHROME_DEB="/tmp/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb"
-        curl -4so ${CHROME_DEB} "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb"
+        curl -4so ${CHROME_DEB} "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_RELEASE}-1_amd64.deb"
         apt-dpkg-wrap apt-get install -y ${CHROME_DEB}
         rm -f ${CHROME_DEB}
     fi


### PR DESCRIPTION
I have excess 5.6-sol and Fable 5 credits, and decided to use them to contribute back to OSS that I depend upon.

gpt5.6-sol cross-checked by Opus 4.8. Fable 5 could not cross-check due to safeties being triggered.

## What

Fetch the pinned amd64 Chrome package over HTTPS instead of plaintext HTTP.

## Why

The pinned-release branch downloads a local `.deb` directly and passes it to
`apt-get install`, outside the authenticated APT-repository path used by the
`latest` branch. Google's existing HTTPS endpoint serves the same pinned
artifact, so the download does not need plaintext transport.

This is a narrow transport-hardening change. It does not claim to add an
independent checksum or package-signature mechanism.

## Validation

- `bash -n jibri/rootfs/usr/bin/install-chrome.sh`: pass.
- `git diff --check`: pass.
- Exact pinned HTTPS package endpoint: HTTP 200.
- Isolated HTTP-only substitution control against the patched script: curl
  rejected the HTTPS connection and no package maintainer script executed.

Base:
`fbbec37d5d67dd2b012fa3505a89e89d15b69199`.
