### PR TITLE
fix(prosody) create the data folder at runtime to fix its ownership

### DIFF
--- a/prosody/rootfs/defaults/prosody.cfg.lua
+++ b/prosody/rootfs/defaults/prosody.cfg.lua
@@ -436,6 +436,6 @@ http_interfaces = { "*", "::" }
 http_interfaces = { "*" }
 {{ end }}
 
-data_path = "/var/lib/prosody"
+data_path = "/var/lib/prosody/data"
 
 Include "conf.d/*.cfg.lua"

--- a/prosody/rootfs/etc/s6-overlay/scripts/config
+++ b/prosody/rootfs/etc/s6-overlay/scripts/config
@@ -13,6 +13,13 @@ fi
 # fail fast if the persistent data volume is not writable by the container user
 check-writable /var/lib/prosody '${CONFIG}/storage/prosody' || exit 1
 
+# prosody's data folder is created at runtime by the container user (uid 1000)
+# so it is owned by that user even when /var/lib/prosody itself is a root-owned
+# mount point (e.g. a Kubernetes volume)
+PROSODY_DATA_DIR="/var/lib/prosody/data"
+mkdir -p "$PROSODY_DATA_DIR"
+check-writable "$PROSODY_DATA_DIR" '${CONFIG}/storage/prosody' || exit 1
+
 PROSODY_CFG="/run/prosody/config/prosody.cfg.lua"
 
 mkdir -pm 750 /run/prosody/config/certs
@@ -20,8 +27,8 @@ mkdir -pm 750 /run/prosody/config/conf.d
 cp -r /config/. /run/prosody/config
 
 # copy existing prosody accounts from the old setup if this is the initial run
-if [[ -z $(ls /var/lib/prosody) ]] && [[ -d /config/data ]]; then
-    cp -r /config/data/. /var/lib/prosody
+if [[ -z $(ls "$PROSODY_DATA_DIR") ]] && [[ -d /config/data ]]; then
+    cp -r /config/data/. "$PROSODY_DATA_DIR"
 fi
 
 [ -z "$PROSODY_MODE" ] && export PROSODY_MODE="client"
@@ -96,6 +103,6 @@ if [[ ! -f "/run/prosody/config/certs/$XMPP_AUTH_DOMAIN.crt" ]]; then
     echo | prosodyctl --config $PROSODY_CFG cert generate $XMPP_AUTH_DOMAIN
 fi
 
-# certs will be created in /var/lib/prosody
-mv /var/lib/prosody/*.{crt,key} /run/prosody/config/certs/ || true
-rm -f /var/lib/prosody/*.cnf
+# certs will be created in the prosody data folder
+mv "$PROSODY_DATA_DIR"/*.{crt,key} /run/prosody/config/certs/ || true
+rm -f "$PROSODY_DATA_DIR"/*.cnf


### PR DESCRIPTION
Prosody stores its data in `/var/lib/prosody`, which is a mounted volume. In Kubernetes that mount point is owned by `root` even when it is world-writable and an unprivileged container cannot change the ownership of the mount point itself. The [Helm chart][helm] works around this with a `chown -R 1000:1000` init container, which needs root privileges and a writable root filesystem, exactly what the rootless setup avoids.

Instead of using the mount point itself as the data folder, `data_path` now points to `/var/lib/prosody/data`, which is created at runtime by the container user (uid 1000). The folder and everything Prosody writes below it are therefore owned by that user, and no init container is needed.

The mount point still has to be writable by uid 1000 (mode `777` or group-writable with `fsGroup: 1000`). The existing `check-writable` guard reports it if it is not.

`${CONFIG}/storage/prosody:/var/lib/prosody` is unchanged, so there is nothing for existing Docker users to do. The data simply moves one level down and service accounts are re-registered from the environment on start.

[helm]: https://github.com/jitsi-contrib/jitsi-helm/blob/main/templates/prosody/statefulset.yaml#L129-L143