### PR TITLE
feat(prosody): enable trace module on the JVB brewery MUC

### DIFF
--- a/prosody/rootfs/defaults/conf.d/brewery.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/brewery.cfg.lua
@@ -1,6 +1,7 @@
 {{ $JVB_XMPP_AUTH_DOMAIN := .Env.JVB_XMPP_AUTH_DOMAIN | default "auth.jvb.meet.jitsi" -}}
 {{ $JVB_XMPP_INTERNAL_MUC_DOMAIN := .Env.JVB_XMPP_INTERNAL_MUC_DOMAIN | default "muc.jvb.meet.jitsi" -}}
 {{ $JVB_AUTH_USER := .Env.JVB_AUTH_USER | default "jvb" -}}
+{{ $ENABLE_TRACING := .Env.ENABLE_TRACING | default "0" | toBool -}}
 
 admins = {
     "focus@{{ $JVB_XMPP_AUTH_DOMAIN }}",
@@ -23,6 +24,9 @@ VirtualHost "{{ $JVB_XMPP_AUTH_DOMAIN }}"
 Component "{{ $JVB_XMPP_INTERNAL_MUC_DOMAIN }}" "muc"
     modules_enabled = {
       "muc_hide_all";
+      {{ if $ENABLE_TRACING }}
+      "trace";
+      {{ end -}}
       "muc_filter_access";
     }
     storage = "memory"


### PR DESCRIPTION
## Problem

#2303 added the OpenTelemetry `trace` module to the internal MUC in `jitsi-meet.cfg.lua` (`XMPP_INTERNAL_MUC_DOMAIN`). That's the right place for the **default single-prosody** layout, where the JVB brewery lives on the internal MUC and the jicofo→JVB colibri2 `conference-modify` IQs — the only stanzas `mod_trace` spans — flow through it.

Deployments that run a **dedicated brewery prosody** (`PROSODY_MODE=brewery`, i.e. a separate `prosody-jvb`) host the JVB brewery on `JVB_XMPP_INTERNAL_MUC_DOMAIN` instead. There, colibri `conference-modify` IQs never traverse the internal MUC, so the brewery prosody produces **no spans** even with `ENABLE_TRACING=1`.

`brewery.cfg.lua` has no `ENABLE_TRACING` handling, and the `trace` module can't be added via env — a global `modules_enabled` entry (e.g. `GLOBAL_MODULES`) loads on VirtualHosts but **not** on MUC components (verified: it lands on the `auth.jvb` VirtualHost, not the `muc.jvb` component).

## Change

Enable `trace` on the brewery MUC component in `brewery.cfg.lua`, gated on `ENABLE_TRACING` (default off), mirroring the internal-MUC placement from #2303. The global `otlp_endpoint` is already emitted by `prosody.cfg.lua` in all modes, so no other change is needed.

## Testing

- `tpl` renders correctly: `"trace";` appears in the brewery MUC `modules_enabled` when `ENABLE_TRACING=1`, and is absent (clean) when unset.
- Runtime: booted the prosody image in brewery mode with the patched file; with the module in the component's `modules_enabled`, prosody loads it on the **component** — log shows `muc.jvb.<domain>:trace` (contrast a `GLOBAL_MODULES=...,trace` run, which only loaded it on the `auth.jvb` VirtualHost). With a reachable `otlp_endpoint` the module is active and exports `colibri.conference-modify` spans that stitch into the jicofo/jvb traces via `traceparent`.

No-op unless `ENABLE_TRACING=1` and the OTLP endpoint is reachable.