### PR TITLE
feat: add optional Jibri recording library

### DIFF
--- a/env.example
+++ b/env.example
@@ -24,6 +24,10 @@ HTTP_PORT=8000
 # Exposed HTTPS port
 HTTPS_PORT=8443
 
+# Loopback-only port for the optional Jibri recording library (recordings.yml)
+# Put this behind an authenticated reverse proxy before exposing it to users.
+#RECORDINGS_PORT=8090
+
 # System time zone
 TZ=UTC
 

--- a/recordings.yml
+++ b/recordings.yml
@@ -1,0 +1,10 @@
+services:
+    recordings:
+        build:
+            context: ./recordings
+        restart: ${RESTART_POLICY:-unless-stopped}
+        ports:
+            # Deliberately bind to loopback: Jibri recordings may contain private content.
+            - '127.0.0.1:${RECORDINGS_PORT:-8090}:80'
+        volumes:
+            - ${CONFIG}/storage/jibri/recordings:/recordings:ro,Z

--- a/recordings/Dockerfile
+++ b/recordings/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:1.27-alpine
+
+COPY default.conf /etc/nginx/conf.d/default.conf
+COPY site /usr/share/nginx/site

--- a/recordings/README.md
+++ b/recordings/README.md
@@ -1,0 +1,21 @@
+# Jibri recording library
+
+This optional, read-only page lists completed Jibri MP4 recordings and provides
+playback and download links. It requires the Jibri service and its default
+recording storage location.
+
+## Start it
+
+```bash
+docker compose -f docker-compose.yml -f jibri.yml -f recordings.yml up -d --build
+```
+
+The page listens only on `127.0.0.1:${RECORDINGS_PORT:-8090}`. Put it behind an
+authenticated reverse proxy before making it available to users: recordings can
+contain private meeting content. Do not expose the port directly to the Internet.
+
+For a deployment where the Jitsi web service is already reverse-proxied, route a
+separate protected hostname or a protected `/recordings/` path to
+`http://127.0.0.1:${RECORDINGS_PORT:-8090}`. The sidecar dynamically discovers
+MP4 files in `${CONFIG}/storage/jibri/recordings` and never writes to that
+directory.

--- a/recordings/default.conf
+++ b/recordings/default.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name _;
+    charset utf-8;
+
+    root /usr/share/nginx/site;
+    index index.html;
+
+    location /media/ {
+        alias /recordings/;
+        autoindex on;
+        autoindex_exact_size off;
+        autoindex_localtime on;
+        add_header Cache-Control "private, max-age=3600" always;
+        add_header X-Content-Type-Options nosniff always;
+    }
+}

