### PR TITLE
feat(web,jvb): remove deprecated colibri websocket support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,9 +32,6 @@ services:
             - CODEC_ORDER_JVB_MOBILE
             - CODEC_ORDER_P2P
             - CODEC_ORDER_P2P_MOBILE
-            - COLIBRI_WEBSOCKET_PORT
-            - COLIBRI_WEBSOCKET_JVB_LOOKUP_NAME
-            - COLIBRI_WEBSOCKET_REGEX
             - CONFCODE_URL
             - CORS_HEADER_ACCESS_CONTROL_ALLOW_ORIGIN
             - CSP_HEADER
@@ -50,7 +47,6 @@ services:
             - DIALOUT_AUTH_URL
             - DIALOUT_CODES_URL
             - DISABLE_AUDIO_LEVELS
-            - DISABLE_COLIBRI_WEBSOCKET_JVB_LOOKUP
             - DISABLE_DEEP_LINKING
             - DISABLE_GRANT_MODERATOR
             - DISABLE_HTTPS
@@ -74,7 +70,6 @@ services:
             - ENABLE_BREAKOUT_ROOMS
             - ENABLE_CALENDAR
             - ENABLE_COLIBRI_WEBSOCKET
-            - ENABLE_COLIBRI_WEBSOCKET_UNSAFE_REGEX
             - ENABLE_E2EPING
             - ENABLE_FILE_RECORDING_SHARING
             - ENABLE_GUESTS
@@ -84,7 +79,6 @@ services:
             - ENABLE_LETSENCRYPT
             - ENABLE_NO_AUDIO_DETECTION
             - ENABLE_NOISY_MIC_DETECTION
-            - ENABLE_OCTO
             - ENABLE_OPUS_RED
             - ENABLE_PREJOIN_PAGE
             - ENABLE_P2P
@@ -515,14 +509,10 @@ services:
             - JVB_OCTO_RELAY_ID
             - JVB_REQUIRE_VALID_ADDRESS
             - JVB_USE_USRSCTP
-            - JVB_WS_DOMAIN
-            - JVB_WS_SERVER_ID
-            - JVB_WS_TLS
             - JVB_XMPP_AUTH_DOMAIN
             - JVB_XMPP_INTERNAL_MUC_DOMAIN
             - JVB_XMPP_PORT
             - JVB_XMPP_SERVER
-            - PUBLIC_URL
             - SENTRY_DSN="${JVB_SENTRY_DSN:-0}"
             - SENTRY_ENVIRONMENT
             - SENTRY_RELEASE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,6 @@ services:
             - ENABLE_AUTH_DOMAIN
             - ENABLE_BREAKOUT_ROOMS
             - ENABLE_CALENDAR
-            - ENABLE_COLIBRI_WEBSOCKET
             - ENABLE_E2EPING
             - ENABLE_FILE_RECORDING_SHARING
             - ENABLE_GUESTS
@@ -385,9 +384,7 @@ services:
             - ENABLE_CODEC_OPUS_RED
             - ENABLE_JVB_XMPP_SERVER
             - ENABLE_OCTO
-            - ENABLE_OCTO_SCTP
             - ENABLE_RECORDING
-            - ENABLE_SCTP
             - ENABLE_SHARED_DOCUMENT_RANDOM_NAME
             - ENABLE_TRANSCRIPTIONS
             - ENABLE_VISITORS
@@ -487,10 +484,8 @@ services:
             - AUTOSCALER_SIDECAR_STATS_POLLING_INTERVAL
             - DISABLE_AWS_HARVESTER
             - DOCKER_HOST_ADDRESS
-            - ENABLE_COLIBRI_WEBSOCKET
             - ENABLE_JVB_XMPP_SERVER
             - ENABLE_OCTO
-            - ENABLE_SCTP
             - JVB_ADVERTISE_IPS
             - JVB_ADVERTISE_PRIVATE_CANDIDATES
             - JVB_AUTH_USER

--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -4,11 +4,9 @@
 {{ $AUTH_TYPE := .Env.AUTH_TYPE | default "internal" -}}
 {{ $JICOFO_AUTH_TYPE := .Env.JICOFO_AUTH_TYPE | default $AUTH_TYPE -}}
 {{ $JICOFO_AUTH_LIFETIME := .Env.JICOFO_AUTH_LIFETIME | default "24 hours" -}}
