### PR TITLE
Fix standalone acme.sh session using wrong HTTP port

### DIFF
--- a/web/rootfs/etc/s6-overlay/scripts/config
+++ b/web/rootfs/etc/s6-overlay/scripts/config
@@ -54,6 +54,7 @@ if [[ $DISABLE_HTTPS -ne 1 ]]; then
             $ACME_SERVER \
             --issue \
             --standalone \
+            --httpport 8000 \
             --pre-hook "if [[ -d /run/service/nginx ]]; then s6-svc -d /run/service/nginx; fi" \
             --post-hook "if [[ -d /run/service/nginx ]]; then s6-svc -u /run/service/nginx; fi" \
             -d $LETSENCRYPT_DOMAIN


### PR DESCRIPTION
Since the change to use rootless containers, the default HTTP port is 8000 instead of 80.
Retrieving certificates failed because acme.sh was still listening on port 80 so it was never reachable from the internet.