--- a/recordings/site/app.js
+++ b/recordings/site/app.js
@@ -1,0 +1,80 @@
+const root = document.querySelector('#recordings');
+const status = document.querySelector('#status');
+const template = document.querySelector('#recording-template');
+
+function prettyName(filename) {
+  return decodeURIComponent(filename).replace(/\.mp4$/i, '').replace(/[_-]/g, ' ');
+}
+
+function bytes(value) {
+  if (!Number.isFinite(value) || value <= 0) return 'MP4 recording';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const index = Math.min(Math.floor(Math.log(value) / Math.log(1024)), units.length - 1);
+  return `${(value / 1024 ** index).toFixed(index ? 1 : 0)} ${units[index]}`;
+}
+
+function date(value) {
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime())
+    ? 'Completed recording'
+    : parsed.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+}
+
+async function metadata(url) {
+  try {
+    const response = await fetch(url, { method: 'HEAD' });
+    return { size: Number(response.headers.get('content-length')), modified: response.headers.get('last-modified') };
+  } catch {
+    return { size: NaN, modified: '' };
+  }
+}
+
+async function recordingFiles(url) {
+  const response = await fetch(url, { cache: 'no-store' });
+  if (!response.ok) return [];
+  const page = new DOMParser().parseFromString(await response.text(), 'text/html');
+  return [...page.querySelectorAll('a[href$=".mp4"], a[href$=".MP4"]')]
+    .map((link) => new URL(link.getAttribute('href'), url));
+}
+
+async function load() {
+  root.replaceChildren();
+  status.textContent = 'Loading recordings…';
+  try {
+    const mediaRoot = new URL('./media/', location.href);
+    const response = await fetch(mediaRoot, { cache: 'no-store' });
+    if (!response.ok) throw new Error(`Recording index returned ${response.status}`);
+    const page = new DOMParser().parseFromString(await response.text(), 'text/html');
+    const links = [...page.querySelectorAll('a[href]')].map((link) => new URL(link.getAttribute('href'), mediaRoot));
+    const directFiles = links.filter((url) => /\.mp4$/i.test(url.pathname));
+    const folders = links.filter((url) => url.pathname.endsWith('/') && url.href !== mediaRoot.href && url.pathname.startsWith(mediaRoot.pathname));
+    const nestedFiles = (await Promise.all(folders.map(recordingFiles))).flat();
+    const urls = [...new Set([...directFiles, ...nestedFiles].map((url) => url.href))].sort().reverse();
+
+    if (!urls.length) {
+      root.innerHTML = '<p class="empty">No completed recordings are available yet.</p>';
+      status.textContent = '0 recordings';
+      return;
+    }
+
+    const recordings = await Promise.all(urls.map(async (url) => ({ url, ...(await metadata(url)) })));
+    for (const recording of recordings) {
+      const node = template.content.cloneNode(true);
+      const filename = new URL(recording.url).pathname.split('/').pop();
+      node.querySelector('.recording-name').textContent = prettyName(filename);
+      node.querySelector('.recording-meta').textContent = `${date(recording.modified)} · ${bytes(recording.size)}`;
+      node.querySelector('.play').href = recording.url;
+      const download = node.querySelector('.download');
+      download.href = recording.url;
+      root.append(node);
+    }
+    status.textContent = `${recordings.length} recording${recordings.length === 1 ? '' : 's'}`;
+  } catch (error) {
+    root.innerHTML = '<p class="empty">The recording library could not be loaded. Refresh to try again.</p>';
+    status.textContent = 'Unavailable';
+    console.error(error);
+  }
+}
+
+document.querySelector('#refresh').addEventListener('click', load);
+load();