-{{ $ENABLE_SCTP := .Env.ENABLE_SCTP | default "1" | toBool -}}
 {{ $ENABLE_RECORDING := .Env.ENABLE_RECORDING | default "0" | toBool -}}
 {{ $ENABLE_TRANSCRIPTIONS := .Env.ENABLE_TRANSCRIPTIONS | default "0" | toBool -}}
 {{ $ENABLE_OCTO := .Env.ENABLE_OCTO | default "0" | toBool -}}
-{{ $ENABLE_OCTO_SCTP := .Env.ENABLE_OCTO_SCTP | default $ENABLE_SCTP | toBool -}}
 {{ $ENABLE_AUTO_LOGIN := .Env.ENABLE_AUTO_LOGIN | default "1" | toBool -}}
 {{ $ENABLE_REST := .Env.JICOFO_ENABLE_REST | default "0" | toBool -}}
 {{ $ENABLE_JVB_XMPP_SERVER := .Env.ENABLE_JVB_XMPP_SERVER | default "0" | toBool -}}
@@ -263,7 +261,7 @@ jicofo {
       // two MUST be in sync (otherwise bridges will crash because they won't know how to
       // deal with octo channels).
       enabled = {{ $ENABLE_OCTO }}
-      sctp-datachannels = {{ $ENABLE_OCTO_SCTP }}
+      sctp-datachannels = true
     }
 
     {{ if $ENABLE_REST }}
