### PR TITLE
fix(jibri): recording on the read-only container

### DIFF
--- a/jibri.yml
+++ b/jibri.yml
@@ -6,6 +6,7 @@ services:
         tmpfs:
             - /run:size=256M,mode=1750,exec
             - /tmp:size=256M,mode=1777,noexec
+            - /var/log/jitsi/jibri:size=256M,mode=1777,noexec
         volumes:
             - ${CONFIG}/jibri:/config:Z
             - ${CONFIG}/storage/jibri:/storage:Z

--- a/jibri/rootfs/etc/s6-overlay/scripts/config
+++ b/jibri/rootfs/etc/s6-overlay/scripts/config
@@ -1,5 +1,6 @@
 #!/command/with-contenv bash
 
+mkdir -p /run/jibri/tmp
 mkdir -p /run/jibri/config
 find /config -maxdepth 1 -type f -exec cp {} /run/jibri/config \;
 

--- a/jibri/rootfs/etc/s6-overlay/scripts/jibri
+++ b/jibri/rootfs/etc/s6-overlay/scripts/jibri
@@ -1,11 +1,10 @@
 #!/command/with-contenv bash
-
-# we have to set it, otherwise chrome won't find ~/.asoundrc file
-HOME=/home/s6
-
-DAEMON=/opt/jitsi/jibri/launch.sh
+ 
+# pre-warm google chrome before jibri launches to ensure fast chrome launch during recordings
 CHROME_BIN_PATH="$(which google-chrome)"
 [ $? -ne 0 ] && CHROME_BIN_PATH="$(which chromium)"
-# pre-warm google chrome before jibri launches to ensure fast chrome launch during recordings
 [ -n "$CHROME_BIN_PATH" ] && $CHROME_BIN_PATH --timeout=1000 --headless --no-sandbox about:blank
-exec /bin/bash -c "exec $DAEMON"
+ 
+exec java -Djava.util.logging.config.file=/run/jibri/config/logging.properties \
+  -Dconfig.file=/run/jibri/config/jibri.conf -Djava.io.tmpdir=/run/jibri/tmp \
+  -jar /opt/jitsi/jibri/jibri.jar


### PR DESCRIPTION
PR fixes the recording issue on the read-only container

- `chromedriver` needs a writable `/var/log/jitsi/jibri/`
- Executable tmp folder for `jibri`
- Creating the tmp folder during the config time

Closes #2290
Related with #2292 