--- a/recordings/site/index.html
+++ b/recordings/site/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex,nofollow" />
+    <title>Recordings · Jitsi Meet</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <header class="topbar">
+        <span class="brand"><span class="brand-mark" aria-hidden="true">J</span>Jitsi <strong>Meet</strong></span>
+        <span class="eyebrow">Recording library</span>
+      </header>
+      <section class="intro" aria-labelledby="title">
+        <p class="eyebrow">Jibri recordings</p>
+        <h1 id="title">Meetings, ready to revisit.</h1>
+        <p>Completed recordings from this Jitsi server. Select a recording to play it, or download the original MP4.</p>
+      </section>
+      <section class="library" aria-labelledby="library-title">
+        <div class="library-heading">
+          <div><h2 id="library-title">Available recordings</h2><p id="status" role="status">Loading recordings…</p></div>
+          <button id="refresh" type="button">Refresh</button>
+        </div>
+        <div id="recordings" class="recordings" aria-live="polite"></div>
+      </section>
+    </main>
+    <template id="recording-template">
+      <article class="recording-card">
+        <div class="film" aria-hidden="true"><span></span><span></span><span></span></div>
+        <div class="recording-details"><p class="recording-name"></p><p class="recording-meta"></p></div>
+        <div class="recording-actions"><a class="play" target="_blank" rel="noopener">Play</a><a class="download" download>Download</a></div>
+      </article>
+    </template>
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/recordings/site/style.css
+++ b/recordings/site/style.css
@@ -1,0 +1,32 @@
+:root { color-scheme: dark; --page: #101214; --surface: #1c1f23; --surface-hover: #252a30; --line: #343940; --text: #f5f7fa; --muted: #aeb6c2; --blue: #2684ff; }
+* { box-sizing: border-box; }
+body { margin: 0; min-width: 320px; background: radial-gradient(circle at 88% -10%, #243247 0, transparent 30rem), var(--page); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
+.shell { width: min(1080px, calc(100% - 40px)); margin: 0 auto; padding-bottom: 80px; }
+.topbar { min-height: 80px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--line); }
+.brand { display: inline-flex; align-items: center; gap: 10px; font-size: 20px; font-weight: 500; letter-spacing: -.25px; }
+.brand-mark { width: 29px; height: 29px; display: grid; place-items: center; border-radius: 9px; background: var(--blue); color: #fff; font-size: 17px; font-weight: 800; transform: rotate(-7deg); }
+.eyebrow { margin: 0; color: var(--muted); font-size: 12px; font-weight: 650; letter-spacing: .11em; text-transform: uppercase; }
+.intro { max-width: 680px; padding: 78px 0 64px; }
+.intro .eyebrow { color: #4c9aff; }
+h1 { margin: 13px 0 18px; font-size: clamp(38px, 6vw, 65px); line-height: .98; letter-spacing: -2.4px; font-weight: 650; }
+.intro > p:last-child { max-width: 590px; margin: 0; color: var(--muted); font-size: 18px; line-height: 1.58; }
+.library { border-top: 1px solid var(--line); padding-top: 28px; }
+.library-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px; margin-bottom: 22px; }
+h2 { margin: 0 0 7px; font-size: 19px; letter-spacing: -.2px; }
+#status { margin: 0; color: var(--muted); font-size: 14px; }
+button, .recording-actions a { border: 1px solid var(--line); border-radius: 7px; color: var(--text); cursor: pointer; font: inherit; font-size: 14px; font-weight: 600; text-decoration: none; }
+button { padding: 9px 14px; background: transparent; }
+button:hover, button:focus-visible { border-color: var(--blue); color: #4c9aff; }
+.recordings { display: grid; gap: 10px; }
+.recording-card { min-height: 98px; display: grid; grid-template-columns: 58px minmax(0, 1fr) auto; gap: 18px; align-items: center; padding: 17px 19px; border: 1px solid var(--line); border-radius: 10px; background: var(--surface); }
+.recording-card:hover { background: var(--surface-hover); border-color: #4a515a; }
+.film { width: 42px; height: 54px; padding: 9px 0; display: flex; flex-direction: column; justify-content: space-around; border: 1px solid #536171; border-radius: 7px; background: #171a1d; }
+.film span { height: 4px; margin: 0 5px; border-radius: 3px; background: #4c9aff; opacity: .88; }
+.recording-name { margin: 0 0 6px; overflow-wrap: anywhere; font-size: 16px; font-weight: 600; }
+.recording-meta { margin: 0; color: var(--muted); font-size: 13px; }
+.recording-actions { display: flex; gap: 9px; }
+.recording-actions a { padding: 9px 13px; }
+.recording-actions .play { border-color: var(--blue); background: var(--blue); }
+.recording-actions .download { color: #4c9aff; }
+.empty { padding: 34px 0; color: var(--muted); text-align: center; border: 1px dashed var(--line); border-radius: 10px; }
+@media (max-width: 600px) { .shell { width: min(100% - 28px, 1080px); } .topbar { min-height: 68px; } .topbar > .eyebrow { display: none; } .intro { padding: 54px 0 46px; } .recording-card { grid-template-columns: 42px minmax(0, 1fr); gap: 14px; padding: 15px; } .recording-actions { grid-column: 2; } .film { width: 34px; height: 46px; } }


### PR DESCRIPTION
## Summary\n- add an optional, read-only recording-library sidecar for completed Jibri MP4 files\n- provide a lightweight page with playback and download links\n- bind the service to loopback only and document authenticated reverse-proxy deployment\n\n## Usage\n\n```bash\ndocker compose -f docker-compose.yml -f jibri.yml -f recordings.yml up -d --build\n```\n\nThe sidecar reads the default `/storage/jibri/recordings` path and does not write to it. It is deliberately not exposed directly to the Internet.\n\n## Validation\n- `docker compose -f docker-compose.yml -f jibri.yml -f recordings.yml config --quiet`\n- `node --check recordings/site/app.js`\n\nA local Docker image smoke test could not run because the local Docker daemon is unavailable.