### PR TITLE
fix(web) Default ENABLE_VIRTUAL_BACKGROUND_V2 to true

### DIFF
--- a/web/rootfs/defaults/settings-config.js
+++ b/web/rootfs/defaults/settings-config.js
@@ -25,7 +25,7 @@
 {{ $ENABLE_TALK_WHILE_MUTED := .Env.ENABLE_TALK_WHILE_MUTED | default "false" | toBool -}}
 {{ $ENABLE_TCC := .Env.ENABLE_TCC | default "true" | toBool -}}
 {{ $ENABLE_TRANSCRIPTIONS := .Env.ENABLE_TRANSCRIPTIONS | default "false" | toBool -}}
-{{ $ENABLE_VIRTUAL_BACKGROUND_V2 := .Env.ENABLE_VIRTUAL_BACKGROUND_V2 | default "false" | toBool -}}
+{{ $ENABLE_VIRTUAL_BACKGROUND_V2 := .Env.ENABLE_VIRTUAL_BACKGROUND_V2 | default "true" | toBool -}}
 {{ $TRANSLATION_LANGUAGES := .Env.TRANSLATION_LANGUAGES | default "[]" -}}
 {{ $TRANSLATION_LANGUAGES_HEAD := .Env.TRANSLATION_LANGUAGES_HEAD | default "['en']" -}}
 {{ $USE_APP_LANGUAGE := .Env.USE_APP_LANGUAGE | default "true" | toBool -}}


### PR DESCRIPTION
Follow-up to #2270. Flips the default of `ENABLE_VIRTUAL_BACKGROUND_V2` from `false` → `true` to match the upstream client change ([jitsi/jitsi-meet#17662](https://github.com/jitsi/jitsi-meet/pull/17662)), which makes V2 the default engine unless `config.virtualBackground.enableV2` is explicitly set to `false`.

New defaults:
- Fresh docker deployment → V2 (matches upstream client default).
- Opt out via `ENABLE_VIRTUAL_BACKGROUND_V2=0` → emits `enableV2: false` → client uses V1.
