### PR TITLE
fix: add ::1 to the prosody rate limit whitelist

### DIFF
--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -360,6 +360,7 @@ Component "{{ $XMPP_MUC_DOMAIN }}" "muc"
     -- List of regular expressions for IP addresses that are not limited by this module.
     rate_limit_whitelist = {
         "127.0.0.1";
+        "::1";
 {{ range $index, $cidr := (splitList "," $RATE_LIMIT_ALLOW_RANGES | compact) }}
         "{{ $cidr }}";
 {{ end }}

--- a/prosody/rootfs/defaults/conf.d/visitors.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/visitors.cfg.lua
@@ -172,6 +172,7 @@ Component '{{ $VISITORS_MUC_PREFIX }}.v{{ $VISITOR_INDEX }}.{{ $VISITORS_XMPP_DO
     -- List of regular expressions for IP addresses that are not limited by this module.
     rate_limit_whitelist = {
         "127.0.0.1";
+        "::1";
         {{ range $index, $cidr := (splitList "," $RATE_LIMIT_ALLOW_RANGES) -}}
         "{{ $cidr }}";
         {{ end -}}


### PR DESCRIPTION
`mod_rate_limit` has `127.0.0.1` and `::1` in its own default whitelist. These templates replace that default with `127.0.0.1` plus `PROSODY_RATE_LIMIT_ALLOW_RANGES`, so `::1` was lost.

The main prosody and a visitor node on the same host connect over the IPv6 loopback address. The s2s link between them was therefore rate limited. This can throttle the burst of presence stanzas that `mod_visitors` sends when it connects a visitor node, and a visitor that joins during the throttle gets an incomplete MUC roster.

### Related

Parts of the same fix:

- jitsi/jitsi-meet#17739 - do not rate limit s2s sessions
- jitsi/docker-jitsi-meet#2309 - add `::1` to the whitelist in the prosody templates
- jitsi/infra-configuration#944 - add `::1` to the ansible default whitelist
- jitsi/infra-provisioning#1139 - set the session rate on the visitor node task