@@ -273,7 +271,7 @@ jicofo {
     {{ end }}
 
     sctp {
-      enabled = {{ $ENABLE_SCTP }}
+      enabled = true
     }
 
     {{ if .Env.JICOFO_TRANSLATION_URL_TEMPLATE }}

--- a/jvb/rootfs/defaults/jvb.conf
+++ b/jvb/rootfs/defaults/jvb.conf
@@ -1,7 +1,6 @@
 {{ $COLIBRI_REST_ENABLED := .Env.COLIBRI_REST_ENABLED | default "false" | toBool -}}
 {{ $DISABLE_AWS_HARVESTER := .Env.DISABLE_AWS_HARVESTER | default "true" | toBool -}}
 {{ $DISABLE_XMPP := .Env.JVB_DISABLE_XMPP | default "0" | toBool -}}
-{{ $ENABLE_COLIBRI_WEBSOCKET := .Env.ENABLE_COLIBRI_WEBSOCKET | default "0" | toBool -}}
 {{ $ENABLE_OCTO := .Env.ENABLE_OCTO | default "0" | toBool -}}
 {{ $ENABLE_SCTP := .Env.ENABLE_SCTP | default "1" | toBool -}}
 {{ $ENABLE_JVB_XMPP_SERVER := .Env.ENABLE_JVB_XMPP_SERVER | default "0" | toBool }}
@@ -20,12 +19,8 @@
 {{ $JVB_XMPP_PORT := .Env.JVB_XMPP_PORT | default "6222" -}}
 {{ $JVB_XMPP_SERVER := .Env.JVB_XMPP_SERVER | default "xmpp.jvb.meet.jitsi" -}}
 {{ $JVB_XMPP_SERVERS := splitList "," $JVB_XMPP_SERVER | compact -}}
-{{ $PUBLIC_URL_DOMAIN := .Env.PUBLIC_URL | default "https://localhost:8443" | trimPrefix "https://" | trimSuffix "/" -}}
 {{ $SHUTDOWN_REST_ENABLED := .Env.SHUTDOWN_REST_ENABLED | default "false" | toBool -}}
 {{ $USE_USRSCTP := .Env.JVB_USE_USRSCTP | default "false" | toBool -}}
-{{ $WS_DOMAIN := .Env.JVB_WS_DOMAIN | default $PUBLIC_URL_DOMAIN -}}
-{{ $WS_SERVER_ID := .Env.JVB_WS_SERVER_ID | default .Env.JVB_WS_SERVER_ID_FALLBACK | default "default" -}}
-{{ $WS_TLS := .Env.JVB_WS_TLS | default "1" | toBool -}}
 {{ $XMPP_AUTH_DOMAIN := .Env.XMPP_AUTH_DOMAIN | default "auth.meet.jitsi" -}}
 {{ $XMPP_INTERNAL_MUC_DOMAIN := .Env.XMPP_INTERNAL_MUC_DOMAIN | default "internal-muc.meet.jitsi" -}}
 {{ $XMPP_PORT := .Env.XMPP_PORT | default "5222" -}}
@@ -97,21 +92,10 @@ videobridge {
     stats {
         enabled = true
     }
-    websockets {
-        enabled = {{ $ENABLE_COLIBRI_WEBSOCKET }}
-        domain = "{{ $WS_DOMAIN }}"
-        tls = {{ $WS_TLS }}
-        server-id = "{{ $WS_SERVER_ID }}"
-    }
     http-servers {
         private {
           host = 0.0.0.0
           send-server-version = false
-        }
-        public {
-            host = 0.0.0.0
-            port = 9090
-            send-server-version = false
         }
     }
     health {

--- a/jvb/rootfs/defaults/jvb.conf
+++ b/jvb/rootfs/defaults/jvb.conf
@@ -2,7 +2,6 @@
 {{ $DISABLE_AWS_HARVESTER := .Env.DISABLE_AWS_HARVESTER | default "true" | toBool -}}
 {{ $DISABLE_XMPP := .Env.JVB_DISABLE_XMPP | default "0" | toBool -}}
 {{ $ENABLE_OCTO := .Env.ENABLE_OCTO | default "0" | toBool -}}
-{{ $ENABLE_SCTP := .Env.ENABLE_SCTP | default "1" | toBool -}}
 {{ $ENABLE_JVB_XMPP_SERVER := .Env.ENABLE_JVB_XMPP_SERVER | default "0" | toBool }}
 {{ $JVB_DISABLE_STUN := .Env.JVB_DISABLE_STUN | default "0" | toBool -}}
 {{ $JVB_STUN_SERVERS := .Env.JVB_STUN_SERVERS | default "meet-jit-si-turnrelay.jitsi.net:443" -}}
@@ -86,7 +85,7 @@ videobridge {
         }
     }
     sctp {
-      enabled = {{ $ENABLE_SCTP }}
+      enabled = true
       use-usrsctp = {{ $USE_USRSCTP }}
     }
     stats {

--- a/jvb/rootfs/etc/s6-overlay/scripts/config
+++ b/jvb/rootfs/etc/s6-overlay/scripts/config
@@ -9,13 +9,13 @@ if [[ -z "$JVB_DISABLE_XMPP" ]]; then
         echo 'FATAL ERROR: JVB auth password must be set'
         exit 1
     fi
+fi
 
-    [ -z "${XMPP_SERVER}" ] && export XMPP_SERVER=xmpp.meet.jitsi
-
-    # On environments like Swarm the IP address used by the default gateway need not be
-    # the one used for inter-container traffic. Use that one for our fallback ID.
-    XMPP_SERVER_IP=$(dig +short +search ${XMPP_SERVER})
-    export JVB_WS_SERVER_ID_FALLBACK=$(ip route get ${XMPP_SERVER_IP} | grep -oP '(?<=src ).*' | awk '{ print $1 '})
+if [[ "$ENABLE_COLIBRI_WEBSOCKET" == "1" || "$ENABLE_COLIBRI_WEBSOCKET" == "true" ]]; then
+    echo "WARNING: colibri websockets are no longer supported, ENABLE_COLIBRI_WEBSOCKET is ignored"
+    if [[ "$ENABLE_SCTP" == "0" || "$ENABLE_SCTP" == "false" ]]; then
+        echo "WARNING: SCTP is disabled and colibri websockets are no longer available, so clients will have NO bridge channel; unset ENABLE_SCTP (or set it to 1) to restore the bridge channel over SCTP data channels"
+    fi
 fi
 
 # Migration from DOCKER_HOST_ADDRESS to JVB_ADVERTISE_IPS

--- a/jvb/rootfs/etc/s6-overlay/scripts/config
+++ b/jvb/rootfs/etc/s6-overlay/scripts/config
@@ -11,13 +11,6 @@ if [[ -z "$JVB_DISABLE_XMPP" ]]; then
     fi
 fi
 
-if [[ "$ENABLE_COLIBRI_WEBSOCKET" == "1" || "$ENABLE_COLIBRI_WEBSOCKET" == "true" ]]; then
-    echo "WARNING: colibri websockets are no longer supported, ENABLE_COLIBRI_WEBSOCKET is ignored"
-    if [[ "$ENABLE_SCTP" == "0" || "$ENABLE_SCTP" == "false" ]]; then
-        echo "WARNING: SCTP is disabled and colibri websockets are no longer available, so clients will have NO bridge channel; unset ENABLE_SCTP (or set it to 1) to restore the bridge channel over SCTP data channels"
-    fi
-fi
-
 # Migration from DOCKER_HOST_ADDRESS to JVB_ADVERTISE_IPS
 if [[ -z "${JVB_ADVERTISE_IPS}" ]]; then
     if [[ -n "${DOCKER_HOST_ADDRESS}" ]]; then

--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -1,9 +1,5 @@
-{{ $ENABLE_COLIBRI_WEBSOCKET := .Env.ENABLE_COLIBRI_WEBSOCKET | default "0" | toBool }}
-{{ $COLIBRI_WEBSOCKET_PORT := .Env.COLIBRI_WEBSOCKET_PORT | default "9090" }}
-{{ $COLIBRI_WEBSOCKET_REGEX := .Env.COLIBRI_WEBSOCKET_REGEX | default "jvb" }}
 {{ $ENABLE_JAAS_COMPONENTS := .Env.ENABLE_JAAS_COMPONENTS | default "0" | toBool }}
 {{ $ENABLE_LOAD_TEST_CLIENT := .Env.ENABLE_LOAD_TEST_CLIENT | default "0" | toBool }}
-{{ $ENABLE_OCTO := .Env.ENABLE_OCTO | default "0" | toBool -}}
 {{ $ENABLE_XMPP_WEBSOCKET := .Env.ENABLE_XMPP_WEBSOCKET | default "1" | toBool }}
 {{ $ENABLE_SUBDOMAINS := .Env.ENABLE_SUBDOMAINS | default "true" | toBool -}}
 {{ $XMPP_DOMAIN := .Env.XMPP_DOMAIN | default "meet.jitsi" -}}
@@ -78,32 +74,6 @@ location ~ ^/(libs|css|static|images|fonts|lang|sounds|connection_optimization|.
         expires 1y;
     }
 }
-
-{{ if $ENABLE_COLIBRI_WEBSOCKET }}
-# colibri (JVB) websockets
-location ~ ^/colibri-ws/({{ $COLIBRI_WEBSOCKET_REGEX }})/(.*) {
-    tcp_nodelay on;
-
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
-
-    proxy_pass http://$1:{{ $COLIBRI_WEBSOCKET_PORT }}/colibri-ws/$1/$2$is_args$args;
-}
-
-{{ if $ENABLE_OCTO }}
-# colibri (JVB) Relay to Relay websockets
-location ~ ^/colibri-relay-ws/([a-zA-Z0-9-\._]+)/(.*) {
-    tcp_nodelay on;
-
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
-
-    proxy_pass http://$1:{{ $COLIBRI_WEBSOCKET_PORT }}/colibri-relay-ws/$1/$2$is_args$args;
-}
-{{ end }}
-{{ end }}
 
 # BOSH
 location = /http-bind {

--- a/web/rootfs/etc/s6-overlay/scripts/config
+++ b/web/rootfs/etc/s6-overlay/scripts/config
@@ -122,23 +122,8 @@ fi
 
 echo "Using Nginx resolver: =$NGINX_RESOLVER="
 
-# colibri-ws settings
-COLIBRI_WEBSOCKET_UNSAFE_REGEX="[a-zA-Z0-9-\._]+"
-# use custom websocket regex if provided
-if [ -z "$COLIBRI_WEBSOCKET_REGEX" ]; then
-    # default to the previous unsafe behavior only if flag is set
-    if [[ "$ENABLE_COLIBRI_WEBSOCKET_UNSAFE_REGEX" == "1" ]]; then
-        export COLIBRI_WEBSOCKET_REGEX="$COLIBRI_WEBSOCKET_UNSAFE_REGEX"
-    else
-        # default value to the JVB IP, works in compose and anywhere a dns lookup of the JVB reveals the correct IP for proxying
-        [ -z "$COLIBRI_WEBSOCKET_JVB_LOOKUP_NAME" ] && export COLIBRI_WEBSOCKET_JVB_LOOKUP_NAME="jvb"
-        if [[ "$DISABLE_COLIBRI_WEBSOCKET_JVB_LOOKUP" == "1" ]]; then
-            # otherwise value default to the static value in the template 'jvb'
-            echo "WARNING: DISABLE_COLIBRI_WEBSOCKET_JVB_LOOKUP is set and no value for COLIBRI_WEBSOCKET_REGEX was provided, using static value 'jvb' for COLIBRI_WEBSOCKET_REGEX"
-        else
-            export COLIBRI_WEBSOCKET_REGEX="$(dig +short +search $COLIBRI_WEBSOCKET_JVB_LOOKUP_NAME)"
-        fi
-    fi
+if [[ "$ENABLE_COLIBRI_WEBSOCKET" == "1" || "$ENABLE_COLIBRI_WEBSOCKET" == "true" ]]; then
+    echo "WARNING: colibri websockets are no longer supported, ENABLE_COLIBRI_WEBSOCKET is ignored"
 fi
 
 # maintain backward compatibility with older variable

--- a/web/rootfs/etc/s6-overlay/scripts/config
+++ b/web/rootfs/etc/s6-overlay/scripts/config
@@ -122,10 +122,6 @@ fi
 
 echo "Using Nginx resolver: =$NGINX_RESOLVER="
 
-if [[ "$ENABLE_COLIBRI_WEBSOCKET" == "1" || "$ENABLE_COLIBRI_WEBSOCKET" == "true" ]]; then
-    echo "WARNING: colibri websockets are no longer supported, ENABLE_COLIBRI_WEBSOCKET is ignored"
-fi
-
 # maintain backward compatibility with older variable
 [ -z "${XMPP_HIDDEN_DOMAIN}" ] && export XMPP_HIDDEN_DOMAIN="$XMPP_RECORDER_DOMAIN"
 


### PR DESCRIPTION
## Summary

Colibri websockets (`colibri-ws` and `colibri-relay-ws`) are deprecated; the bridge channel uses SCTP data channels. This removes the websocket plumbing from the web and JVB containers and makes SCTP always-on.

### web
- Remove the `/colibri-ws/` and `/colibri-relay-ws/` nginx proxy location blocks and their template variables (`ENABLE_COLIBRI_WEBSOCKET`, `COLIBRI_WEBSOCKET_PORT`, `COLIBRI_WEBSOCKET_REGEX`, and the now-unused `ENABLE_OCTO`)
- Remove the JVB regex/`dig` lookup logic (`COLIBRI_WEBSOCKET_JVB_LOOKUP_NAME`, `DISABLE_COLIBRI_WEBSOCKET_JVB_LOOKUP`, `ENABLE_COLIBRI_WEBSOCKET_UNSAFE_REGEX`) from the config script

### jvb
- Remove the `websockets {}` block from jvb.conf along with `JVB_WS_DOMAIN`, `JVB_WS_SERVER_ID`, `JVB_WS_TLS` and the `PUBLIC_URL`-derived websocket domain
- Remove the public http server on port 9090, which only served colibri websockets (the private server used for health/stats is untouched)
- Remove the Swarm-specific `dig`/`ip route` fallback server-id lookup from the config script
- SCTP is now always enabled; the `ENABLE_SCTP` setting is removed (`JVB_USE_USRSCTP` still selects the implementation)

### jicofo
- SCTP is now always enabled, including octo `sctp-datachannels`; the `ENABLE_SCTP` and `ENABLE_OCTO_SCTP` settings are removed

## Breaking changes

`ENABLE_COLIBRI_WEBSOCKET`, `ENABLE_SCTP` and `ENABLE_OCTO_SCTP` are no longer honored: SCTP data channels are always on and are the only bridge channel transport.